### PR TITLE
fix: adds openaikey as secret

### DIFF
--- a/composio/templates/composio-secrets.yaml
+++ b/composio/templates/composio-secrets.yaml
@@ -10,6 +10,7 @@ Auto-generate secrets on first install, persist across upgrades
 {{- $authSecret := "" }}
 {{- $composioApiKey := "" }}
 {{- $bootstrapApiKey := "" }}
+{{- $openAiApiKey := "" }}
 
 {{- if $secretObj }}
   {{/* Secret exists, use existing values */}}

--- a/composio/templates/composio-secrets.yaml
+++ b/composio/templates/composio-secrets.yaml
@@ -21,6 +21,7 @@ Auto-generate secrets on first install, persist across upgrades
   {{- $authSecret = index $secretObj.data "AUTH_SECRET" }}
   {{- $composioApiKey = index $secretObj.data "COMPOSIO_API_KEY" }}
   {{- $bootstrapApiKey = index $secretObj.data "BOOTSTRAP_API_KEY_VALUE" }}
+  {{- $openAiApiKey = index $secretObj.data "OPENAI_API_KEY" }}
 {{- else }}
   {{/* Secret doesn't exist, generate new values or use provided ones */}}
   {{- $adminToken = (.Values.secrets.adminToken | default (randAlphaNum 32)) | b64enc }}
@@ -31,6 +32,7 @@ Auto-generate secrets on first install, persist across upgrades
   {{- $authSecret = (.Values.secrets.authSecret | default (randAlphaNum 32)) | b64enc }}
   {{- $composioApiKey = (.Values.secrets.composioApiKey | default (randAlphaNum 32)) | b64enc }}
   {{- $bootstrapApiKey = $composioApiKey }}
+  {{- $openAiApiKey = (.Values.secrets.openAiApiKey | default (randAlphaNum 32)) | b64enc }}
 {{- end }}
 
 apiVersion: v1
@@ -61,3 +63,4 @@ data:
   AUTH_SECRET: {{ $authSecret }}
   COMPOSIO_API_KEY: {{ $composioApiKey }}
   BOOTSTRAP_API_KEY_VALUE: {{ $bootstrapApiKey }}
+  OPENAI_API_KEY: {{ $openAiApiKey }}


### PR DESCRIPTION
This secret must be overridden with a valid value for it to be useful. This is being added to ensure it's present in helm chart for reference.