### PR TITLE
fix: creates temporal namespace default

### DIFF
--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -200,6 +200,12 @@ temporal:
             maxConns: 20
             maxIdleConns: 20
             maxConnLifetime: "1h"
+      namespaces:
+        # Enable this to create namespaces
+        create: true
+        namespace:
+          - name: default
+            retention: 7d
 
     # Frontend service configuration
     frontend:


### PR DESCRIPTION
By default temporal helm chart doesn't create a namespace. Passing these values creates a default namespace.