### PR TITLE
Chore: otel fixes for google cloud

### DIFF
--- a/composio/templates/apollo.yaml
+++ b/composio/templates/apollo.yaml
@@ -137,9 +137,9 @@ spec:
             - name: OTEL_ENVIRONMENT
               value: {{ .Values.otel.environment | default .Values.global.environment | default "development" | quote }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.otel.exporter.otlp.endpoint | default (printf "http://%s-otel-collector:4317" .Release.Name) | quote }}
+              value: {{ .Values.otel.exporter.otlp.endpoint | default (printf "%s-otel-collector:4317" .Release.Name) | quote }}
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-              value: {{ .Values.otel.exporter.otlp.endpoint | default (printf "http://%s-otel-collector:4317" .Release.Name) | quote }}
+              value: {{ .Values.otel.exporter.otlp.tracesEndpoint | default (printf "%s-otel-collector:4317" .Release.Name) | quote }}
             - name: OTEL_EXPORTER_OTLP_INSECURE
               value: {{ .Values.otel.exporter.otlp.insecure | default "true" | quote }}
             - name: OTEL_TRACES_EXPORTER

--- a/composio/templates/mercury-service.yaml
+++ b/composio/templates/mercury-service.yaml
@@ -106,7 +106,7 @@ spec:
             - name: OTEL_ENVIRONMENT
               value: {{ .Values.otel.environment | default .Values.global.environment | default "development" | quote }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.otel.exporter.otlp.endpoint | default (printf "http://%s-otel-collector:4317" .Release.Name) | quote }}
+              value: {{ .Values.otel.exporter.otlp.endpoint | default (printf "%s-otel-collector:4317" .Release.Name) | quote }}
             - name: OTEL_EXPORTER_OTLP_INSECURE
               value: {{ .Values.otel.exporter.otlp.insecure | default "true" | quote }}
             - name: OTEL_TRACES_ENABLED

--- a/composio/templates/mercury.yaml
+++ b/composio/templates/mercury.yaml
@@ -120,7 +120,7 @@ spec:
             - name: OTEL_ENVIRONMENT
               value: {{ .Values.otel.environment | default .Values.global.environment | default "development" | quote }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ .Values.otel.exporter.otlp.endpoint | default (printf "http://%s-otel-collector:4317" .Release.Name) | quote }}
+              value: {{ .Values.otel.exporter.otlp.endpoint | default (printf "%s-otel-collector:4317" .Release.Name) | quote }}
             - name: OTEL_EXPORTER_OTLP_INSECURE
               value: {{ .Values.otel.exporter.otlp.insecure | default "true" | quote }}
             - name: OTEL_TRACES_ENABLED

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -484,9 +484,12 @@ otel:
         - ALL
   exporter:
     otlp:
-      endpoint: "composio-otel-collector:4317"  # gRPC endpoint without http://
-      tracesEndpoint: "composio-otel-collector:4317"  # Traces endpoint
-      metricsEndpoint: "composio-otel-collector:4317"  # Metrics endpoint
+      # gRPC endpoint for OTLP (no protocol prefix needed for gRPC)
+      endpoint: "composio-otel-collector:4317"
+      # Separate trace endpoint (optional, defaults to endpoint)
+      tracesEndpoint: "composio-otel-collector:4317"
+      # Separate metrics endpoint for gRPC (optional, defaults to endpoint)
+      metricsEndpoint: "composio-otel-collector:4317"
       insecure: true
       headers: ""  # Optional headers for authentication
   traces:

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -574,7 +574,7 @@ otel:
         googlecloud:
           project: "self-host-kubernetes"
           metric:
-            prefix: "composio/"
+            prefix: "custom.googleapis.com/composio/"
           trace: {}
       
       # Processors for data transformation


### PR DESCRIPTION
Turns out this config has changed lately in our helm charts. Fixing it back to http and grpc endpoints respectively.