### PR TITLE
feat: make smtp a secret

### DIFF
--- a/composio/templates/apollo.yaml
+++ b/composio/templates/apollo.yaml
@@ -183,10 +183,15 @@ spec:
               value: {{ .Values.apollo.nextPublicDisableSocialLogin | quote }}
             - name: OTEL_LOGS_EXPORTER
               value: "otlp"
+            {{- if .Values.apollo.smtp.enabled }}
             - name: SMTP_CONNECTION_STRING
-              value: {{ .Values.apollo.smtpConnectionString | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.apollo.smtp.credentialsSecret | default (printf "%s-smtp-credentials" .Release.Name) }}
+                  key: SMTP_CONNECTION_STRING
+            {{- end }}
             - name: SMTP_AUTHOR_EMAIL
-              value: {{ .Values.apollo.smtpAuthorEmail | quote }}
+              value: {{ .Values.apollo.smtp.smtpAuthorEmail | quote }}
             - name: S3_BUCKET
               value: {{ .Values.apollo.s3Bucket | quote }}
             - name: TEST_DEBUG

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -129,6 +129,12 @@ apollo:
       name: "external-postgres-secret"
       key: "url"
   
+  # SMTP configuration
+  smtp:
+    enabled: false
+    smtpAuthorEmail: "admin@yourdomain.com"
+    # credentialsSecret: ""  # Optional: custom secret name (defaults to {release-name}-smtp-credentials)
+  
   # Note: Secrets are now managed globally in the 'secrets' section
   
   # HPA (Horizontal Pod Autoscaler) configuration


### PR DESCRIPTION
### TL;DR

Improved SMTP configuration security by moving connection string to a Kubernetes secret.

### What changed?

- Modified `apollo.yaml` to load SMTP connection string from a Kubernetes secret instead of directly from values
- Added conditional rendering of SMTP environment variables based on whether SMTP is enabled
- Restructured SMTP configuration in `values.yaml` to use a dedicated `smtp` object with:
  - `enabled` flag to toggle SMTP functionality
  - `smtpAuthorEmail` for the sender email address
  - Optional `credentialsSecret` parameter to specify a custom secret name

### How to test?

1. Deploy with SMTP disabled:
   ```
   helm install my-release ./composio --set apollo.smtp.enabled=false
   ```

2. Deploy with SMTP enabled using default secret name:
   ```
   kubectl create secret generic my-release-smtp-credentials --from-literal=SMTP_CONNECTION_STRING='smtp://user:pass@smtp.example.com:587'
   helm install my-release ./composio --set apollo.smtp.enabled=true --set apollo.smtp.smtpAuthorEmail=admin@example.com
   ```

3. Deploy with SMTP enabled using custom secret:
   ```
   kubectl create secret generic custom-smtp-secret --from-literal=SMTP_CONNECTION_STRING='smtp://user:pass@smtp.example.com:587'
   helm install my-release ./composio --set apollo.smtp.enabled=true --set apollo.smtp.credentialsSecret=custom-smtp-secret
   ```

### Why make this change?

This change improves security by storing sensitive SMTP credentials in a Kubernetes secret rather than in plain text values. It also adds flexibility by making SMTP configuration optional and allowing users to specify a custom secret name for credentials.