### PR TITLE
fix: helm chart for OVERWRITE_FE_URL

### DIFF
--- a/composio/templates/apollo.yaml
+++ b/composio/templates/apollo.yaml
@@ -84,8 +84,6 @@ spec:
               value: {{ .Values.aws.region | quote }}
             - name: COMPOSIO_ENV
               value: "production"
-            - name: OVERWRITE_FE_URL
-              value: {{ .Values.apollo.overwrite_fe_url | quote }}
             - name: USE_CLICKHOUSE_FOR_LOGS
               value: "false"
             - name: SELF_HOSTED
@@ -94,7 +92,10 @@ spec:
               value: "--max-old-space-size=4096"
             - name: THERMOS_URL
               value: {{ printf "http://%s-thermos:8180" .Release.Name | quote }}
- 
+            {{- if .Values.apollo.overwrite_fe_url }}
+             - name: OVERWRITE_FE_URL
+              value: {{ .Values.apollo.overwrite_fe_url | quote }}
+            {{- end }}
             - name: OVERWRITE_APOLLO_URL
               value: {{ .Values.apollo.overwrite_apollo_url | default (printf "http://%s-apollo:9900" .Release.Name) | quote }}
             - name: OAUTH2_REDIRECT_URI_OVERRIDE


### PR DESCRIPTION
### TL;DR

Made the `OVERWRITE_FE_URL` environment variable conditional in the Apollo Kubernetes deployment.

### What changed?

- Removed the unconditional `OVERWRITE_FE_URL` environment variable from the Apollo container spec
- Added a conditional block that only sets `OVERWRITE_FE_URL` when `.Values.apollo.overwrite_fe_url` is defined

### How to test?

1. Deploy the Helm chart with `.Values.apollo.overwrite_fe_url` set to verify the variable is included
2. Deploy the Helm chart without setting `.Values.apollo.overwrite_fe_url` to verify the variable is omitted
3. Verify Apollo functions correctly in both scenarios

### Why make this change?

This change makes the frontend URL override optional rather than mandatory, allowing for more flexible deployments where the default frontend URL is acceptable. This improves the template's adaptability to different deployment scenarios without requiring explicit overrides.