### PR TITLE
fix: mcp localhost issues in apollo

### DIFF
--- a/composio/templates/apollo.yaml
+++ b/composio/templates/apollo.yaml
@@ -92,6 +92,8 @@ spec:
               value: "--max-old-space-size=4096"
             - name: THERMOS_URL
               value: {{ printf "http://%s-thermos:8180" .Release.Name | quote }}
+            - name: BACKEND_URL
+              value: {{ .Values.apollo.overwrite_apollo_url | printf "http://%s-apollo:9900" .Release.Name | quote }}
             {{- if .Values.apollo.overwrite_fe_url }}
              - name: OVERWRITE_FE_URL
               value: {{ .Values.apollo.overwrite_fe_url | quote }}


### PR DESCRIPTION
### TL;DR

Added a new environment variable `BACKEND_URL` to the Apollo deployment configuration.

### What changed?

Added a new environment variable `BACKEND_URL` to the Apollo container configuration in the Kubernetes deployment template. The value is set to either the overwritten Apollo URL from `.Values.apollo.overwrite_apollo_url` if provided, or defaults to a URL constructed from the release name (`http://[release-name]-apollo:9900`).

### How to test?

1. Deploy the updated Helm chart with and without setting the `apollo.overwrite_apollo_url` value
2. Verify that the Apollo pod has the correct `BACKEND_URL` environment variable set
3. Confirm that Apollo services correctly use this backend URL for communication

### Why make this change?

This change allows Apollo to be configured with a custom backend URL, enabling more flexible deployment configurations and supporting scenarios where the default URL construction isn't appropriate (such as in multi-cluster setups or when using service meshes).