### PR TITLE
fix: remove NEXT_PUBLIC_BACKEND_URL from frontend setup doc

### DIFF
--- a/docs/frontend-setup.md
+++ b/docs/frontend-setup.md
@@ -48,9 +48,7 @@ frontend:
 
   env:
     # Server-side Apollo URL (in-cluster by default)
-    # OVERRIDE_BACKEND_URL: "http://composio-apollo:9900"
-    # Public Apollo URL that the browser should use
-    NEXT_PUBLIC_BACKEND_URL: "https://api.example.com"
+    #OVERRIDE_BACKEND_URL: "http://composio-apollo:9900"
     # Public frontend URL (helps generate absolute links)
     NEXT_PUBLIC_APP_URL: "https://app.example.com"
     # Optional flags


### PR DESCRIPTION
### TL;DR

Removed the `NEXT_PUBLIC_BACKEND_URL` environment variable from frontend configuration.

### What changed?

- Removed the `NEXT_PUBLIC_BACKEND_URL: "https://api.example.com"` line from the frontend environment configuration in `docs/frontend-setup.md`
- Adjusted formatting of the commented `OVERRIDE_BACKEND_URL` line

### How to test?

1. Review the updated frontend setup documentation
2. Verify that applications using this configuration don't rely on the removed `NEXT_PUBLIC_BACKEND_URL` environment variable
3. Ensure frontend deployments work correctly without this variable

### Why make this change?

This change likely removes a redundant or deprecated configuration variable that is no longer needed for the frontend to communicate with the backend. This simplifies the configuration and removes potential confusion about which URL should be used for backend communication.