### PR TITLE
fix: helm chart for mercury service for useKnative=false

### DIFF
--- a/composio/templates/mercury.yaml
+++ b/composio/templates/mercury.yaml
@@ -167,7 +167,7 @@ metadata:
 spec:
   type: {{ .Values.mercury.service.type | default "ClusterIP" }}
   ports:
-    - port: {{ .Values.mercury.service.port | default 8080 }}
+    - port: {{ .Values.mercury.service.port | default 80 }}
       targetPort: {{ .Values.mercury.service.port | default 8080 }}
       protocol: TCP
   selector:

--- a/composio/templates/thermos.yaml
+++ b/composio/templates/thermos.yaml
@@ -105,7 +105,7 @@ spec:
             - name: LAMBDA_USE_HTTP
               value: "true"
             - name: LAMBDA_USE_HTTP_ENDPOINT
-              value: "http://{{ include "composio.fullname" . }}-mercury.composio.svc.cluster.local"
+              value: "http://{{ include "composio.fullname" . }}-mercury.composio.svc.cluster.local:{{ .Values.mercury.service.port | default 80 }}"
             - name: AWS_LAMBDA_REGION
               value: {{ .Values.aws.region | quote }}
             - name: AWS_S3_REGION

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -726,7 +726,7 @@ mercury:
 
   service:
     type: ClusterIP
-    port: 8080
+    port: 80
   
   autoscaling:
     minScale: 1


### PR DESCRIPTION
### TL;DR

Changed Mercury service port from 8080 to 80 and updated related configurations.

### What changed?

- Changed the default Mercury service port from 8080 to 80 in `values.yaml`
- Updated the Mercury service port default in `mercury.yaml` to match the new value
- Modified the Thermos configuration to explicitly include the Mercury port in the HTTP endpoint URL

### How to test?

1. Deploy the chart with default values and verify Mercury service is exposed on port 80
2. Verify Thermos can successfully connect to Mercury using the updated endpoint URL
3. Test with a custom port value to ensure the override still works properly

### Why make this change?

This change standardizes the Mercury service to use the conventional HTTP port 80, which is more aligned with web service best practices. It also makes the connection between Thermos and Mercury more explicit by including the port in the endpoint URL, improving clarity and preventing potential connection issues.