### PR TITLE
feat: add support for azure environment variables and add doc

### DIFF
--- a/composio/templates/apollo.yaml
+++ b/composio/templates/apollo.yaml
@@ -124,6 +124,24 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-s3-credentials
                   key: S3_SECRET_ACCESS_KEY
+            # Object storage configuration
+            - name: OBJECT_STORAGE_BACKEND
+              value: {{ .Values.apollo.objectStorage.backend | default "s3" | quote }}
+            {{- if eq (default "s3" .Values.apollo.objectStorage.backend) "azure_blob_storage" }}
+            - name: AZURE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-azure-connection-string
+                  key: AZURE_CONNECTION_STRING
+            {{- end }}
+            {{- if .Values.apollo.objectStorage.namespaces.temp }}
+            - name: TEMP_STORAGE_NAMESPACE
+              value: {{ .Values.apollo.objectStorage.namespaces.temp | quote }}
+            {{- end }}
+            {{- if .Values.apollo.objectStorage.namespaces.permanent }}
+            - name: PERMANENT_STORAGE_NAMESPACE
+              value: {{ .Values.apollo.objectStorage.namespaces.permanent | quote }}
+            {{- end }}
             - name: SERVICE_NAME
               value: "apollo"
             - name: APOLLO_URL

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -142,6 +142,18 @@ apollo:
     smtpAuthorEmail: "admin@yourdomain.com"
     # credentialsSecret: ""  # Optional: custom secret name (defaults to {release-name}-smtp-credentials)
   
+  # Object storage configuration
+  objectStorage:
+    # Supported: "s3", "azure_blob_storage"
+    backend: "s3"
+    namespaces:
+      # Blob container for temporary files
+      temp: "composio-temp"
+      # Blob container for permanent files
+      permanent: "composio-permanent"
+    # For Azure, the connection string is read from the Secret:
+    #   {release}-azure-connection-string (key: AZURE_CONNECTION_STRING)
+  
   # Note: Secrets are now managed globally in the 'secrets' section
   
   # HPA (Horizontal Pod Autoscaler) configuration

--- a/docs/azure-blob-storage.md
+++ b/docs/azure-blob-storage.md
@@ -1,0 +1,84 @@
+## Using Azure Blob Storage for Apollo
+
+This guide explains how to configure Composio (Apollo) to use Azure Blob Storage for object storage. You will set the storage backend, provide an Azure Storage connection string, and configure namespaces used for temporary and permanent files.
+
+### Prerequisites
+
+- An Azure Storage Account
+- A Blob service with at least two containers for:
+  - temporary files (e.g., `composio-temp`)
+  - permanent files (e.g., `composio-permanent`)
+- An Azure Storage connection string with permissions to read/write blobs
+- `kubectl` access to your cluster and namespace running Composio
+
+You can retrieve the connection string from the Azure Portal:
+- Storage Account → Security + networking → Access keys → Connection string
+
+
+### Create the Kubernetes Secret
+
+Create a Secret named `{release}-azure-connection-string` (replace `composio` below with your Helm release name if different). The key must be `AZURE_CONNECTION_STRING`:
+
+```bash
+kubectl create secret generic composio-azure-connection-string \
+  -n composio \
+  --from-literal=AZURE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=<name>;AccountKey=<key>;EndpointSuffix=core.windows.net"
+```
+
+### Configure Helm values
+
+Add the following under `apollo:` in your values override file (e.g., `values-override.yaml`). Update the connection string and namespaces to match your setup.
+
+```yaml
+apollo:
+  objectStorage:
+    backend: "azure_blob_storage"
+    namespaces:
+      temp: "composio-temp"
+      permanent: "composio-permanent"
+```
+
+Notes:
+- The `backend` must be set to `"azure_blob_storage"`.
+- The Azure connection string is read from the Secret `{release}-azure-connection-string` with key `AZURE_CONNECTION_STRING`.
+- Ensure the specified containers exist in your storage account.
+- Note: You can also use the same container for both temporary files and permanent files since keys don't collide, but we recommend having different containers.
+
+### Deploy or upgrade
+
+```bash
+helm upgrade --install composio ./composio \
+  -n composio \
+  --create-namespace \
+  -f values-override.yaml
+```
+
+### Verify configuration
+
+Check that Apollo has the Azure environment variables:
+
+```bash
+kubectl exec -n composio deploy/composio-apollo -- env | grep -E "^(OBJECT_STORAGE_BACKEND|AZURE_CONNECTION_STRING|TEMP_STORAGE_NAMESPACE|PERMANENT_STORAGE_NAMESPACE)="
+```
+
+Expected variables:
+- `OBJECT_STORAGE_BACKEND=azure`
+- `AZURE_CONNECTION_STRING=...` (redact in logs)
+- `TEMP_STORAGE_NAMESPACE=<your-temp-container>`
+- `PERMANENT_STORAGE_NAMESPACE=<your-permanent-container>`
+
+You can also inspect logs to ensure no authentication or container errors are reported:
+
+```bash
+kubectl logs -n composio deploy/composio-apollo --tail=200
+```
+
+### FAQ
+
+- Do I need to use a secret for the connection string?  
+  It is recommended. This chart supports setting the connection string via values; you may alternatively template a Secret and reference it through a custom value to avoid storing credentials in plain text files.
+
+- Do other services need Azure Blob Storage?  
+  Apollo is the primary consumer for object storage. Some toolkits that handle files rely on object storage; configure accordingly for your workload.
+
+

--- a/secret-setup.sh
+++ b/secret-setup.sh
@@ -37,6 +37,7 @@ usage() {
     echo "  THERMOS_POSTGRES_URL PostgreSQL connection URL for Thermos (postgresql://user:pass@host:port/db)"
     echo "  REDIS_URL            Redis connection URL (redis://user:pass@host:port/db)"
     echo "  OPENAI_API_KEY       OpenAI API key for AI functionality"
+    echo "  AZURE_CONNECTION_STRING Azure Storage connection string for Apollo (when backend=azure)"
     echo "  S3_ACCESS_KEY_ID     S3 access key ID used by Apollo"
     echo "  S3_SECRET_ACCESS_KEY S3 secret access key used by Apollo"
     echo "  SMTP_CONNECTION_STRING SMTP connection string (e.g., smtps://user:pass@smtp.example.com:465)"
@@ -55,6 +56,7 @@ usage() {
     echo "  • external-thermos-postgres-secret    (from THERMOS_POSTGRES_URL)"
     echo "  • external-redis-secret               (from REDIS_URL)"
     echo "  • openai-secret                       (from OPENAI_API_KEY)"
+    echo "  • \${release}-azure-connection-string (from AZURE_CONNECTION_STRING)"
     echo "  • \${release}-s3-credentials          (from S3_ACCESS_KEY_ID + S3_SECRET_ACCESS_KEY)"
     echo "  • \${release}-smtp-credentials        (from SMTP_CONNECTION_STRING)"
     echo ""
@@ -375,6 +377,18 @@ if [[ -n "$OPENAI_API_KEY" ]]; then
     fi
 else
     print_info "OPENAI_API_KEY not provided - skipping OpenAI secret creation"
+fi
+
+# Azure connection string secret (used by apollo.yaml when backend=azure)
+if [[ -n "$AZURE_CONNECTION_STRING" ]]; then
+    azure_secret_name="${RELEASE_NAME}-azure-connection-string"
+    if secret_exists "$azure_secret_name"; then
+        print_warning "Secret already exists: $azure_secret_name"
+    else
+        create_simple_secret "$azure_secret_name" "AZURE_CONNECTION_STRING" "$AZURE_CONNECTION_STRING"
+    fi
+else
+    print_info "AZURE_CONNECTION_STRING not provided - skipping Azure connection secret creation"
 fi
 
 # S3 credentials secret (required by apollo.yaml env valueFrom)


### PR DESCRIPTION
# Add Azure Blob Storage support for Apollo

### TL;DR

Added support for Azure Blob Storage as an alternative object storage backend for Apollo.

### What changed?

- Added configuration options in `values.yaml` to specify object storage backend (S3 or Azure)
- Added environment variables in Apollo deployment template to support Azure Blob Storage
- Created new documentation file `docs/azure-blob-storage.md` with detailed setup instructions
- Updated `secret-setup.sh` to handle Azure connection string

### How to test?

1. Create an Azure Storage Account with two blob containers
2. Create a secret with your Azure connection string:
   ```bash
   kubectl create secret generic composio-azure-connection-string \
     -n composio \
     --from-literal=AZURE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=<name>;AccountKey=<key>;EndpointSuffix=core.windows.net"
   ```
3. Configure Apollo with the following values:
   ```yaml
   apollo:
     objectStorage:
       backend: "azure_blob_storage"
       namespaces:
         temp: "composio-temp"
         permanent: "composio-permanent"
   ```
4. Deploy or upgrade Composio with the new values
5. Verify configuration with:
   ```bash
   kubectl exec -n composio deploy/composio-apollo -- env | grep -E "^(OBJECT_STORAGE_BACKEND|AZURE_CONNECTION_STRING|TEMP_STORAGE_NAMESPACE|PERMANENT_STORAGE_NAMESPACE)="
   ```

### Why make this change?

This change provides flexibility for users who prefer or require Azure Blob Storage instead of S3-compatible storage. It allows Composio to be deployed in Azure-centric environments where Azure Blob Storage is the preferred object storage solution.