### PR TITLE
fix: revert mercury service port to 8080

### DIFF
--- a/composio/templates/mercury.yaml
+++ b/composio/templates/mercury.yaml
@@ -167,7 +167,7 @@ metadata:
 spec:
   type: {{ .Values.mercury.service.type | default "ClusterIP" }}
   ports:
-    - port: {{ .Values.mercury.service.port | default 80 }}
+    - port: {{ .Values.mercury.service.port | default 8080 }}
       targetPort: {{ .Values.mercury.service.port | default 8080 }}
       protocol: TCP
   selector:

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -745,7 +745,7 @@ mercury:
 
   service:
     type: ClusterIP
-    port: 80
+    port: 8080
   
   autoscaling:
     minScale: 1


### PR DESCRIPTION
### TL;DR

Updated Mercury service port from 80 to 8080 to align with the target port.

### What changed?

- Changed the default port in `composio/templates/mercury.yaml` from 80 to 8080
- Updated the service port in `composio/values.yaml` from 80 to 8080

### How to test?

1. Deploy the Mercury service with the updated configuration
2. Verify that the service is accessible on port 8080
3. Confirm that traffic is properly routed to the target port

### Why make this change?

The service was previously configured with port 80 but was targeting port 8080, which could cause confusion and potential connectivity issues. This change ensures consistency between the service port and target port, making the configuration more intuitive and reducing the risk of misconfiguration.