### PR TITLE
docs: mention how to configure initial admin email in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,17 @@ External services (PostgreSQL, Redis, OpenAI) are configured via the `secret-set
 - Without authentication: `redis://host:6379/0`
 - With SSL: `rediss://username:password@host:6380/0`
 
+### Initial Admin Email
+
+Set the initial admin user's email used by the database init jobs. Update `values.yaml`:
+
+```yaml
+dbInit:
+  adminEmail: "your-admin@example.com"
+```
+
+This value is consumed by init jobs (maps to `ADMIN_EMAIL`) to create/configure the admin user.
+
 ### Knative-Specific Configuration
 
 | Parameter | Description | Default |


### PR DESCRIPTION
### TL;DR

Added documentation for configuring the initial admin email in the Helm chart.

### What changed?

Updated the README.md to include a new section titled "Initial Admin Email" that explains how to set the admin user's email address in the Helm chart's `values.yaml` file. The documentation shows how to configure the `dbInit.adminEmail` parameter, which is used by database initialization jobs to create and configure the admin user.

### How to test?

1. Review the updated README.md
2. Verify that the instructions for setting the admin email are clear
3. Test setting the `dbInit.adminEmail` parameter in your `values.yaml` file
4. Confirm that the initialization jobs correctly use this value as `ADMIN_EMAIL`

### Why make this change?

This documentation improvement helps users understand how to properly configure the initial admin user when deploying the application. Without this information, users might not know how to set up the admin account correctly during initialization, potentially causing deployment issues or requiring manual intervention later.