### PR TITLE
fix: add openai api key in apollo

### DIFF
--- a/composio/templates/apollo.yaml
+++ b/composio/templates/apollo.yaml
@@ -171,6 +171,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-composio-api-key
                   key: COMPOSIO_API_KEY
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-openai-credentials
+                  key: OPENAI_API_KEY
             - name: APOLLO_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
For features like dependency graph, we use openAI api key.