### PR TITLE
fix: temporal disabled support and admin token changes

### DIFF
--- a/composio/Chart.yaml
+++ b/composio/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     alias: temporal
     version: "0.68.1"
     repository: "file://./charts/temporal"
-    # Temporal is auto-deployed; thermos uses it only when features.auth_refresh or features.triggers is enabled
+    condition: temporal.enabled
   - name: replicated
     repository: oci://registry.replicated.com/library
     version: 1.12.1

--- a/composio/Chart.yaml
+++ b/composio/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     alias: temporal
     version: "0.68.1"
     repository: "file://./charts/temporal"
-    condition: temporal.enabled
+    condition: features.temporal
   - name: replicated
     repository: oci://registry.replicated.com/library
     version: 1.12.1

--- a/composio/Chart.yaml
+++ b/composio/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     alias: temporal
     version: "0.68.1"
     repository: "file://./charts/temporal"
-    condition: temporal.enabled
+    # Temporal is auto-deployed; thermos uses it only when features.auth_refresh or features.triggers is enabled
   - name: replicated
     repository: oci://registry.replicated.com/library
     version: 1.12.1

--- a/composio/Chart.yaml
+++ b/composio/Chart.yaml
@@ -13,6 +13,7 @@ dependencies:
     alias: temporal
     version: "0.68.1"
     repository: "file://./charts/temporal"
+    condition: temporal.enabled
   - name: replicated
     repository: oci://registry.replicated.com/library
     version: 1.12.1

--- a/composio/templates/NOTES.txt
+++ b/composio/templates/NOTES.txt
@@ -21,11 +21,12 @@
    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "composio.fullname" . }}-apollo 8080:{{ .Values.apollo.service.port }}
    Then visit: http://127.0.0.1:8080
 
-
+{{- if eq (include "composio.temporalEnabled" .) "true" }}
 
    Temporal Web UI:
    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ .Release.Name }}-temporal-web 8082:8080
    Then visit: http://127.0.0.1:8082
+{{- end }}
 
 
 3. Verify installation:
@@ -66,6 +67,7 @@ kubectl get secret \
   -o jsonpath='{.data.ENCRYPTION_KEY}' | base64 -d
 ```
 
+{{- if eq (include "composio.temporalEnabled" .) "true" }}
 ### 🔐 Temporal Database Encryption Key
 
 Run the command below to retrieve the Temporal encryption key:
@@ -76,6 +78,7 @@ kubectl get secret \
   {{ include "composio.coreSecretName" . }} \
   -o jsonpath='{.data.TEMPORAL_TRIGGER_ENCRYPTION_KEY}' | base64 -d
 ```
+{{- end }}
 ### ⚠️ IMPORTANT NOTES
 
 * These keys are **generated once**

--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -19,30 +19,15 @@ Expand the name of the chart.
 {{- end -}}
 
 
-{{- define "apollo-admin-token" -}}
+{{- define "composio-admin-token" -}}
 {{- $coreName := include "composio.coreSecretName" . -}}
 {{- $core := lookup "v1" "Secret" .Release.Namespace $coreName -}}
-{{- if and $core (hasKey $core.data "APOLLO_ADMIN_TOKEN") -}}
-  {{- index $core.data "APOLLO_ADMIN_TOKEN" | b64dec -}}
+{{- if and $core (hasKey $core.data "COMPOSIO_ADMIN_TOKEN") -}}
+  {{- index $core.data "COMPOSIO_ADMIN_TOKEN" | b64dec -}}
 {{- else -}}
-  {{- $legacy := lookup "v1" "Secret" .Release.Namespace (printf "%s-apollo-admin-token" .Release.Name) -}}
-  {{- if and $legacy (hasKey $legacy.data "APOLLO_ADMIN_TOKEN") -}}
-    {{- index $legacy.data "APOLLO_ADMIN_TOKEN" | b64dec -}}
-  {{- else -}}
-    {{- randAlphaNum 32 -}}
-  {{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "composio-api-key" -}}
-{{- $coreName := include "composio.coreSecretName" . -}}
-{{- $core := lookup "v1" "Secret" .Release.Namespace $coreName -}}
-{{- if and $core (hasKey $core.data "COMPOSIO_API_KEY") -}}
-  {{- index $core.data "COMPOSIO_API_KEY" | b64dec -}}
-{{- else -}}
-  {{- $legacy := lookup "v1" "Secret" .Release.Namespace (printf "%s-composio-api-key" .Release.Name) -}}
-  {{- if and $legacy (hasKey $legacy.data "COMPOSIO_API_KEY") -}}
-    {{- index $legacy.data "COMPOSIO_API_KEY" | b64dec -}}
+  {{- $legacy := lookup "v1" "Secret" .Release.Namespace (printf "%s-composio-admin-token" .Release.Name) -}}
+  {{- if and $legacy (hasKey $legacy.data "COMPOSIO_ADMIN_TOKEN") -}}
+    {{- index $legacy.data "COMPOSIO_ADMIN_TOKEN" | b64dec -}}
   {{- else -}}
     {{- randAlphaNum 32 -}}
   {{- end -}}

--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -66,11 +66,11 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Check if Temporal is needed based on feature flags or explicit enablement
-Returns "true" if temporal.enabled is true OR features.auth_refresh is true OR features.triggers is true
+Check if Temporal is enabled via features.temporal flag
+This flag both deploys the temporal subchart (via Chart.yaml condition) and configures thermos to use it
 */}}
 {{- define "composio.temporalEnabled" -}}
-{{- if or .Values.temporal.enabled (and .Values.features .Values.features.auth_refresh) (and .Values.features .Values.features.triggers) -}}
+{{- if and .Values.features .Values.features.temporal -}}
 true
 {{- else -}}
 false
@@ -282,7 +282,7 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := list -}}
 {{- $messages := append $messages (include "composio.validateValues.database" .) -}}
 {{- $messages := append $messages (include "composio.validateValues.redis" .) -}}
-{{- $messages := append $messages (include "composio.validateValues.temporal" .) -}}
+
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 {{- if $message -}}
@@ -304,14 +304,6 @@ composio: database
 {{/*
 Validate Redis configuration
 */}}
-{{- define "composio.validateValues.temporal" -}}
-{{- if and (not .Values.temporal.enabled) (eq (include "composio.temporalEnabled" .) "true") -}}
-composio: temporal
-    features.auth_refresh or features.triggers is enabled but temporal.enabled is false.
-    Please set temporal.enabled=true to deploy the Temporal workflow engine.
-{{- end -}}
-{{- end -}}
-
 {{/*
 Validate Redis configuration
 */}}

--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -66,11 +66,11 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Check if Temporal integration is needed based on feature flags
-Returns "true" if features.auth_refresh or features.triggers is enabled
+Check if Temporal is needed based on feature flags or explicit enablement
+Returns "true" if temporal.enabled is true OR features.auth_refresh is true OR features.triggers is true
 */}}
 {{- define "composio.temporalEnabled" -}}
-{{- if or (and .Values.features .Values.features.auth_refresh) (and .Values.features .Values.features.triggers) -}}
+{{- if or .Values.temporal.enabled (and .Values.features .Values.features.auth_refresh) (and .Values.features .Values.features.triggers) -}}
 true
 {{- else -}}
 false
@@ -282,7 +282,7 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := list -}}
 {{- $messages := append $messages (include "composio.validateValues.database" .) -}}
 {{- $messages := append $messages (include "composio.validateValues.redis" .) -}}
-
+{{- $messages := append $messages (include "composio.validateValues.temporal" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 {{- if $message -}}
@@ -304,6 +304,14 @@ composio: database
 {{/*
 Validate Redis configuration
 */}}
+{{- define "composio.validateValues.temporal" -}}
+{{- if and (not .Values.temporal.enabled) (eq (include "composio.temporalEnabled" .) "true") -}}
+composio: temporal
+    features.auth_refresh or features.triggers is enabled but temporal.enabled is false.
+    Please set temporal.enabled=true to deploy the Temporal workflow engine.
+{{- end -}}
+{{- end -}}
+
 {{/*
 Validate Redis configuration
 */}}

--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -80,6 +80,18 @@ Expand the name of the chart.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Check if Temporal is needed based on feature flags or explicit enablement
+Returns "true" if temporal.enabled is true OR features.auth_refresh is true OR features.triggers is true
+*/}}
+{{- define "composio.temporalEnabled" -}}
+{{- if or .Values.temporal.enabled (and .Values.features .Values.features.auth_refresh) (and .Values.features .Values.features.triggers) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
 {{- define "temporal-encryption-key" -}}
 {{- $coreName := include "composio.coreSecretName" . -}}
 {{- $core := lookup "v1" "Secret" .Release.Namespace $coreName -}}

--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -282,6 +282,7 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := list -}}
 {{- $messages := append $messages (include "composio.validateValues.database" .) -}}
 {{- $messages := append $messages (include "composio.validateValues.redis" .) -}}
+{{- $messages := append $messages (include "composio.validateValues.temporal" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 {{- if $message -}}
@@ -297,6 +298,17 @@ Validate database configuration
 composio: database
     You must provide database URL when PostgreSQL is disabled.
     Please set apollo.secrets.databaseUrl
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate Redis configuration
+*/}}
+{{- define "composio.validateValues.temporal" -}}
+{{- if and (not .Values.temporal.enabled) (eq (include "composio.temporalEnabled" .) "true") -}}
+composio: temporal
+    features.auth_refresh or features.triggers is enabled but temporal.enabled is false.
+    Please set temporal.enabled=true to deploy the Temporal workflow engine.
 {{- end -}}
 {{- end -}}
 

--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -66,11 +66,11 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Check if Temporal is needed based on feature flags or explicit enablement
-Returns "true" if temporal.enabled is true OR features.auth_refresh is true OR features.triggers is true
+Check if Temporal integration is needed based on feature flags
+Returns "true" if features.auth_refresh or features.triggers is enabled
 */}}
 {{- define "composio.temporalEnabled" -}}
-{{- if or .Values.temporal.enabled (and .Values.features .Values.features.auth_refresh) (and .Values.features .Values.features.triggers) -}}
+{{- if or (and .Values.features .Values.features.auth_refresh) (and .Values.features .Values.features.triggers) -}}
 true
 {{- else -}}
 false
@@ -282,7 +282,7 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := list -}}
 {{- $messages := append $messages (include "composio.validateValues.database" .) -}}
 {{- $messages := append $messages (include "composio.validateValues.redis" .) -}}
-{{- $messages := append $messages (include "composio.validateValues.temporal" .) -}}
+
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 {{- if $message -}}
@@ -304,14 +304,6 @@ composio: database
 {{/*
 Validate Redis configuration
 */}}
-{{- define "composio.validateValues.temporal" -}}
-{{- if and (not .Values.temporal.enabled) (eq (include "composio.temporalEnabled" .) "true") -}}
-composio: temporal
-    features.auth_refresh or features.triggers is enabled but temporal.enabled is false.
-    Please set temporal.enabled=true to deploy the Temporal workflow engine.
-{{- end -}}
-{{- end -}}
-
 {{/*
 Validate Redis configuration
 */}}

--- a/composio/templates/apollo/apollo-db-init.job.yaml
+++ b/composio/templates/apollo/apollo-db-init.job.yaml
@@ -73,11 +73,6 @@ spec:
                 secretKeyRef:
                   name: {{ $coreSecret }}
                   key: ENCRYPTION_KEY
-            - name: COMPOSIO_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: COMPOSIO_API_KEY
             - name: ADMIN_EMAIL
               value: {{ .Values.dbInit.adminEmail | default "hello@composio.dev" | quote }}
           resources:

--- a/composio/templates/apollo/apollo.yaml
+++ b/composio/templates/apollo/apollo.yaml
@@ -119,11 +119,6 @@ spec:
                 secretKeyRef:
                   name: {{ $coreSecret }}
                   key: ENCRYPTION_KEY
-            - name: COMPOSIO_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: COMPOSIO_API_KEY
             {{- if .Values.openAI.enabled }}
             - name: OPENAI_API_KEY
               valueFrom:
@@ -135,7 +130,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ $coreSecret }}
-                  key: APOLLO_ADMIN_TOKEN
+                  key: COMPOSIO_ADMIN_TOKEN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/composio/templates/database/postgres-init-job.yaml
+++ b/composio/templates/database/postgres-init-job.yaml
@@ -39,18 +39,22 @@ spec:
         - -c
         - |
           cat <<'EOF' | psql
-          
+
 
           -- Create databases
           CREATE DATABASE composiodb;
+          {{- if eq (include "composio.temporalEnabled" .) "true" }}
           CREATE DATABASE temporal;
           CREATE DATABASE temporal_visibility;
+          {{- end }}
           CREATE DATABASE thermosdb;
-          
-          -- Alter Database 
+
+          -- Alter Database
           ALTER DATABASE composiodb OWNER TO {{ .Values.databaseMigration.user }};
+          {{- if eq (include "composio.temporalEnabled" .) "true" }}
           ALTER DATABASE temporal OWNER TO {{ .Values.databaseMigration.user }};
           ALTER DATABASE temporal_visibility OWNER TO {{ .Values.databaseMigration.user }};
+          {{- end }}
           ALTER DATABASE thermosdb OWNER TO {{ .Values.databaseMigration.user }};
 
           -- Grant privileges on thermosdb
@@ -69,6 +73,7 @@ spec:
           ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {{ .Values.databaseMigration.user }};
           ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {{ .Values.databaseMigration.user }};
 
+          {{- if eq (include "composio.temporalEnabled" .) "true" }}
           -- Grant privileges on temporal
           \c temporal
           GRANT ALL PRIVILEGES ON DATABASE temporal TO {{ .Values.databaseMigration.user }};
@@ -84,6 +89,7 @@ spec:
           ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {{ .Values.databaseMigration.user }};
           ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {{ .Values.databaseMigration.user }};
           ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {{ .Values.databaseMigration.user }};
+          {{- end }}
 
           -- Grant database creation privilege
           \c postgres

--- a/composio/templates/mercury/mercury-service.yaml
+++ b/composio/templates/mercury/mercury-service.yaml
@@ -73,7 +73,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ $coreSecret }}
-                  key: APOLLO_ADMIN_TOKEN
+                  key: COMPOSIO_ADMIN_TOKEN
             - name: USE_APOLLO_GET_DOWNLOAD_URL_API
               value: "true"
           resources:

--- a/composio/templates/mercury/mercury.yaml
+++ b/composio/templates/mercury/mercury.yaml
@@ -83,7 +83,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ $coreSecret }}
-                  key: APOLLO_ADMIN_TOKEN
+                  key: COMPOSIO_ADMIN_TOKEN
             {{- if .Values.otel.enabled }}
             # OTEL Resource attributes
             - name: OTEL_RESOURCE_ATTRIBUTES

--- a/composio/templates/preflight-checks/preflight-config.yaml
+++ b/composio/templates/preflight-checks/preflight-config.yaml
@@ -35,11 +35,13 @@ stringData:
             namespace: "{{ .Release.Namespace }}"
             key: "JWT_SECRET"
             includeValue: false
+        {{- if eq (include "composio.temporalEnabled" .) "true" }}
         - secret:
             name: "{{ $coreSecret }}"
             namespace: "{{ .Release.Namespace }}"
             key: "TEMPORAL_TRIGGER_ENCRYPTION_KEY"
             includeValue: false
+        {{- end }}
         - secret:
             name: "{{ $coreSecret }}"
             namespace: "{{ .Release.Namespace }}"
@@ -104,6 +106,7 @@ stringData:
               - pass:
                   message: "Found {{ $coreSecret }} (JWT_SECRET)."
 
+        {{- if eq (include "composio.temporalEnabled" .) "true" }}
         - secret:
             checkName: "Temporal encryption key secret present"
             secretName: "{{ $coreSecret }}"
@@ -114,6 +117,7 @@ stringData:
                   message: "Missing {{ $coreSecret }} or key TEMPORAL_TRIGGER_ENCRYPTION_KEY."
               - pass:
                   message: "Found {{ $coreSecret }} (TEMPORAL_TRIGGER_ENCRYPTION_KEY)."
+        {{- end }}
         - secret:
             checkName: "Apollo Postgres URL present"
             secretName: "{{ $coreSecret }}"

--- a/composio/templates/preflight-checks/preflight-config.yaml
+++ b/composio/templates/preflight-checks/preflight-config.yaml
@@ -18,12 +18,7 @@ stringData:
         - secret:
             name: "{{ $coreSecret }}"
             namespace: "{{ .Release.Namespace }}"
-            key: "APOLLO_ADMIN_TOKEN"
-            includeValue: false
-        - secret:
-            name: "{{ $coreSecret }}"
-            namespace: "{{ .Release.Namespace }}"
-            key: "COMPOSIO_API_KEY"
+            key: "COMPOSIO_ADMIN_TOKEN"
             includeValue: false
         - secret:
             name: "{{ $coreSecret }}"
@@ -66,23 +61,12 @@ stringData:
             checkName: "Apollo admin token secret present"
             secretName: "{{ $coreSecret }}"
             namespace: "{{ .Release.Namespace }}"
-            key: "APOLLO_ADMIN_TOKEN"
+            key: "COMPOSIO_ADMIN_TOKEN"
             outcomes:
               - fail:
-                  message: "Missing {{ $coreSecret }} or key APOLLO_ADMIN_TOKEN."
+                  message: "Missing {{ $coreSecret }} or key COMPOSIO_ADMIN_TOKEN."
               - pass:
-                  message: "Found {{ $coreSecret }} (APOLLO_ADMIN_TOKEN)."
-
-        - secret:
-            checkName: "Composio API key secret present"
-            secretName: "{{ $coreSecret }}"
-            namespace: "{{ .Release.Namespace }}"
-            key: "COMPOSIO_API_KEY"
-            outcomes:
-              - fail:
-                  message: "Missing {{ $coreSecret }} or key COMPOSIO_API_KEY."
-              - pass:
-                  message: "Found {{ $coreSecret }} (COMPOSIO_API_KEY)."
+                  message: "Found {{ $coreSecret }} (COMPOSIO_ADMIN_TOKEN)."
 
         - secret:
             checkName: "Encryption key secret present"

--- a/composio/templates/thermos/thermos-config.yaml
+++ b/composio/templates/thermos/thermos-config.yaml
@@ -13,11 +13,13 @@ data:
   POLLING_TRIGGER_SLEEP: "60"
   REGISTRY_LOOKUP_CACHE_DIR: "/tmp/.lookup"
   SELF_HOSTED: "true"
+  {{- if eq (include "composio.temporalEnabled" .) "true" }}
   TEMPORAL_CLOUD_HOST_PORT: "temporal-stack-frontend:7233"
   TEMPORAL_CLOUD_NAMESPACE: "default"
   TEMPORAL_WEBHOOK_NAMESPACE: "webhook"
   TEMPORAL_BATCHED_POLLING_NAMESPACE: "batched-polling"
   DISABLE_TEMPORAL_TLS: "true"
+  {{- end }}
   LAMBDA_USE_HTTP: "true"
   LAMBDA_USE_HTTP_ENDPOINT: "http://{{ include "composio.fullname" . }}-mercury.{{ .Release.Namespace }}.svc.cluster.local"
   AWS_LAMBDA_REGION: {{ .Values.aws.region | quote }}

--- a/composio/templates/thermos/thermos-config.yaml
+++ b/composio/templates/thermos/thermos-config.yaml
@@ -19,6 +19,8 @@ data:
   TEMPORAL_WEBHOOK_NAMESPACE: "webhook"
   TEMPORAL_BATCHED_POLLING_NAMESPACE: "batched-polling"
   DISABLE_TEMPORAL_TLS: "true"
+  {{- else }}
+  DISABLE_TEMPORAL: "true"
   {{- end }}
   LAMBDA_USE_HTTP: "true"
   LAMBDA_USE_HTTP_ENDPOINT: "http://{{ include "composio.fullname" . }}-mercury.{{ .Release.Namespace }}.svc.cluster.local"

--- a/composio/templates/thermos/thermos-db-init-job.yaml
+++ b/composio/templates/thermos/thermos-db-init-job.yaml
@@ -66,11 +66,6 @@ spec:
                 secretKeyRef:
                   name: {{ $coreSecret }}
                   key: THERMOS_DATABASE_URL
-            - name: COMPOSIO_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: COMPOSIO_API_KEY
             - name: ADMIN_EMAIL
               value: {{ .Values.dbInit.adminEmail | default "hello@composio.dev" | quote }}
             {{- if .Values.thermos.dbInit.extraAtlasFlags }}

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -84,7 +84,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ $coreSecret }}
-                  key: APOLLO_ADMIN_TOKEN
+                  key: COMPOSIO_ADMIN_TOKEN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -2,6 +2,17 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Feature flags for optional functionality
+# These control whether certain features (and their dependencies) are enabled
+# NOTE: When enabling auth_refresh or triggers, you must also set temporal.enabled=true
+features:
+  # -- Enable auth token refresh functionality (requires Temporal)
+  # When set to true, also set temporal.enabled: true
+  auth_refresh: false
+  # -- Enable triggers functionality (requires Temporal)
+  # When set to true, also set temporal.enabled: true
+  triggers: false
+
 # Composio Application Secrets
 secret:
   name: "composio-composio-secrets"
@@ -384,10 +395,14 @@ dbInit:
     restartPolicy: OnFailure
 
 # Temporal workflow engine configuration
+# Temporal is required when features.auth_refresh or features.triggers is enabled
+# When disabled, Temporal-dependent features will not be available
 temporal:
+  # -- Enable Temporal deployment. Set to true when features.auth_refresh or features.triggers is enabled
+  enabled: false
   # -- Override the full name of Temporal resources
   fullnameOverride: "temporal-stack"
-  
+
   # Temporal server configuration
   server:
     # -- Enable Temporal server

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -3,11 +3,12 @@
 # Declare variables to be passed into your templates.
 
 # Feature flags for optional functionality
-# Enabling auth_refresh or triggers automatically activates Temporal integration in thermos
+# These control whether certain features (and their dependencies) are enabled
+# Enabling auth_refresh or triggers requires temporal.enabled=true (validated at install time)
 features:
-  # -- Enable auth token refresh functionality
+  # -- Enable auth token refresh functionality (requires Temporal)
   auth_refresh: false
-  # -- Enable triggers functionality
+  # -- Enable triggers functionality (requires Temporal)
   triggers: false
 
 # Composio Application Secrets
@@ -392,8 +393,10 @@ dbInit:
     restartPolicy: OnFailure
 
 # Temporal workflow engine configuration
-# Temporal is always deployed; thermos connects to it only when features.auth_refresh or features.triggers is enabled
+# Required when features.auth_refresh or features.triggers is enabled
 temporal:
+  # -- Enable Temporal deployment (required when auth_refresh or triggers features are enabled)
+  enabled: false
   # -- Override the full name of Temporal resources
   fullnameOverride: "temporal-stack"
 

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -4,13 +4,11 @@
 
 # Feature flags for optional functionality
 # These control whether certain features (and their dependencies) are enabled
-# NOTE: When enabling auth_refresh or triggers, you must also set temporal.enabled=true
+# Enabling auth_refresh or triggers requires temporal.enabled=true (validated at install time)
 features:
   # -- Enable auth token refresh functionality (requires Temporal)
-  # When set to true, also set temporal.enabled: true
   auth_refresh: false
   # -- Enable triggers functionality (requires Temporal)
-  # When set to true, also set temporal.enabled: true
   triggers: false
 
 # Composio Application Secrets
@@ -395,10 +393,9 @@ dbInit:
     restartPolicy: OnFailure
 
 # Temporal workflow engine configuration
-# Temporal is required when features.auth_refresh or features.triggers is enabled
-# When disabled, Temporal-dependent features will not be available
+# Required when features.auth_refresh or features.triggers is enabled
 temporal:
-  # -- Enable Temporal deployment. Set to true when features.auth_refresh or features.triggers is enabled
+  # -- Enable Temporal deployment (required when auth_refresh or triggers features are enabled)
   enabled: false
   # -- Override the full name of Temporal resources
   fullnameOverride: "temporal-stack"

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -3,12 +3,11 @@
 # Declare variables to be passed into your templates.
 
 # Feature flags for optional functionality
-# These control whether certain features (and their dependencies) are enabled
-# Enabling auth_refresh or triggers requires temporal.enabled=true (validated at install time)
+# Enabling auth_refresh or triggers automatically activates Temporal integration in thermos
 features:
-  # -- Enable auth token refresh functionality (requires Temporal)
+  # -- Enable auth token refresh functionality
   auth_refresh: false
-  # -- Enable triggers functionality (requires Temporal)
+  # -- Enable triggers functionality
   triggers: false
 
 # Composio Application Secrets
@@ -393,10 +392,8 @@ dbInit:
     restartPolicy: OnFailure
 
 # Temporal workflow engine configuration
-# Required when features.auth_refresh or features.triggers is enabled
+# Temporal is always deployed; thermos connects to it only when features.auth_refresh or features.triggers is enabled
 temporal:
-  # -- Enable Temporal deployment (required when auth_refresh or triggers features are enabled)
-  enabled: false
   # -- Override the full name of Temporal resources
   fullnameOverride: "temporal-stack"
 

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -3,13 +3,10 @@
 # Declare variables to be passed into your templates.
 
 # Feature flags for optional functionality
-# These control whether certain features (and their dependencies) are enabled
-# Enabling auth_refresh or triggers requires temporal.enabled=true (validated at install time)
 features:
-  # -- Enable auth token refresh functionality (requires Temporal)
-  auth_refresh: false
-  # -- Enable triggers functionality (requires Temporal)
-  triggers: false
+  # -- Enable Temporal, auth token refresh, and triggers
+  # When true, deploys Temporal and enables auth refresh + trigger workers in thermos
+  temporal: false
 
 # Composio Application Secrets
 secret:
@@ -393,10 +390,7 @@ dbInit:
     restartPolicy: OnFailure
 
 # Temporal workflow engine configuration
-# Required when features.auth_refresh or features.triggers is enabled
 temporal:
-  # -- Enable Temporal deployment (required when auth_refresh or triggers features are enabled)
-  enabled: false
   # -- Override the full name of Temporal resources
   fullnameOverride: "temporal-stack"
 

--- a/docs/post-installation/index.md
+++ b/docs/post-installation/index.md
@@ -271,16 +271,15 @@ Composio uses a comprehensive secret management system that handles both auto-ge
 
 | Secret Name | Purpose | Key |
 |-------------|---------|-----|
-| `{release}-composio-secrets` | Consolidated chart-managed secrets | `APOLLO_ADMIN_TOKEN`, `ENCRYPTION_KEY`, `TEMPORAL_TRIGGER_ENCRYPTION_KEY`, `COMPOSIO_API_KEY`, `JWT_SECRET` |
+| `{release}-composio-secrets` | Consolidated chart-managed secrets | `COMPOSIO_ADMIN_TOKEN`, `ENCRYPTION_KEY`, `TEMPORAL_TRIGGER_ENCRYPTION_KEY`, `JWT_SECRET` |
 
 To create or rotate the consolidated secret manually:
 
 ```bash
 kubectl create secret generic <release>-composio-secrets \
-  --from-literal=APOLLO_ADMIN_TOKEN=<token> \
+  --from-literal=COMPOSIO_ADMIN_TOKEN=<token> \
   --from-literal=ENCRYPTION_KEY=<encryption-key> \
   --from-literal=TEMPORAL_TRIGGER_ENCRYPTION_KEY=<temporal-key> \
-  --from-literal=COMPOSIO_API_KEY=<api-key> \
   --from-literal=JWT_SECRET=<jwt-secret> \
   --from-literal=POSTGRES_URL=<postgres_url> \
   --from-literal=THERMOS_DATABASE_URL=<thermos_database_url> \

--- a/docs/replicated-pre-installation.md
+++ b/docs/replicated-pre-installation.md
@@ -20,10 +20,9 @@ Based on your database configured change `sslmode=require` for **POSTGRES_URL** 
 
 ```bash
 kubectl create secret generic composio-composio-secrets \
-  --from-literal=APOLLO_ADMIN_TOKEN=<CREATE_RANDOM_TOKEN-A> \
+  --from-literal=COMPOSIO_ADMIN_TOKEN=<CREATE_RANDOM_TOKEN-A> \
   --from-literal=ENCRYPTION_KEY=<ENCRYPTION_KEY_FOR_DATABASE> \
   --from-literal=TEMPORAL_TRIGGER_ENCRYPTION_KEY=<ENCRYPTION_KEY_FOR_DATABASE_TEMPORAL> \
-  --from-literal=COMPOSIO_API_KEY=<CREATE_RANDOM_TOKEN-B> \
   --from-literal=JWT_SECRET=<CREATE_RANDOM_TOKEN-C> \
   --from-literal=POSTGRES_URL="postgresql://<DATABASE_USER>:<DATABASE_PASSWORD>@<DATABASE_HOST>:5432/composiodb?sslmode=require" \
   --from-literal=THERMOS_DATABASE_URL="postgresql://<DATABASE_USER>:<DATABASE_PASSWORD>@<DATABASE_HOST>:5432/thermosdb?sslmode=require" \
@@ -40,11 +39,9 @@ kubectl create secret generic composio-composio-secrets \
    Used by the Composio application for database encryption.
 2. **TEMPORAL_TRIGGER_ENCRYPTION_KEY**  
    Used by Temporal for database encryption.
-3. **APOLLO_ADMIN_TOKEN**  
+3. **COMPOSIO_ADMIN_TOKEN**  
    API token for the Composio Apollo application.
-4. **COMPOSIO_API_KEY**  
-   API key for Composio applications.
-5. **JWT_SECRET**  
+4. **JWT_SECRET**  
    Secret key used for signing and verifying JWT tokens.
 6. **POSTGRES_URL**  
    Database connection URI for the Composio Apollo database.

--- a/secret-setup.sh
+++ b/secret-setup.sh
@@ -44,7 +44,7 @@ usage() {
     echo "  SMTP_SECRET_NAME     Optional. Overrides default secret name (\${release}-smtp-credentials)"
     echo ""
     echo -e "${YELLOW}Generated Secrets (auto-created if missing):${NC}"
-    echo "  • \${release}-composio-secrets (contains APOLLO_ADMIN_TOKEN, ENCRYPTION_KEY, TEMPORAL_TRIGGER_ENCRYPTION_KEY, COMPOSIO_API_KEY, JWT_SECRET, and optional user-provided URLs/keys)"
+    echo "  • \${release}-composio-secrets (contains COMPOSIO_ADMIN_TOKEN, ENCRYPTION_KEY, TEMPORAL_TRIGGER_ENCRYPTION_KEY, JWT_SECRET, and optional user-provided URLs/keys)"
     echo ""
     echo -e "${YELLOW}Examples:${NC}"
     echo "  # Setup with all external secrets"
@@ -213,25 +213,22 @@ else
     else
         print_info "Creating consolidated core secret: $CORE_SECRET_NAME"
 
-        apollo_admin_token="$(get_secret_value "${RELEASE_NAME}-apollo-admin-token" "APOLLO_ADMIN_TOKEN")"
+        apollo_admin_token="$(get_secret_value "${RELEASE_NAME}-composio-admin-token" "COMPOSIO_ADMIN_TOKEN")"
         encryption_key="$(get_secret_value "${RELEASE_NAME}-encryption-key" "ENCRYPTION_KEY")"
         temporal_encryption_key="$(get_secret_value "${RELEASE_NAME}-temporal-encryption-key" "TEMPORAL_TRIGGER_ENCRYPTION_KEY")"
-        composio_api_key="$(get_secret_value "${RELEASE_NAME}-composio-api-key" "COMPOSIO_API_KEY")"
         jwt_secret="$(get_secret_value "${RELEASE_NAME}-jwt-secret" "JWT_SECRET")"
 
         [[ -z "$apollo_admin_token" ]] && apollo_admin_token="$(generate_random 32)"
         [[ -z "$encryption_key" ]] && encryption_key="$(generate_random 32)"
         [[ -z "$temporal_encryption_key" ]] && temporal_encryption_key="$(generate_random 32)"
-        [[ -z "$composio_api_key" ]] && composio_api_key="$(generate_random 32)"
         [[ -z "$jwt_secret" ]] && jwt_secret="$(generate_random 32)"
 
         if [[ "$DRY_RUN" == true ]]; then
             print_info "[DRY-RUN] Would create secret: $CORE_SECRET_NAME"
             print_info "kubectl create secret generic \"$CORE_SECRET_NAME\" \\"
-            print_info "  --from-literal=\"APOLLO_ADMIN_TOKEN=$apollo_admin_token\" \\"
+            print_info "  --from-literal=\"COMPOSIO_ADMIN_TOKEN=$apollo_admin_token\" \\"
             print_info "  --from-literal=\"ENCRYPTION_KEY=$encryption_key\" \\"
             print_info "  --from-literal=\"TEMPORAL_TRIGGER_ENCRYPTION_KEY=$temporal_encryption_key\" \\"
-            print_info "  --from-literal=\"COMPOSIO_API_KEY=$composio_api_key\" \\"
             print_info "  --from-literal=\"JWT_SECRET=$jwt_secret\" \\"
             [[ -n "$POSTGRES_URL" ]] && print_info "  --from-literal=\"POSTGRES_URL=$POSTGRES_URL\" \\"
             [[ -n "$THERMOS_POSTGRES_URL" ]] && print_info "  --from-literal=\"THERMOS_DATABASE_URL=$THERMOS_POSTGRES_URL\" \\"
@@ -241,10 +238,9 @@ else
         else
             create_args=(
                 kubectl create secret generic "$CORE_SECRET_NAME"
-                --from-literal="APOLLO_ADMIN_TOKEN=$apollo_admin_token"
+                --from-literal="COMPOSIO_ADMIN_TOKEN=$apollo_admin_token"
                 --from-literal="ENCRYPTION_KEY=$encryption_key"
                 --from-literal="TEMPORAL_TRIGGER_ENCRYPTION_KEY=$temporal_encryption_key"
-                --from-literal="COMPOSIO_API_KEY=$composio_api_key"
                 --from-literal="JWT_SECRET=$jwt_secret"
                 -n "$NAMESPACE"
             )


### PR DESCRIPTION
## Summary
- Deploy temporal only when temporal is enabled
- Add DISABLE_TEMPORAL flag to thermos config when temporal is not enabled
- Remove COMPOSIO_API_KEY completely
- Rename APOLLO_ADMIN_TOKEN to COMPOSIO_ADMIN_TOKEN in secret reference.

## Test plan
- [ ] Verify helm install works with temporal disabled
- [ ] Verify temporal components are not deployed when disabled
