### PR TITLE
feat: add signup invite-only and allowed domains configuration

### DIFF
--- a/composio/templates/apollo/apollo-configmap.yaml
+++ b/composio/templates/apollo/apollo-configmap.yaml
@@ -62,6 +62,12 @@ data:
   OTEL_METRICS_ENDPOINT: {{ .Values.otel.apollo.metricsEndpoint | default (printf "http://%s-otel-collector:4318/v1/metrics" .Release.Name) | quote }}
   OTEL_RESOURCE_ATTRIBUTES: "service.name={{ .Values.otel.apollo.serviceName | default "apollo" }},service.version={{ .Values.otel.apollo.serviceVersion | default "1.0.0" }},deployment.environment={{ .Values.otel.environment | default .Values.global.environment | default "development" }}"
   {{- end }}
+  {{- if .Values.apollo.signup }}
+  SIGNUP_INVITE_ONLY: {{ .Values.apollo.signup.inviteOnly | default false | toString | quote }}
+  {{- if .Values.apollo.signup.allowedDomains }}
+  SIGNUP_ALLOWED_DOMAINS: {{ .Values.apollo.signup.allowedDomains | quote }}
+  {{- end }}
+  {{- end }}
   SMTP_AUTHOR_EMAIL: {{ .Values.apollo.smtp.smtpAuthorEmail | quote }}
   S3_BUCKET: {{ .Values.apollo.s3Bucket | quote }}
   TEST_DEBUG: "true"

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -191,6 +191,13 @@ apollo:
       # -- CPU limit for Apollo
       cpu: "1"
   
+  # Signup configuration
+  signup:
+    # -- Enable invite-only signup mode (requires invitation to register)
+    inviteOnly: false
+    # -- Comma-separated list of allowed email domains for signup (e.g., "composio.dev,usefulagents.com")
+    allowedDomains: ""
+
   # SMTP configuration for email notifications
   smtp:
     # -- Enable SMTP


### PR DESCRIPTION
## Summary
Add new configuration options for controlling signup behavior in Apollo.

## Changes
- Added `apollo.signup.inviteOnly` (boolean) - When set to `true`, enables invite-only signup mode
- Added `apollo.signup.allowedDomains` (string) - Comma-separated list of allowed email domains for signup (e.g., `composio.dev,usefulagents.com`)

## Usage
```yaml
apollo:
  signup:
    inviteOnly: true
    allowedDomains: "composio.dev,usefulagents.com"
```

Co-Authored-By: Warp <agent@warp.dev>