### PR TITLE
feat(apollo): optional OpenAI key + OpenAI/Bedrock endpoint env support

### DIFF
--- a/composio/templates/apollo/apollo.yaml
+++ b/composio/templates/apollo/apollo.yaml
@@ -129,7 +129,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.openAI.secretRef }}
                   key: {{ .Values.openAI.key }}
+                  optional: true
             {{- end }} 
+            - name: OPENAI_BASE_URL
+              value: {{ .Values.openAI.baseUrl | quote }}
             - name: APOLLO_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -172,6 +175,10 @@ spec:
             {{- if .Values.aws.bedrock.region }}
             - name: AWS_BEDROCK_REGION
               value: {{ .Values.aws.bedrock.region }}
+            {{- end }}
+            {{- if .Values.aws.bedrock.endpoint }}
+            - name: AWS_BEDROCK_ENDPOINT
+              value: {{ .Values.aws.bedrock.endpoint }}
             {{- end }}
             {{- if .Values.apollo.env }}
             {{- toYaml .Values.apollo.env | nindent 12 }}

--- a/composio/templates/frontend/frontend.yaml
+++ b/composio/templates/frontend/frontend.yaml
@@ -86,6 +86,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.openAI.secretRef }}
                   key: {{ .Values.openAI.key }}
+                  optional: true
             {{- end }}
             {{- if and .Values.frontend.secrets .Values.frontend.secrets.PLAIN_SECRET }}
             - name: PLAIN_SECRET
@@ -179,4 +180,3 @@ spec:
       selectPolicy: Max
 {{- end }}
 {{- end }}
-

--- a/composio/templates/mercury/mercury-service.yaml
+++ b/composio/templates/mercury/mercury-service.yaml
@@ -64,6 +64,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.openAI.secretRef }}
                   key: {{ .Values.openAI.key }}
+                  optional: true
             {{- end }}
             - name: BACKEND_URL
               value: {{ printf "http://%s-apollo:9900" .Release.Name | quote }}

--- a/composio/templates/mercury/mercury.yaml
+++ b/composio/templates/mercury/mercury.yaml
@@ -78,6 +78,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.openAI.secretRef }}
                   key: {{ .Values.openAI.key }}
+                  optional: true
             {{- end }}
             - name: APOLLO_ADMIN_TOKEN
               valueFrom:

--- a/composio/templates/preflight-checks/preflight-openai.yaml
+++ b/composio/templates/preflight-checks/preflight-openai.yaml
@@ -14,13 +14,6 @@ stringData:
     spec:
       {{- if .Values.openAI.enabled }}
       collectors:
-        # --- Source OpenAI secret referenced by your values ---
-        - secret:
-            name: "{{ .Values.openAI.secretRef }}"
-            namespace: "{{ .Release.Namespace }}"
-            key: "{{ .Values.openAI.key }}"
-            includeValue: false
-
         # --- Validate OpenAI key by real HTTP request ---
         - runPod:
             collectorName: "validate-openai-api-key"
@@ -60,17 +53,6 @@ stringData:
                       fi
 
       analyzers:
-        - secret:
-            checkName: "OpenAI source secret present"
-            secretName: "{{ .Values.openAI.secretRef }}"
-            namespace: "{{ .Release.Namespace }}"
-            key: "{{ .Values.openAI.key }}"
-            outcomes:
-              - fail:
-                  message: "Missing OpenAI source Secret {{ .Values.openAI.secretRef }} or key {{ .Values.openAI.key }}."
-              - pass:
-                  message: "Found OpenAI source Secret {{ .Values.openAI.secretRef }} (key {{ .Values.openAI.key }})."
-
         - textAnalyze:
             checkName: "OpenAI API key is valid"
             fileName: "/validate-openai-api-key.log"

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -117,8 +117,10 @@ openAI:
   enabled: false
   # -- Secret name containing OpenAI API key
   secretRef: "composio-composio-secrets" 
-  # -- Key name in the secret
+  # -- Key name in the secret (optional when OPENAI key is not required)
   key: "OPENAI_API_KEY"
+  # -- Base URL for OpenAI-compatible API endpoints
+  baseUrl: "https://api.openai.com/v1"
 
 # Apollo service configuration (main API service)
 apollo:
@@ -935,6 +937,8 @@ aws:
   bedrock:
     # -- AWS Bedrock region
     region: us-east-1
+    # -- AWS Bedrock OpenAI-compatible runtime endpoint
+    endpoint: "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1"
     # -- AWS Bedrock secret name
     secretName: ""
     

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -294,9 +294,9 @@ apollo:
         # -- Embedding dimensions for unified search
         dimensions: 1024
       # -- Index/collection name for tool search
-      indexTool: "ToolData"
+      indexTool: "ToolDataOpenai"
       # -- Index/collection name for plan search
-      indexPlan: "UsecasePlans"
+      indexPlan: "UsecasePlansOpenai"
     # Weaviate Configuration
     weaviate:
       # -- Default collection name for Weaviate


### PR DESCRIPTION
## Summary
- Make OPENAI API key optional when OpenAI is enabled by marking OPENAI_API_KEY env var references as optional in Apollo, Mercury, and Frontend.
- Add configurable Apollo env vars for external endpoints:
  - OPENAI_BASE_URL from .Values.openAI.baseUrl
  - AWS_BEDROCK_ENDPOINT from .Values.aws.bedrock.endpoint
- Relax OpenAI preflight to avoid hard-fail when the OpenAI secret/key is missing while preserving optional key validation when present.