### PR TITLE
Glean deployment customizations

### DIFF
--- a/composio/.helmignore
+++ b/composio/.helmignore
@@ -43,4 +43,4 @@ docker-compose.yml
 docker-compose.yaml
 # Temporary files
 tmp/
-temp/ 
+temp/

--- a/composio/Chart.lock
+++ b/composio/Chart.lock
@@ -3,10 +3,7 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 17.11.3
 - name: temporal
-  repository: file://./charts/temporal
-  version: 0.68.1
-- name: replicated
-  repository: oci://registry.replicated.com/library
-  version: 1.12.1
-digest: sha256:8f2481ed7004c96882861f726ae53cc4dfb44f1b253e751fe9a124d26efed4d5
-generated: "2026-01-02T15:47:25.123571+05:30"
+  repository: https://go.temporal.io/helm-charts
+  version: 0.64.0
+digest: sha256:1c13e2fad613314638938c742fce0432c5594681f529375a623e89c99ddab05b
+generated: "2025-07-09T20:00:44.179347+05:30"

--- a/composio/Chart.yaml
+++ b/composio/Chart.yaml
@@ -2,19 +2,13 @@ apiVersion: v2
 name: composio
 description: A Helm chart for Composio
 type: application
-version: "0.1.40"
-appVersion: "0.1.40"
+version: 0.1.0
+appVersion: "1.0.0"
+
 dependencies:
   - name: redis
     version: "17.11.3"
-    repository: "https://charts.bitnami.com/bitnami"
-    condition: redis.enabled
+    repository: "file://./charts/redis"
   - name: temporal
-    alias: temporal
-    version: "0.68.1"
+    version: "0.64.0"
     repository: "file://./charts/temporal"
-    condition: features.temporal
-  - name: replicated
-    repository: oci://registry.replicated.com/library
-    version: 1.12.1
-    condition: replicated.enabled 

--- a/composio/templates/NOTES.txt
+++ b/composio/templates/NOTES.txt
@@ -21,12 +21,11 @@
    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "composio.fullname" . }}-apollo 8080:{{ .Values.apollo.service.port }}
    Then visit: http://127.0.0.1:8080
 
-{{- if eq (include "composio.temporalEnabled" .) "true" }}
+
 
    Temporal Web UI:
    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ .Release.Name }}-temporal-web 8082:8080
    Then visit: http://127.0.0.1:8082
-{{- end }}
 
 
 3. Verify installation:
@@ -46,46 +45,7 @@ For more information:
 - Support: https://discord.gg/composio
 
 
-## 🚨 CRITICAL: Database Encryption Keys (DO NOT SKIP)
-
-**These encryption keys are REQUIRED to decrypt your database.**
-If you lose them, **your data is permanently inaccessible.**
-No backups. No override.
-
-👉 **Store these keys securely (password manager / vault / offline backup).**
-
----
-
-### 🔐 Composio Database Encryption Key
-
-Run the command below to retrieve the encryption key:
-
-```bash
-kubectl get secret \
-  --namespace {{ .Release.Namespace }} \
-  {{ include "composio.coreSecretName" . }} \
-  -o jsonpath='{.data.ENCRYPTION_KEY}' | base64 -d
-```
-
-{{- if eq (include "composio.temporalEnabled" .) "true" }}
-### 🔐 Temporal Database Encryption Key
-
-Run the command below to retrieve the Temporal encryption key:
-
-```bash
-kubectl get secret \
-  --namespace {{ .Release.Namespace }} \
-  {{ include "composio.coreSecretName" . }} \
-  -o jsonpath='{.data.TEMPORAL_TRIGGER_ENCRYPTION_KEY}' | base64 -d
-```
-{{- end }}
-### ⚠️ IMPORTANT NOTES
-
-* These keys are **generated once**
-* They are **not recoverable**
-* Losing them = **irreversible data loss**
-
----
 {{- if and .Values.redis.enabled .Values.redis.auth.enabled (not .Values.redis.auth.password) }}
+
 INFO: Redis password will be auto-managed by the chart for security.
 {{- end }}

--- a/composio/templates/apollo/apollo-configmap.yaml
+++ b/composio/templates/apollo/apollo-configmap.yaml
@@ -12,13 +12,13 @@ data:
   {{- if and .Values.apollo.googleServiceAccount .Values.apollo.googleServiceAccount.enabled }}
   GOOGLE_APPLICATION_CREDENTIALS: "{{ .Values.apollo.googleServiceAccount.mountPath }}/key.json"
   {{- end }}
-  AWS_REGION: {{ .Values.aws.region | quote }}
+  AWS_REGION: {{ .Values.aws.region | default "us-east-1" | quote }}
   COMPOSIO_ENV: "production"
   USE_CLICKHOUSE_FOR_LOGS: "false"
   SELF_HOSTED: "true"
   NODE_OPTIONS: "--max-old-space-size=4096"
   THERMOS_URL: {{ printf "http://%s-thermos:8180" .Release.Name | quote }}
-  BACKEND_URL: {{ .Values.apollo.overwrite_apollo_url | default (printf "http://%s-apollo:9900" .Release.Name) | quote }}
+  BACKEND_URL: {{ .Values.apollo.overwrite_apollo_url | default (printf "http://%s-apollo.composio.svc.cluster.local:9900" .Release.Name) | quote }}
   {{- if .Values.apollo.overwrite_fe_url }}
   OVERWRITE_FE_URL: {{ .Values.apollo.overwrite_fe_url | quote }}
   {{- end }}
@@ -38,7 +38,7 @@ data:
   PERMANENT_STORAGE_NAMESPACE: {{ .Values.apollo.objectStorage.namespaces.permanent | quote }}
   {{- end }}
   SERVICE_NAME: "apollo"
-  APOLLO_URL: {{ .Values.apollo.apollo_url | default (printf "http://%s-apollo:9900" .Release.Name) | quote }}
+  APOLLO_URL: {{ .Values.apollo.apollo_url | default (printf "http://%s-apollo.composio.svc.cluster.local:9900" .Release.Name) | quote }}
   MAX_AUTH_FAILURES_FOR_EXPIRY: "1"
   {{- if or (.Values.apollo.frontendUrl) (.Values.apollo.overwrite_fe_url) }}
   FRONTEND_URL: {{ (.Values.apollo.overwrite_fe_url | default .Values.apollo.frontendUrl | default (printf "https://app.%s" .Values.global.domain)) | quote }}
@@ -61,12 +61,6 @@ data:
   ENABLE_OTEL_METRICS: {{ .Values.otel.metrics.enabled | default "true" | quote }}
   OTEL_METRICS_ENDPOINT: {{ .Values.otel.apollo.metricsEndpoint | default (printf "http://%s-otel-collector:4318/v1/metrics" .Release.Name) | quote }}
   OTEL_RESOURCE_ATTRIBUTES: "service.name={{ .Values.otel.apollo.serviceName | default "apollo" }},service.version={{ .Values.otel.apollo.serviceVersion | default "1.0.0" }},deployment.environment={{ .Values.otel.environment | default .Values.global.environment | default "development" }}"
-  {{- end }}
-  {{- if .Values.apollo.signup }}
-  SIGNUP_INVITE_ONLY: {{ .Values.apollo.signup.inviteOnly | default false | toString | quote }}
-  {{- if .Values.apollo.signup.allowedDomains }}
-  SIGNUP_ALLOWED_DOMAINS: {{ .Values.apollo.signup.allowedDomains | quote }}
-  {{- end }}
   {{- end }}
   SMTP_AUTHOR_EMAIL: {{ .Values.apollo.smtp.smtpAuthorEmail | quote }}
   S3_BUCKET: {{ .Values.apollo.s3Bucket | quote }}
@@ -92,17 +86,7 @@ data:
   {{- end }}
   {{- end }}
   # Embeddings Provider Configuration
-  {{- if eq .Values.apollo.search.embeddings.provider "cohere-bedrock" }}
-  EMBEDDINGS_PROVIDER: {{ .Values.apollo.search.embeddings.provider | default "cohere-bedrock" | quote }}
-  EMBEDDINGS_MODEL: {{ .Values.apollo.search.embeddings.model | default "cohere.embed-v4:0" | quote }}
-  EMBEDDINGS_DIMENSIONS: {{ .Values.apollo.search.embeddings.dimensions | default 1024 | toString | quote }}
-  {{- if .Values.apollo.search.unified.enabled }}
-  UNIFIED_EMBEDDINGS_PROVIDER: {{ .Values.apollo.search.unified.embeddings.provider | default "cohere-bedrock" | quote }}
-  UNIFIED_EMBEDDINGS_MODEL: {{ .Values.apollo.search.unified.embeddings.model | default "cohere.embed-v4:0" | quote }}
-  UNIFIED_EMBEDDINGS_DIMENSIONS: {{ .Values.apollo.search.unified.embeddings.dimensions | default 1024 | toString | quote }}
-  {{- end }}
-  {{- end }}
-  {{- if eq .Values.apollo.search.embeddings.provider "openai" }}
+  {{- if .Values.openAI.enabled }}
   EMBEDDINGS_PROVIDER: {{ .Values.apollo.search.embeddings.provider | default "openai" | quote }}
   EMBEDDINGS_MODEL: {{ .Values.apollo.search.embeddings.model | default "text-embedding-3-large" | quote }}
   EMBEDDINGS_DIMENSIONS: {{ .Values.apollo.search.embeddings.dimensions | default 1024 | toString | quote }}

--- a/composio/templates/apollo/apollo-db-init.job.yaml
+++ b/composio/templates/apollo/apollo-db-init.job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.apollo.dbInit.enabled }}
-{{- $randomHash := include "hash" (dict "data" .Values.apollo.image.tag) }}
+{{- $randomHash := include "hash" (dict "data" .Values.apolloDbInit.image.imageName) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -18,70 +18,80 @@ spec:
         app: apollo-db-init
         release: {{ .Release.Name }}
     spec:
-      {{- if .Values.apollo.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.apollo.serviceAccount.name  }}
+      {{- if .Values.apolloDbInit.serviceAccountName }}
+      serviceAccountName: {{ .Values.apolloDbInit.serviceAccountName }}
       {{- end }}
-      {{- if .Values.replicated.enabled }}
-      {{- include "replicated.imagePullSecrets" . | nindent 6 }}
-      {{- end }}
-      {{- if not .Values.replicated.enabled }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
-      {{- end }}
-      {{- with .Values.apollo.dbInit.podSecurityContext }}
+      {{- with .Values.apolloDbInit.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      restartPolicy: {{ .Values.dbInit.job.restartPolicy | default "OnFailure" }}
-      {{- with .Values.apollo.nodeSelector }}
+      restartPolicy: {{ .Values.apolloDbInit.job.restartPolicy | default "OnFailure" }}
+      {{- with .Values.apolloDbInit.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.apollo.affinity }}
+      {{- with .Values.apolloDbInit.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.apollo.tolerations }}
+      {{- with .Values.apolloDbInit.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.apolloDbInit.additionalInitContainers}}
+      initContainers:
+        {{- with .Values.apolloDbInit.additionalInitContainers }}
+          {{- toYaml . | nindent 8}}
+        {{- end }}
+      {{- end }}
       containers:
         - name: apollo-db-init
-          image: "{{ include "chart.registry" . }}/{{ .Values.apollo.dbInit.image.repository }}:{{ .Values.apollo.dbInit.image.tag }}"
-          imagePullPolicy: {{ .Values.apollo.dbInit.image.pullPolicy }}
-          {{- with .Values.apollo.dbInit.containerSecurityContext }}
+          image: "{{ .Values.apolloDbInit.image.imageName }}"
+          imagePullPolicy: {{ .Values.apolloDbInit.image.pullPolicy }}
+          {{- with .Values.apolloDbInit.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- $coreSecret := include "composio.coreSecretName" . }}
             # Apollo database URL
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: POSTGRES_URL
+                  name: external-postgres-secret
+                  key: url
             - name: ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
+                  name: {{ .Release.Name }}-secrets
                   key: ENCRYPTION_KEY
             - name: ORG_API_KEY_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
+                  name: {{ .Release.Name }}-secrets
                   key: ENCRYPTION_KEY
+            - name: COMPOSIO_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: COMPOSIO_API_KEY
             - name: ADMIN_EMAIL
-              value: {{ .Values.dbInit.adminEmail | default "hello@composio.dev" | quote }}
+              value: {{ .Values.apolloDbInit.adminEmail | default "hello@composio.dev" | quote }}
+          {{- with .Values.apolloDbInit.additionalVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.apolloDbInit.resources }}
           resources:
-            requests:
-              cpu: 500m
-              memory: 512Mi
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-  backoffLimit: {{ .Values.dbInit.job.backoffLimit | default 3 }}
-  activeDeadlineSeconds: {{ .Values.dbInit.job.activeDeadlineSeconds | default 300 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.apolloDbInit.additionalVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  backoffLimit: {{ .Values.apolloDbInit.job.backoffLimit | default 3 }}
+  activeDeadlineSeconds: {{ .Values.apolloDbInit.job.activeDeadlineSeconds | default 300 }}
 {{- end }}

--- a/composio/templates/apollo/apollo.yaml
+++ b/composio/templates/apollo/apollo.yaml
@@ -1,6 +1,3 @@
-{{- if eq .Values.redis.enabled .Values.externalRedis.enabled }}
-{{- fail "Error: Either redis.enabled or externalRedis.enabled must be true, but not both" }}
-{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,25 +21,19 @@ spec:
       labels:
         app: apollo
         release: {{ .Release.Name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/apollo/apollo-configmap.yaml") . | sha256sum }}
+        checksum/env: {{ toYaml .Values.apollo.env | sha256sum }}
     spec:
-      {{- if .Values.apollo.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.apollo.serviceAccount.name  }}
+      {{- if .Values.apollo.serviceAccountName }}
+      serviceAccountName: {{ .Values.apollo.serviceAccountName }}
       {{- end }}
-      {{- if .Values.replicated.enabled }}
-      {{- include "replicated.imagePullSecrets" . | nindent 6 }}
-      {{- end }}
-      {{- if not .Values.replicated.enabled }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
-      {{- end }}
       {{- with .Values.apollo.podSecurityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.apollo.nodeSelector }}
-      nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.apollo.affinity }}
@@ -53,9 +44,23 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.nodeSelector .Values.apollo.nodeSelector }}
+      nodeSelector:
+        {{- with .Values.apollo.nodeSelector }}
+          {{- toYaml . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.nodeSelector | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.apollo.additionalInitContainers}}
+      initContainers:
+        {{- with .Values.apollo.additionalInitContainers }}
+          {{- toYaml . | nindent 8}}
+        {{- end }}
+      {{- end }}
       containers:
         - name: apollo
-          image: "{{ include "chart.registry" . }}/{{ .Values.apollo.image.repository }}:{{ .Values.apollo.image.tag }}"
+          image: "{{ .Values.apollo.image.imageName }}"
           imagePullPolicy: {{ .Values.apollo.image.pullPolicy }}
           {{- with .Values.apollo.containerSecurityContext }}
           securityContext:
@@ -83,102 +88,61 @@ spec:
             - configMapRef:
                 name: {{ .Release.Name }}-apollo-config
           env:
-            {{- $coreSecret := include "composio.coreSecretName" . }}
-            {{- if eq .Values.apollo.objectStorage.backend "s3"}}
-            - name: S3_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.apollo.objectStorage.accessKey.secretName }}
-                  key: {{ .Values.apollo.objectStorage.accessKey.key }}
-            - name: S3_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.apollo.objectStorage.secretKey.secretName }}
-                  key: {{ .Values.apollo.objectStorage.secretKey.key }}
-            {{- end }}
-            {{- if eq .Values.apollo.objectStorage.backend "azure_blob_storage" }}
+            {{- if eq (default "s3" .Values.apollo.objectStorage.backend) "azure_blob_storage" }}
             - name: AZURE_CONNECTION_STRING
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.apollo.objectStorage.azureConnectionString.secretName }}
-                  key: {{ .Values.apollo.objectStorage.azureConnectionString.key }}
-            {{- end }} 
-            {{- if .Values.externalRedis.enabled }}
+                  name: {{ .Release.Name }}-azure-connection-string
+                  key: AZURE_CONNECTION_STRING
+            {{- end }}
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.externalRedis.secretRef }}
-                  key: {{ .Values.externalRedis.key }}
-            {{- end }}
-            {{- if .Values.redis.enabled }}
-            - name: REDIS_URL
-            {{- if .Values.redis.auth.password }}
-              value: "redis://:{{ .Values.redis.auth.password }}@{{ .Release.Name }}-redis-master:6379"
-            {{- else }}
-              value: "redis://{{ .Release.Name }}-redis-master:6379"
-            {{- end }}
-            {{- end }}
-            - name: ENCRYPTION_KEY
+                  name: external-redis-secret
+                  key: url
+            - name: COMPOSIO_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: ENCRYPTION_KEY
+                  name: {{ .Release.Name }}-secrets
+                  key: COMPOSIO_API_KEY
             {{- if .Values.openAI.enabled }}
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.openAI.secretRef }}
-                  key: {{ .Values.openAI.key }}
-                  optional: true
-            {{- end }} 
-            - name: OPENAI_BASE_URL
-              value: {{ .Values.openAI.baseUrl | quote }}
+                  name: {{ .Release.Name }}-openai-credentials
+                  key: OPENAI_API_KEY
+            {{- end }}
             - name: APOLLO_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: COMPOSIO_ADMIN_TOKEN
+                  name: {{ .Release.Name }}-apollo-admin-token
+                  key: APOLLO_ADMIN_TOKEN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: POSTGRES_URL
+                  name: external-postgres-secret
+                  key: url
             - name: ORG_API_KEY_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
+                  name: {{ .Release.Name }}-secrets
                   key: ENCRYPTION_KEY
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
+                  name: {{ .Release.Name }}-jwt-secret
                   key: JWT_SECRET
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-encryption-key
+                  key: ENCRYPTION_KEY
             {{- if .Values.apollo.smtp.enabled }}
             - name: SMTP_CONNECTION_STRING
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.apollo.smtp.secretRef | default (printf "%s-smtp-credentials" .Release.Name) }}
-                  key: {{ .Values.apollo.smtp.key }}
-            {{- end }}
-            {{- if .Values.aws.bedrock.secretName }}
-            - name: AWS_BEDROCK_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.aws.bedrock.secretName }}
-                  key: AWS_BEDROCK_ACCESS_KEY_ID
-            - name: AWS_BEDROCK_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.aws.bedrock.secretName }}
-                  key: AWS_BEDROCK_SECRET_ACCESS_KEY
-            {{- end }}
-            {{- if .Values.aws.bedrock.region }}
-            - name: AWS_BEDROCK_REGION
-              value: {{ .Values.aws.bedrock.region }}
-            {{- end }}
-            {{- if .Values.aws.bedrock.endpoint }}
-            - name: AWS_BEDROCK_OPENAI_ENDPOINT
-              value: {{ .Values.aws.bedrock.endpoint }}
+                  name: {{ .Values.apollo.smtp.credentialsSecret | default (printf "%s-smtp-credentials" .Release.Name) }}
+                  key: SMTP_CONNECTION_STRING
             {{- end }}
             {{- if .Values.apollo.env }}
             {{- toYaml .Values.apollo.env | nindent 12 }}

--- a/composio/templates/apollo/service-account.yaml
+++ b/composio/templates/apollo/service-account.yaml
@@ -14,3 +14,4 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end }}
+

--- a/composio/templates/apollo/stack-secrets.yaml
+++ b/composio/templates/apollo/stack-secrets.yaml
@@ -1,0 +1,114 @@
+# TODO: encryption-key key at 2 places
+{{- $secretName := printf "%s-apollo-admin-token" .Release.Name -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if not $secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    helm.sh/resource-policy: keep
+  name: {{ $secretName }}
+type: Opaque
+stringData:
+  APOLLO_ADMIN_TOKEN: {{ include "apollo-admin-token" . }}
+{{- end }}
+---
+{{- $secretName := printf "%s-composio-api-key" .Release.Name -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if not $secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    helm.sh/resource-policy: keep
+stringData:
+  COMPOSIO_API_KEY: {{ include "composio-api-key" . }}
+{{- end }}
+---
+{{- $secretName := printf "%s-encryption-key" .Release.Name -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if not $secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  ENCRYPTION_KEY: {{ include "encryption-key" . }}
+{{- end }}
+---
+{{- $secretName := printf "%s-jwt-secret" .Release.Name -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if not $secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  JWT_SECRET: {{ include "jwt-secret" . }}
+{{- end }}
+---
+{{- $secretName := printf "%s-temporal-encryption-key" .Release.Name -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if not $secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  TEMPORAL_TRIGGER_ENCRYPTION_KEY: {{ include "temporal-encryption-key" . }}
+{{- end }}
+---
+{{- if .Values.externalRedis }}
+{{- $secretName := "external-redis-secret" -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if not $secret }}
+{{- $password := include "getSecretCred" (dict "name" $.Values.redisConnection.password.secretRef "namespace" .Release.Namespace "key" $.Values.redisConnection.password.key) | trim }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+{{- if $password }}
+  url: "redis://:{{ $password }}@{{ .Values.redisConnection.host }}:{{ .Values.redisConnection.port }}/0"
+{{- else }}
+  url: "redis://{{ .Values.redisConnection.host }}:{{ .Values.redisConnection.port }}/0"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/composio/templates/composio-secrets.yaml
+++ b/composio/templates/composio-secrets.yaml
@@ -1,0 +1,59 @@
+{{/*
+Auto-generate secrets on first install, persist across upgrades
+*/}}
+{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace (printf "%s-secrets" .Release.Name)) }}
+{{- $adminToken := "" }}
+{{- $encryptionKey := "" }}
+{{- $temporalEncryptionKey := "" }}
+{{- $authSecret := "" }}
+{{- $composioApiKey := "" }}
+{{- $bootstrapApiKey := "" }}
+{{- $openAiApiKey := "" }}
+
+{{- if $secretObj }}
+  {{/* Secret exists, use existing values */}}
+  {{- $adminToken = index $secretObj.data "APOLLO_ADMIN_TOKEN" }}
+  {{- $encryptionKey = index $secretObj.data "ENCRYPTION_KEY" }}
+  {{- $temporalEncryptionKey = index $secretObj.data "TEMPORAL_TRIGGER_ENCRYPTION_KEY" }}
+  {{- $authSecret = index $secretObj.data "AUTH_SECRET" }}
+  {{- $composioApiKey = index $secretObj.data "COMPOSIO_API_KEY" }}
+  {{- $bootstrapApiKey = index $secretObj.data "BOOTSTRAP_API_KEY_VALUE" }}
+  {{- $openAiApiKey = index $secretObj.data "OPENAI_API_KEY" }}
+{{- else }}
+  {{/* Secret doesn't exist, generate new values or use provided ones */}}
+  {{- $adminToken = (.Values.secrets.adminToken | default (randAlphaNum 32)) | b64enc }}
+  {{- $encryptionKey = (.Values.secrets.encryptionKey | default (randAlphaNum 32)) | b64enc }}
+  {{- $temporalEncryptionKey = (.Values.secrets.temporalEncryptionKey | default (randAlphaNum 32)) | b64enc }}
+  {{- $authSecret = (.Values.secrets.authSecret | default (randAlphaNum 32)) | b64enc }}
+  {{- $composioApiKey = (.Values.secrets.composioApiKey | default (randAlphaNum 32)) | b64enc }}
+  {{- $bootstrapApiKey = $composioApiKey }}
+  {{- $openAiApiKey = (.Values.secrets.openAiApiKey | default (randAlphaNum 32)) | b64enc }}
+{{- end }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+  labels:
+    app: composio
+    release: {{ .Release.Name }}
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+type: Opaque
+data:
+  # Database configuration is now handled by external-postgres-secret
+  # DATABASE_URL is referenced directly from external-postgres-secret
+
+  # Global Redis configuration (auto-generated from chart dependencies)
+  REDIS_URL: {{ printf "redis://:%s@redis-%s-master:6379" .Values.redis.auth.password .Release.Name | b64enc }}
+  # Auto-generated secrets (generated once, persisted across upgrades)
+  APOLLO_ADMIN_TOKEN: {{ $adminToken }}
+  ENCRYPTION_KEY: {{ $encryptionKey }}
+  TEMPORAL_TRIGGER_ENCRYPTION_KEY: {{ $temporalEncryptionKey }}
+  AUTH_SECRET: {{ $authSecret }}
+  COMPOSIO_API_KEY: {{ $composioApiKey }}
+  BOOTSTRAP_API_KEY_VALUE: {{ $bootstrapApiKey }}
+  OPENAI_API_KEY: {{ $openAiApiKey }}

--- a/composio/templates/ecr-secret.yaml
+++ b/composio/templates/ecr-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.externalSecrets.ecr.token }}
+{{- if and .Values.externalSecrets .Values.externalSecrets.ecr .Values.externalSecrets.ecr.token }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,4 +12,4 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ printf `{"auths":{"%s":{"username":"%s","password":"%s","auth":"%s"}}}` .Values.externalSecrets.ecr.server .Values.externalSecrets.ecr.username .Values.externalSecrets.ecr.token (printf "%s:%s" .Values.externalSecrets.ecr.username .Values.externalSecrets.ecr.token | b64enc) | b64enc }}
-{{- end }} 
+{{- end }}

--- a/composio/templates/knative/knative-crds.yaml
+++ b/composio/templates/knative/knative-crds.yaml
@@ -7,8 +7,8 @@ metadata:
   labels:
     {{- include "composio.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook-weight": "-10"
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-8"
 rules:
 - apiGroups: ["*"]
   resources: ["*"]
@@ -21,8 +21,8 @@ metadata:
   labels:
     {{- include "composio.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook-weight": "-10"
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-7"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -30,7 +30,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "composio.namespace" . }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -41,7 +41,7 @@ metadata:
     {{- include "composio.labels" . | nindent 4 }}
     app.kubernetes.io/component: knative-setup
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-6"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
@@ -58,17 +58,17 @@ spec:
         - -c
         - |
           echo "🚀 Setting up Knative using direct manifests (bypassing operator rate limiting)..."
-          
+
           # Function to apply resource with retry and idempotency
           apply_with_retry() {
             local url=$1
             local resource_type=$2
             echo "📦 Applying $resource_type from $url..."
-            
+
             # Apply the resource (idempotent operation)
             local attempt=1
             local max_attempts=3
-            
+
             while [ $attempt -le $max_attempts ]; do
               if timeout 120 kubectl apply -f "$url"; then
                 echo "✅ Successfully applied $resource_type"
@@ -79,16 +79,16 @@ spec:
                 sleep 10
               fi
             done
-            
+
             echo "❌ Failed to apply $resource_type after $max_attempts attempts"
             echo "🔍 Checking cluster connectivity..."
             kubectl cluster-info || echo "Cluster connectivity issues detected"
             return 1
           }
-          
+
           # Install Knative Serving CRDs (no operator needed)
           apply_with_retry "https://github.com/knative/serving/releases/download/knative-v1.15.0/serving-crds.yaml" "Knative Serving CRDs"
-          
+
           # Wait for CRDs to be established
           echo "⏳ Waiting for Knative Serving CRDs to be ready..."
           if ! kubectl wait --for condition=established --timeout=300s crd/services.serving.knative.dev 2>/dev/null; then
@@ -103,14 +103,14 @@ spec:
           else
             echo "✅ Knative CRDs are ready"
           fi
-          
+
           # Install Knative Serving Core Components (direct, no operator)
           apply_with_retry "https://github.com/knative/serving/releases/download/knative-v1.15.0/serving-core.yaml" "Knative Serving Core"
-          
+
           # Install Kourier networking
           apply_with_retry "https://github.com/knative/net-kourier/releases/download/knative-v1.15.0/kourier.yaml" "Kourier Networking"
-          
-          # Configure Knative to use Kourier and fix domain template
+
+          # Configure Knative to use Kourier
           echo "🔧 Configuring Knative to use Kourier networking..."
           kubectl patch configmap/config-network \
             --namespace knative-serving \
@@ -118,23 +118,14 @@ spec:
             --patch '{"data":{"ingress-class":"kourier.ingress.networking.knative.dev"}}' || {
             echo "⚠️  ConfigMap patch failed, will retry in background"
           }
-          
-          # Fix domain template to prevent DNS lookup issues
-          echo "🌐 Fixing domain template configuration..."
-          kubectl patch configmap/config-network \
-            --namespace knative-serving \
-            --type merge \
-            --patch '{"data":{"domainTemplate":"{{`{{.Name}}.{{.Namespace}}`}}.svc.cluster.local"}}' || {            echo "⚠️  Domain template patch failed, will retry in background"
-          }
-          
+
           echo "✅ Knative setup completed successfully!"
           echo "📊 Installation summary:"
           echo "  • Knative Serving CRDs: Installed"
-          echo "  • Knative Serving Core: Installed" 
+          echo "  • Knative Serving Core: Installed"
           echo "  • Kourier Networking: Installed"
           echo "  • Network Configuration: Kourier enabled"
-          echo "  • Domain Template: Fixed for cluster-local services"
-          
+
           # Verify installation
           echo "🔍 Verifying installation..."
           kubectl get crd | grep knative | head -5

--- a/composio/templates/knative/knative-serving.yaml
+++ b/composio/templates/knative/knative-serving.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.mercury.useKnative }}
+{{- if .Values.namespace.create }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -12,6 +13,7 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-7"
+{{- end }}
 ---
 # Job to configure Knative after installation
 apiVersion: batch/v1
@@ -40,13 +42,13 @@ spec:
         - -c
         - |
           echo "🔧 Configuring Knative for optimal performance..."
-          
+
           # Wait for knative-serving namespace and core components
           echo "⏳ Waiting for Knative serving namespace..."
           kubectl wait --for condition=Ready --timeout=300s namespace/knative-serving || {
             echo "⚠️  Timeout waiting for namespace, but continuing..."
           }
-          
+
           # Wait for config-network ConfigMap to exist with timeout
           echo "⏳ Waiting for config-network ConfigMap..."
           TIMEOUT=300
@@ -65,7 +67,7 @@ spec:
             sleep 10
             ELAPSED=$((ELAPSED + 10))
           done
-          
+
           # Configure domain template for cluster-local services
           echo "🌐 Configuring domain settings..."
           if kubectl get configmap config-domain -n knative-serving >/dev/null 2>&1; then
@@ -79,27 +81,20 @@ spec:
             echo "⚠️  config-domain ConfigMap not found, skipping domain configuration"
           fi
 
-          # Also ensure the domain template is properly set
-          echo "🌐 Setting domain template..."
+          # Configure network settings for cluster-local services
+          echo "🔗 Configuring network settings..."
           if kubectl get configmap config-network -n knative-serving >/dev/null 2>&1; then
             kubectl patch configmap config-network -n knative-serving --type merge --patch '
             {
               "data": {
-                "domainTemplate": "{{`{{.Name}}.{{.Namespace}}`}}.svc.cluster.local"
+                "ingress-class": "kourier.ingress.networking.knative.dev",
+                "domainTemplate": "{{.Name}}.{{.Namespace}}.{{.Domain}}"
               }
-            }' || echo "⚠️  Domain template patch failed, may already be configured"
+            }' || echo "⚠️  Network config patch may have already been applied"
           else
-            echo "⚠️  config-network ConfigMap not found, skipping domain template configuration"
+            echo "⚠️  config-network ConfigMap not found, skipping network configuration"
           fi
-          
-          # Additional network settings (domain template is now handled during installation)
-          echo "🔗 Verifying network settings..."
-          if kubectl get configmap config-network -n knative-serving >/dev/null 2>&1; then
-            echo "✅ Network configuration exists"
-          else
-            echo "⚠️  config-network ConfigMap not found"
-          fi
-          
+
           # Configure defaults for GKE Autopilot optimization
           echo "⚙️  Configuring defaults for GKE Autopilot..."
           if kubectl get configmap config-defaults -n knative-serving >/dev/null 2>&1; then
@@ -107,7 +102,7 @@ spec:
             {
               "data": {
                 "revision-timeout-seconds": "300",
-                "max-revision-timeout-seconds": "600", 
+                "max-revision-timeout-seconds": "600",
                 "revision-cpu-request": "100m",
                 "revision-memory-request": "128Mi",
                 "revision-cpu-limit": "1000m",
@@ -117,14 +112,13 @@ spec:
           else
             echo "⚠️  config-defaults ConfigMap not found, skipping defaults configuration"
           fi
-          
+
           echo "✅ Knative configuration completed!"
           echo "📊 Configuration summary:"
           echo "  • Domain: cluster-local services enabled"
-          echo "  • Network: Configuration verified" 
+          echo "  • Network: Kourier ingress configured"
           echo "  • Defaults: GKE Autopilot optimized"
-          echo "  • Domain Template: Already configured during installation"
-          
+
           # Verify configuration
           echo "🔍 Verifying configuration..."
           kubectl get configmap config-network -n knative-serving -o jsonpath='{.data.ingress-class}' || echo "Could not verify ingress-class"

--- a/composio/templates/mcp/mcp-configmap.yaml
+++ b/composio/templates/mcp/mcp-configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-mcp-config
+  labels:
+    app: mcp
+    release: {{ .Release.Name }}
+data:
+  PORT: "3000"
+  HOSTNAME: "0.0.0.0"
+  APOLLO_COMPOSIO_BASE_URL: {{ printf "http://%s-apollo.composio.svc.cluster.local:9900" .Release.Name | quote }}
+  APOLLO_SPEC_PATH: {{ printf "http://%s-apollo:9900/api/v3/mcp-experimental-openapi.json" .Release.Name | quote }}
+  COMPOSIO_BASE_URL: {{ printf "http://%s-apollo.composio.svc.cluster.local:9900" .Release.Name | quote }}
+  SELF_HOSTED: "true"
+  MCP_BASE_URL: {{ printf "http://%s-mcp.composio.svc.cluster.local:3000" .Release.Name | quote }}
+  SERVICE_NAME: "mcp-server-next"
+  NEXT_PUBLIC_COMPOSIO_BASE_URL: {{ printf "http://%s-apollo.composio.svc.cluster.local:9900" .Release.Name | quote }}
+  APOLLO_URL: {{ printf "http://%s-apollo.composio.svc.cluster.local:9900" .Release.Name | quote }}
+  OVERRIDE_ORIGIN: {{ printf "http://%s-mcp.composio.svc.cluster.local:3000" .Release.Name | quote }}
+  {{- if .Values.otel.enabled }}
+  OTEL_ENABLED: {{ .Values.otel.enabled | quote }}
+  OTEL_SERVICE_NAME: {{ .Values.otel.mcp.serviceName | default "mcp" | quote }}
+  OTEL_SERVICE_VERSION: {{ .Values.otel.mcp.serviceVersion | default "1.0.0" | quote }}
+  OTEL_ENVIRONMENT: {{ .Values.otel.environment | default .Values.global.environment | default "development" | quote }}
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.otel.exporter.otlp.endpoint | default (printf "%s-otel-collector:4317" .Release.Name) | quote }}
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: {{ .Values.otel.exporter.otlp.tracesEndpoint | default (printf "%s-otel-collector:4317" .Release.Name) | quote }}
+  OTEL_EXPORTER_OTLP_INSECURE: {{ .Values.otel.exporter.otlp.insecure | default "true" | quote }}
+  OTEL_TRACES_EXPORTER: "otlp"
+  OTEL_METRICS_EXPORTER: "otlp"
+  OTEL_LOGS_EXPORTER: "otlp"
+  OTEL_RESOURCE_ATTRIBUTES: "service.name={{ .Values.otel.mcp.serviceName | default "mcp" }},service.version={{ .Values.otel.mcp.serviceVersion | default "1.0.0" }},deployment.environment={{ .Values.otel.environment | default .Values.global.environment | default "development" }}"
+  {{- end }}

--- a/composio/templates/mcp/mcp.yaml
+++ b/composio/templates/mcp/mcp.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-mcp
+  labels:
+    app: mcp
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.mcp.replicaCount }}
+  selector:
+    matchLabels:
+      app: mcp
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: mcp
+        release: {{ .Release.Name }}
+    spec:
+      {{- if .Values.mcp.serviceAccountName }}
+      serviceAccountName: {{ .Values.mcp.serviceAccountName }}
+      {{- end }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.nodeSelector .Values.mcp.nodeSelector }}
+      nodeSelector:
+        {{- with .Values.mcp.nodeSelector }}
+          {{- toYaml . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.nodeSelector | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.mcp.additionalInitContainers}}
+      initContainers:
+        {{- with .Values.mcp.additionalInitContainers }}
+          {{- toYaml . | nindent 8}}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: mcp
+          image: "{{ .Values.mcp.image.imageName }}"
+          imagePullPolicy: {{ .Values.mcp.image.pullPolicy }}
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-mcp-config
+          env:
+            - name: AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: AUTH_SECRET
+            - name: COMPOSIO_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: COMPOSIO_API_KEY
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: external-postgres-secret
+                  key: url
+            {{- if .Values.mcp.env }}
+            {{- toYaml .Values.mcp.env | nindent 12 }}
+            {{- end }}
+          {{- with .Values.mcp.additionalVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.mcp.resources | nindent 12 }}
+      {{- with .Values.mcp.additionalVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-mcp
+  labels:
+    app: mcp
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.mcp.service.type }}
+  ports:
+    - port: {{ .Values.mcp.service.port }}
+      targetPort: 3000
+      protocol: TCP
+  selector:
+    app: mcp
+    release: {{ .Release.Name }}

--- a/composio/templates/mercury/mercury-configmap.yaml
+++ b/composio/templates/mercury/mercury-configmap.yaml
@@ -18,6 +18,7 @@ data:
   AWS_S3_ENDPOINT: "http://{{ .Release.Name }}-minio:9000"
   AWS_S3_ENDPOINT_URL: "http://{{ .Release.Name }}-minio:9000"
   AWS_S3_FORCE_PATH_STYLE: "true"
+  USE_APOLLO_GET_DOWNLOAD_URL_API: "true"
   {{- if .Values.otel.enabled }}
   OTEL_ENABLED: {{ .Values.otel.enabled | toString | quote }}
   OTEL_SERVICE_NAME: {{ .Values.otel.mercury.serviceName | default "mercury-openapi" | quote }}
@@ -28,7 +29,6 @@ data:
   OTEL_TRACES_ENABLED: {{ .Values.otel.traces.enabled | toString | quote }}
   OTEL_METRICS_ENABLED: {{ .Values.otel.metrics.enabled | toString | quote }}
   OTEL_METRIC_EXPORT_INTERVAL: {{ .Values.otel.metrics.exportInterval | toString | quote }}
-  USE_APOLLO_GET_DOWNLOAD_URL_API: "true"
   OTEL_RESOURCE_ATTRIBUTES: "service.name={{ .Values.otel.mercury.serviceName | default "mercury-openapi" }},service.version={{ .Values.otel.mercury.serviceVersion | default "1.0.0" }},deployment.environment={{ .Values.otel.environment | default .Values.global.environment | default "development" }}"
   {{- end }}
 {{- end }}

--- a/composio/templates/mercury/mercury-ingress.yaml
+++ b/composio/templates/mercury/mercury-ingress.yaml
@@ -32,4 +32,4 @@ spec:
   tls:
     {{- toYaml .Values.mercury.ingress.tls | nindent 4 }}
   {{- end }}
-{{- end }} 
+{{- end }}

--- a/composio/templates/mercury/mercury-service.yaml
+++ b/composio/templates/mercury/mercury-service.yaml
@@ -3,7 +3,7 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: {{ include "composio.fullname" . }}-mercury
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "composio.namespace" . }}
   labels:
     {{- include "composio.labels" . | nindent 4 }}
     app.kubernetes.io/component: mercury
@@ -11,7 +11,7 @@ metadata:
     # Configure the custom domain for this service
     serving.knative.dev/visibility: cluster-local
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-weight": "-4"
 spec:
   template:
     metadata:
@@ -23,22 +23,29 @@ spec:
         autoscaling.knative.dev/maxScale: "{{ .Values.mercury.autoscaling.maxScale | default "10" }}"
         autoscaling.knative.dev/target: "{{ .Values.mercury.autoscaling.target | default "80" }}"
         # Force new revision only when image changes
-        composio.dev/image-tag: "{{ .Values.mercury.image.tag | default .Chart.AppVersion }}"
+        composio.dev/image-tag: "{{ .Values.mercury.image.imageName | default .Chart.AppVersion }}"
     spec:
-      {{- if .Values.replicated.enabled }}
-      {{- include "replicated.imagePullSecrets" . | nindent 6 }}
-      {{- end }}
-      {{- if not .Values.replicated.enabled }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
+      {{- if or .Values.nodeSelector .Values.mercury.nodeSelector }}
+      nodeSelector:
+        {{- with .Values.mercury.nodeSelector }}
+          {{- toYaml . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.nodeSelector | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
       containerConcurrency: {{ .Values.mercury.containerConcurrency | default 0 }}
       timeoutSeconds: {{ .Values.mercury.timeoutSeconds | default 300 }}
       containers:
         - name: mercury
-          image: "{{ include "chart.registry" . }}/{{ .Values.mercury.image.repository }}:{{ .Values.mercury.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.mercury.image.imageName }}"
           imagePullPolicy: {{ .Values.mercury.image.pullPolicy }}
           {{- if and .Values.mercury.command (gt (len .Values.mercury.command) 0) }}
           command:
@@ -50,33 +57,32 @@ spec:
           {{- end }}
           ports:
             - containerPort: {{ .Values.mercury.service.port | default 8080 }}
-          {{- with .Values.mercury.securityContext }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- toYaml .Values.mercury.securityContext | nindent 12 }}
           env:
-            {{- $coreSecret := include "composio.coreSecretName" . }}
+            # AWS S3 Configuration (using Minio) - matching your reference configuration
+            - name: AWS_S3_REGION_NAME
+              value: "us-east-1"
+            - name: AWS_DEFAULT_REGION
+              value: "us-east-1"
+            - name: AWS_REGION
+              value: "us-east-1"
+            - name: AWS_S3_LAMBDA_BUCKET
+              value: "tools"
+            - name: AWS_S3_CUSTOM_TOOLS_BUCKET
+              value: "tools"
             - name: SELF_HOSTED
               value: "true"
-            {{- if .Values.openAI.enabled }}
+            - name: BACKEND_URL
+              value: {{ printf "http://%s-apollo:9900" .Release.Name | quote }}
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.openAI.secretRef }}
-                  key: {{ .Values.openAI.key }}
-                  optional: true
-            {{- end }}
-            - name: BACKEND_URL
-              value: {{ printf "http://%s-apollo:9900" .Release.Name | quote }}
-            - name: APOLLO_URL
-              value: {{ printf "http://%s-apollo:9900" .Release.Name | quote }}
-            - name: APOLLO_ADMIN_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: COMPOSIO_ADMIN_TOKEN
-            - name: USE_APOLLO_GET_DOWNLOAD_URL_API
+                  name: {{ .Release.Name }}-secrets
+                  key: OPENAI_API_KEY
+            - name: AWS_S3_FORCE_PATH_STYLE
               value: "true"
+
           resources:
             {{- toYaml .Values.mercury.resources | nindent 12 }}
           {{- with .Values.mercury.volumeMounts }}
@@ -88,4 +94,4 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
- 
+

--- a/composio/templates/mercury/mercury.yaml
+++ b/composio/templates/mercury/mercury.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "composio.fullname" . }}-mercury
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "composio.namespace" . }}
   labels:
     {{- include "composio.labels" . | nindent 4 }}
     app.kubernetes.io/component: mercury
@@ -20,14 +20,9 @@ spec:
         {{- include "composio.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: mercury
     spec:
-      {{- if .Values.replicated.enabled }}
-      {{- include "replicated.imagePullSecrets" . | nindent 6 }}
-      {{- end }}
-      {{- if not .Values.replicated.enabled }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.mercury.nodeSelector }}
       nodeSelector:
@@ -43,7 +38,7 @@ spec:
       {{- end }}
       containers:
         - name: mercury
-          image: "{{ include "chart.registry" . }}/{{ .Values.mercury.image.repository }}:{{ .Values.mercury.image.tag }}"
+          image: "{{ .Values.mercury.image.imageName }}"
           imagePullPolicy: {{ .Values.mercury.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.mercury.service.port | default 8080 }}
@@ -57,7 +52,7 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             tcpSocket:
-              port: {{ .Values.mercury.service.port | default 8080 }} 
+              port: {{ .Values.mercury.service.port | default 8080 }}
             timeoutSeconds: 1
           readinessProbe:
             failureThreshold: 3
@@ -71,20 +66,18 @@ spec:
             - configMapRef:
                 name: {{ .Release.Name }}-mercury-config
           env:
-            {{- $coreSecret := include "composio.coreSecretName" . }}
             {{- if .Values.openAI.enabled }}
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.openAI.secretRef }}
-                  key: {{ .Values.openAI.key }}
-                  optional: true
+                  name: {{ .Release.Name }}-openai-credentials
+                  key: OPENAI_API_KEY
             {{- end }}
             - name: APOLLO_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: COMPOSIO_ADMIN_TOKEN
+                  name: {{ .Release.Name }}-apollo-admin-token
+                  key: APOLLO_ADMIN_TOKEN
             {{- if .Values.otel.enabled }}
             # OTEL Resource attributes
             - name: OTEL_RESOURCE_ATTRIBUTES
@@ -105,7 +98,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "composio.fullname" . }}-mercury
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "composio.namespace" . }}
   labels:
     {{- include "composio.labels" . | nindent 4 }}
     app.kubernetes.io/component: mercury
@@ -118,4 +111,4 @@ spec:
   selector:
     {{- include "composio.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: mercury
-{{- end }} 
+{{- end }}

--- a/composio/templates/otel-collector.yaml
+++ b/composio/templates/otel-collector.yaml
@@ -27,16 +27,16 @@ data:
   otel-collector-config.yaml: |
     receivers:
       {{- toYaml .Values.otel.collector.config.receivers | nindent 6 }}
-    
+
     processors:
       {{- toYaml .Values.otel.collector.config.processors | nindent 6 }}
-    
+
     exporters:
       {{- toYaml .Values.otel.collector.config.exporters | nindent 6 }}
-    
+
     extensions:
       {{- toYaml .Values.otel.collector.config.extensions | nindent 6 }}
-    
+
     service:
       {{- toYaml .Values.otel.collector.config.service | nindent 6 }}
 ---

--- a/composio/templates/postgres-secret.yaml
+++ b/composio/templates/postgres-secret.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.externalSecrets .Values.externalSecrets.postgres .Values.externalSecrets.postgres.url }}
+{{- /* Parse PostgreSQL URL: postgresql://user:password@host:port/database?params */ -}}
+{{- $url := .Values.externalSecrets.postgres.url -}}
+{{- $withoutProtocol := regexReplaceAll "^[^:]+://" $url "" -}}
+{{- $userPassAndRest := regexSplit "@" $withoutProtocol 2 -}}
+{{- $userPass := index $userPassAndRest 0 -}}
+{{- $hostPortDbParams := index $userPassAndRest 1 -}}
+{{- $userPassSplit := regexSplit ":" $userPass 2 -}}
+{{- $user := index $userPassSplit 0 -}}
+{{- $password := index $userPassSplit 1 -}}
+{{- $hostPortAndRest := regexSplit "/" $hostPortDbParams 2 -}}
+{{- $hostPort := index $hostPortAndRest 0 -}}
+{{- $dbAndParams := index $hostPortAndRest 1 -}}
+{{- $hostPortSplit := regexSplit ":" $hostPort 2 -}}
+{{- $host := index $hostPortSplit 0 -}}
+{{- $port := index $hostPortSplit 1 -}}
+{{- $database := regexReplaceAll "\\?.*$" $dbAndParams "" -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-postgres-secret
+  namespace: {{ include "composio.namespace" . }}
+  labels:
+    {{- include "composio.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+type: Opaque
+data:
+  # Original URL for services that need it
+  url: {{ .Values.externalSecrets.postgres.url | b64enc }}
+  # Individual components for services like Temporal
+  host: {{ $host | b64enc }}
+  port: {{ $port | b64enc }}
+  user: {{ $user | b64enc }}
+  password: {{ $password | b64enc }}
+  database: {{ $database | b64enc }}
+  # Additional Temporal-specific keys
+  postgres-password: {{ $password | b64enc }}
+{{- end }}

--- a/composio/templates/thermos/thermos-config.yaml
+++ b/composio/templates/thermos/thermos-config.yaml
@@ -13,21 +13,17 @@ data:
   POLLING_TRIGGER_SLEEP: "60"
   REGISTRY_LOOKUP_CACHE_DIR: "/tmp/.lookup"
   SELF_HOSTED: "true"
-  {{- if eq (include "composio.temporalEnabled" .) "true" }}
-  TEMPORAL_CLOUD_HOST_PORT: "temporal-stack-frontend:7233"
+  TEMPORAL_CLOUD_HOST_PORT: "temporal-composio-frontend:7233"
   TEMPORAL_CLOUD_NAMESPACE: "default"
   TEMPORAL_WEBHOOK_NAMESPACE: "webhook"
   TEMPORAL_BATCHED_POLLING_NAMESPACE: "batched-polling"
   DISABLE_TEMPORAL_TLS: "true"
-  {{- else }}
-  DISABLE_TEMPORAL: "true"
-  {{- end }}
   LAMBDA_USE_HTTP: "true"
-  LAMBDA_USE_HTTP_ENDPOINT: "http://{{ include "composio.fullname" . }}-mercury.{{ .Release.Namespace }}.svc.cluster.local"
-  AWS_LAMBDA_REGION: {{ .Values.aws.region | quote }}
-  AWS_S3_REGION: {{ .Values.aws.region | quote }}
-  AWS_S3_LAMBDA_BUCKET_NAME: {{ .Values.aws.s3.lambdaBucketName | quote }}
-  LAMBDA_FUNCTION_NAME: {{ .Values.aws.lambda.functionName | quote }}
+  LAMBDA_USE_HTTP_ENDPOINT: "http://{{ include "composio.fullname" . }}-mercury.composio.svc.cluster.local"
+  AWS_LAMBDA_REGION: {{ .Values.aws.region | default "us-east-1" | quote }}
+  AWS_S3_REGION: {{ .Values.aws.region | default "us-east-1" | quote }}
+  AWS_S3_LAMBDA_BUCKET_NAME: {{ ((.Values.aws).s3).lambdaBucketName | default "" | quote }}
+  LAMBDA_FUNCTION_NAME: "minio"
   AWS_S3_ENDPOINT: "http://{{ .Release.Name }}-minio:9000"
   AWS_S3_FORCE_PATH_STYLE: "true"
   {{- if .Values.otel.enabled }}

--- a/composio/templates/thermos/thermos-db-init-job.yaml
+++ b/composio/templates/thermos/thermos-db-init-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.thermos.dbInit.enabled }}
-{{- $randomHash := include "hash" (dict "data" .Values.apollo.image.tag) }}
+{{- $randomHash := include "hash" (dict "data" .Values.thermosDbInit.image.imageName) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -18,67 +18,83 @@ spec:
         app: thermos-db-init
         release: {{ .Release.Name }}
     spec:
-      {{- if .Values.replicated.enabled }}
-      {{- include "replicated.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.thermosDbInit.serviceAccountName }}
+      serviceAccountName: {{ .Values.thermosDbInit.serviceAccountName }}
       {{- end }}
-      {{- if not .Values.replicated.enabled }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
-      {{- end }}
-      {{- with .Values.thermos.dbInit.podSecurityContext }}
+      {{- with .Values.thermosDbInit.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      restartPolicy: {{ .Values.dbInit.job.restartPolicy | default "OnFailure" }}
-      {{- with .Values.thermos.nodeSelector }}
+      restartPolicy: {{ .Values.thermosDbInit.job.restartPolicy | default "OnFailure" }}
+      {{- with .Values.thermosDbInit.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.thermos.affinity }}
+      {{- with .Values.thermosDbInit.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.thermos.tolerations }}
+      {{- with .Values.thermosDbInit.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.thermosDbInit.additionalInitContainers}}
+      initContainers:
+        {{- with .Values.thermosDbInit.additionalInitContainers }}
+          {{- toYaml . | nindent 8}}
+        {{- end }}
+      {{- end }}
       containers:
         - name: thermos-db-init
-          image: "{{ include "chart.registry" . }}/{{ .Values.thermos.dbInit.image.repository }}:{{ .Values.thermos.dbInit.image.tag }}"
-          imagePullPolicy: {{ .Values.thermos.dbInit.image.pullPolicy }}
-          {{- with .Values.thermos.dbInit.containerSecurityContext }}
+          image: "{{ .Values.thermosDbInit.image.imageName }}"
+          imagePullPolicy: {{ .Values.thermosDbInit.image.pullPolicy }}
+          {{- with .Values.thermosDbInit.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- $coreSecret := include "composio.coreSecretName" . }}
             # Thermos database URL
             - name: POSTGRES_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: THERMOS_DATABASE_URL
+                  name: external-thermos-postgres-secret
+                  key: url
             # Keep DATABASE_URL for backward compatibility with Atlas
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: THERMOS_DATABASE_URL
+                  name: external-thermos-postgres-secret
+                  key: url
+            - name: COMPOSIO_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-composio-api-key
+                  key: COMPOSIO_API_KEY
             - name: ADMIN_EMAIL
-              value: {{ .Values.dbInit.adminEmail | default "hello@composio.dev" | quote }}
-            {{- if .Values.thermos.dbInit.extraAtlasFlags }}
+              value: {{ .Values.thermosDbInit.adminEmail | default "hello@composio.dev" | quote }}
+            {{- if .Values.thermosDbInit.extraAtlasFlags }}
             - name: EXTRA_ATLAS_FLAGS
-              value: {{ .Values.thermos.dbInit.extraAtlasFlags | quote }}
+              value: {{ .Values.thermosDbInit.extraAtlasFlags | quote }}
             {{- end }}
+            {{- if .Values.thermosDbInit.env }}
+            {{- toYaml .Values.thermosDbInit.env | nindent 12 }}
+            {{- end }}
+          {{- with .Values.thermosDbInit.additionalVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.thermosDbInit.resources }}
           resources:
-            requests:
-              cpu: 500m
-              memory: 512Mi
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-  backoffLimit: {{ .Values.dbInit.job.backoffLimit | default 3 }}
-  activeDeadlineSeconds: {{ .Values.dbInit.job.activeDeadlineSeconds | default 300 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.thermosDbInit.additionalVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  backoffLimit: {{ .Values.thermosDbInit.job.backoffLimit | default 3 }}
+  activeDeadlineSeconds: {{ .Values.thermosDbInit.job.activeDeadlineSeconds | default 300 }}
 {{- end }}

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -22,14 +22,12 @@ spec:
         app: thermos
         release: {{ .Release.Name }}
     spec:
-      {{- if .Values.replicated.enabled }}
-      {{- include "replicated.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.thermos.serviceAccountName }}
+      serviceAccountName: {{ .Values.thermos.serviceAccountName }}
       {{- end }}
-      {{- if not .Values.replicated.enabled }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.thermos.podSecurityContext }}
       securityContext:
@@ -47,9 +45,15 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.thermos.additionalInitContainers}}
+      initContainers:
+        {{- with .Values.thermos.additionalInitContainers }}
+          {{- toYaml . | nindent 8}}
+        {{- end }}
+      {{- end }}
       containers:
         - name: thermos
-          image: "{{ include "chart.registry" . }}/{{ .Values.thermos.image.repository }}:{{ .Values.thermos.image.tag }}"
+          image: "{{ .Values.thermos.image.imageName }}"
           imagePullPolicy: {{ .Values.thermos.image.pullPolicy }}
           command: ["/usr/local/bin/thermos", "--cache-dir", "/tmp/.lookup"]
           workingDir: "/tmp"
@@ -79,22 +83,21 @@ spec:
             - configMapRef:
                 name: {{ .Release.Name }}-thermos-config
           env:
-            {{- $coreSecret := include "composio.coreSecretName" . }}
             - name: APOLLO_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: COMPOSIO_ADMIN_TOKEN
+                  name: {{ .Release.Name }}-apollo-admin-token
+                  key: APOLLO_ADMIN_TOKEN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: THERMOS_DATABASE_URL
+                  name: external-thermos-postgres-secret
+                  key: url
             - name: THERMOS_DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: THERMOS_DATABASE_URL
+                  name: external-thermos-postgres-secret
+                  key: url
             {{- if .Values.thermos.env }}
             {{- toYaml .Values.thermos.env | nindent 12 }}
             {{- end }}
@@ -173,4 +176,4 @@ spec:
         value: {{ .Values.thermos.autoscaling.scaleUpPods | default 4 }}
         periodSeconds: {{ .Values.thermos.autoscaling.scaleUpPeriodSeconds | default 15 }}
       selectPolicy: Max
-{{- end }} 
+{{- end }}

--- a/composio/templates/weaviate/weaviate.yaml
+++ b/composio/templates/weaviate/weaviate.yaml
@@ -24,14 +24,9 @@ spec:
         {{- include "composio.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: weaviate
     spec:
-      {{- if .Values.replicated.enabled }}
-      {{- include "replicated.imagePullSecrets" . | nindent 6 }}
-      {{- end }}
-      {{- if not .Values.replicated.enabled }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.weaviate.nodeSelector }}
       nodeSelector:
@@ -47,7 +42,7 @@ spec:
       {{- end }}
       containers:
         - name: weaviate
-          image: "{{ include "chart.registry" . }}/{{ .Values.weaviate.image.repository }}:{{ .Values.weaviate.image.tag }}"
+          image: "{{ .Values.weaviate.image.imageName }}"
           imagePullPolicy: {{ .Values.weaviate.image.pullPolicy }}
           {{- with .Values.weaviate.securityContext }}
           securityContext:
@@ -143,4 +138,3 @@ spec:
     {{- include "composio.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: weaviate
 {{- end }}
-

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -2,1196 +2,280 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Feature flags for optional functionality
-features:
-  # -- Enable Temporal, auth token refresh, and triggers
-  # When true, deploys Temporal and enables auth refresh + trigger workers in thermos
-  temporal: false
-
-# Composio Application Secrets
-secret:
-  name: "composio-composio-secrets"
-# Namespace configuration for Composio services
+# Namespace configuration
+# If create is true, the chart will create namespaces needed by services
+# If create is false, you need to create namespaces externally before deploying
 namespace:
-  # -- Whether to create namespaces automatically
   create: false
-  # -- Name of the namespace where Composio services will be deployed (defaults to "composio" if not specified)
+  # Name of the namespace where Composio services will be deployed
+  # If not specified, defaults to "composio"
   name: "composio"
 
-# replicated based installation. This requires user to authenticate with replicated to download our helm chart. More info on replicated dashboard
-replicated: 
-  enabled: true
-  registry: artifacts.composio.io # Change for custom domain
-  app: "composio-rodent"
-
-# Global configuration applied across all services
 global:
-  # -- Environment name (e.g., development, staging, production)
-  environment: development
-  # -- Domain name for the deployment
+  environment: production
   domain: localhost
-  # Container registry configuration
-  registry: 
-    # -- ECR registry URL
-    name: "008971668139.dkr.ecr.us-east-1.amazonaws.com"
-  # -- Image pull secrets for private registries
-  imagePullSecrets:
-    - name: ecr-secret
 
-databaseMigration: 
-  image: "postgres:15-alpine"
-  enabled: true
-  host: "<DATABASE_HOST>"
-  port: "<DATABASE_PORT>"
-  user: "postgres"
-  password:
-    key: "password"
-
-# External secrets configuration. Pass these during helm install using --set flags
-externalSecrets:
-  # ECR authentication credentials
-  ecr:
-    # -- ECR authentication token. Set via: --set externalSecrets.ecr.token="$(aws ecr get-login-password --region us-east-1)"
-    token: ""
-    # -- ECR server URL
-    server: "008971668139.dkr.ecr.us-east-1.amazonaws.com"
-    # -- ECR username (typically "AWS")
-    username: "AWS" 
-
-# External Redis configuration (recommended for production)
-externalRedis:
-  # -- Enable external Redis. Set to true to use an external Redis instance
+# Disable built-in databases since we're using external PostgreSQL
+postgresql:
   enabled: false
-  # -- Secret name containing Redis connection URL
-  secretRef: "composio-composio-secrets"
-  # -- Key name in the secret containing the Redis URL
-  key: "REDIS_URL"
-    
-# Internal Redis configuration (embedded Redis instance)
+
 redis:
-  image:
-    registry: docker.io
-    repository: redis
-    tag: latest 
-  # -- Enable internal Redis. Set to false when using externalRedis
-  enabled: true
-  # Redis authentication configuration
+  fullnameOverride: "redis-composio"
   auth:
-    # -- Enable Redis authentication
     enabled: true
-    # -- Redis password
-    password: ""
-  # -- Redis architecture (standalone or replication)
+    password: "redis123"
   architecture: standalone
-  # Redis master node configuration
   master:
-    # Persistence configuration
     persistence:
-      # -- Enable persistent storage
-      enabled: false
-      # -- Size of persistent volume
-      size: 8Gi
-    # Resource requests and limits for Redis master
-    resources:
-      requests:
-        # -- Memory request for Redis master
-        memory: "4Gi"
-        # -- CPU request for Redis master
-        cpu: "2"
-      limits:
-        # -- Memory limit for Redis master
-        memory: "4Gi"
-        # -- CPU limit for Redis master
-        cpu: "2"
-    # Disable privileged sysctls for GKE Autopilot compatibility
+      enabled: true
+      size: 2Gi
+    # Disable privileged sysctls for GKE Autopilot
     sysctlImage:
-      # -- Disable sysctl image for GKE Autopilot
       enabled: false
     sysctl:
-      # -- Disable sysctl for GKE Autopilot
       enabled: false
 
-# OpenAI API configuration (required for Frontend, Mercury and Apollo)
-openAI:
-  # -- Enable OpenAI integration
-  enabled: false
-  # -- Secret name containing OpenAI API key
-  secretRef: "composio-composio-secrets" 
-  # -- Key name in the secret (optional when OPENAI key is not required)
-  key: "OPENAI_API_KEY"
-  # -- Base URL for OpenAI-compatible API endpoints
-  baseUrl: "https://api.openai.com/v1"
-
-# Apollo service configuration (main API service)
+# Apollo service configuration - Development
 apollo:
-  # -- Number of Apollo pod replicas
-  replicaCount: 2
-  # Apollo container image configuration
+  database:
+    urlSecret:
+      name: "external-postgres-secret"
+      key: "url"
+  serviceAccountName: composio-ksa
+
+  # Note: Secrets are now managed globally in the 'secrets' section
+
+# MCP service configuration - Development
+mcp:
+  database:
+    urlSecret:
+      name: "external-postgres-secret"
+      key: "url"
+  serviceAccountName: composio-ksa
+
+  # Note: Secrets are now managed globally in the 'secrets' section
+
+  # Note: Secrets are now managed globally in the 'secrets' section
+
+# DB Init - Enabled for development
+dbInit:
+  adminEmail: "admin@composio.dev"
+  database:
+    urlSecret:
+      name: "external-postgres-secret"
+      key: "url"
+  serviceAccountName: composio-ksa
+
+# Enable development monitoring
+prometheus:
+  enabled: false
+  nodeExporter:
+    enabled: false
+  # Fix imagePullSecrets format for GKE Autopilot compatibility
+  imagePullSecrets: []
+
+grafana:
+  enabled: false
+  replicas: 1
+
+testFramework:
+  enabled: false
+
+rbac:
+  create: false
+  pspEnabled: false
+  namespaced: true
+
+# Explicitly disable Elasticsearch and ensure no privileged containers
+elasticsearch:
+  enabled: false
+
+cassandra:
+  enabled: false
+
+# Ingress disabled for development (use port-forward)
+ingress:
+  enabled: false
+
+# Service Account
+serviceAccount:
+  create: true
+  # create: true
+  annotations: {}
+  name: "composio-knative-sa"
+
+# Global node selector - applied to all workloads
+# Default is empty - should be set via Terraform based on deployment configuration
+nodeSelector: &globalNodeSelector
+  {}
+
+# Tolerations - needed for nodes with taints
+# Default is empty - should be set via Terraform based on deployment configuration
+tolerations: &globalTolerations
+  []
+
+# Affinity - disabled for development
+affinity: {}
+
+# AWS configuration - disabled for development
+aws:
+  region: us-east-1
+  s3:
+    lambdaBucketName: "tools"
+  lambda:
+    functionName: "mercury"
+    image: "us-central1-docker.pkg.dev/scio-engineering/glean-images/composio-lambda:latest"
+
+# Mercury service configuration - Development
+mercury:
+  enabled: true
+  # Choose deployment method:
+  # - useKnative: true  = Serverless with auto-scaling (requires Knative installation)
+  # - useKnative: false = Standard Kubernetes deployment
+  useKnative: false
+  replicaCount: 1
   image:
-    # -- Apollo image repository
-    repository: composio-self-host/apollo
-    # -- Apollo image tag
-    tag: "r20260217_00"
-    # -- Image pull policy
+    imageName: us-central1-docker.pkg.dev/scio-engineering/glean-images/composio-mercury:latest
     pullPolicy: Always
 
-  serviceAccount:
-    # -- Enable service account creation
-    enabled: true
-    # -- Name of the service account to create or use
-    name: "composio-apollo"
-    # -- Annotations to add to the service account
-    annotations: {}
-    # -- Labels to add to the service account
-    labels: {}
+  # Let the container use its default entrypoint
+  # command: []
+  # args: []
 
-  # Ingress configuration for Apollo
+  service:
+    type: ClusterIP
+    port: 8080
+
+  autoscaling:
+    minScale: 1
+    maxScale: 10
+    target: 80
+
+  containerConcurrency: 0
+  timeoutSeconds: 300
+
+  knative:
+    minReplicas: 3
+    replicas: 10
+    maxReplicas: 20
+    # Add Knative-specific security context for GKE Autopilot
+
+  # Add security context to ensure proper user permissions
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1000
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
   ingress:
-    # -- Enable ingress
     enabled: false
-    # -- Ingress class name
     className: ""
-    # -- Ingress annotations
     annotations: {}
-    # -- Hostname for Apollo ingress
-    host: "abc.example.com"
-    # -- TLS configuration
+    host: ""
     tls: []
 
-  # Apollo database initialization container
-  dbInit:
-    # -- Enable database initialization
-    enabled: true
-    # Database init container image configuration
-    image:
-      # -- Database init image repository
-      repository: composio-self-host/apollo-db-init
-      # -- Database init image tag
-      tag: "r20260217_00"
-      # -- Image pull policy
-      pullPolicy: Always
-  
-  # Apollo service configuration
-  service:
-    # -- Service type (ClusterIP, NodePort, LoadBalancer)
-    type: NodePort
-    # -- Service port
-    port: 9900
-    # -- NodePort for external access (only applicable when type is NodePort)
-    nodePort: 30900
-  
-  # Resource requests and limits for Apollo pods
-  resources:
-    requests:
-      # -- Memory request for Apollo
-      memory: "5Gi"
-      # -- CPU request for Apollo
-      cpu: "1"
-    limits:
-      # -- Memory limit for Apollo
-      memory: "6Gi"
-      # -- CPU limit for Apollo
-      cpu: "1"
-  
-  # Signup configuration
-  signup:
-    # -- Enable invite-only signup mode (requires invitation to register)
-    inviteOnly: false
-    # -- Comma-separated list of allowed email domains for signup (e.g., "composio.dev,usefulagents.com")
-    allowedDomains: ""
+  # Environment variables are now configured directly in templates/mercury-service.yaml
+  volumeMounts: []
+  volumes: []
 
-  # SMTP configuration for email notifications
-  smtp:
-    # -- Enable SMTP
-    enabled: false
-    # -- Email address for outgoing emails
-    smtpAuthorEmail: "admin@yourdomain.com"
-    # -- Secret reference containing SMTP connection string
-    secretRef: "composio-composio-secrets"
-    # -- Key name in the secret
-    key: "SMTP_CONNECTION_STRING"   
-  
-  # Object storage configuration (S3 or Azure Blob Storage)
-  objectStorage:
-    # -- Storage backend type (s3 or azure_blob_storage)
-    backend: ""
-    # S3 access key configuration
-    accessKey: 
-      # -- Secret name containing S3 access key
-      secretName: "s3-cred"
-      # -- Key name in the secret
-      key: "S3_ACCESS_KEY_ID"
-    # S3 secret key configuration
-    secretKey: 
-      # -- Secret name containing S3 secret key
-      secretName: "s3-cred"
-      # -- Key name in the secret
-      key: "S3_SECRET_ACCESS_KEY"
-    # Azure Blob Storage connection string configuration
-    azureConnectionString: 
-      # -- Secret name containing Azure connection string
-      secretName: "azure-cred"
-      # -- Key name in the secret
-      key: "AZURE_CONNECTION_STRING"
-    # Storage namespace/bucket names
-    namespaces:
-      # -- Bucket/container for temporary files
-      temp: "composio-temp"
-      # -- Bucket/container for permanent files
-      permanent: "composio-permanent"
-  
-  # Horizontal Pod Autoscaler configuration
-  autoscaling:
-    # -- Enable HPA
-    enabled: false
-    # -- Minimum number of replicas
-    minReplicas: 2
-    # -- Maximum number of replicas
-    maxReplicas: 10
-    # -- Target CPU utilization percentage
-    targetCPUUtilizationPercentage: 70
-    # -- Target memory utilization percentage
-    targetMemoryUtilizationPercentage: 80
-    # -- Stabilization window for scale down (seconds)
-    scaleDownStabilizationWindowSeconds: 300
-    # -- Scale down percentage
-    scaleDownPercent: 10
-    # -- Scale down period (seconds)
-    scaleDownPeriodSeconds: 60
-    # -- Stabilization window for scale up (seconds)
-    scaleUpStabilizationWindowSeconds: 60
-    # -- Scale up percentage
-    scaleUpPercent: 100
-    # -- Scale up period (seconds)
-    scaleUpPeriodSeconds: 15
-    # -- Number of pods to scale up at once
-    scaleUpPods: 4
-
-  # Search System Configuration
-  search:
-    # -- Enable search system
-    enabled: false
-    # Vector Store Provider (when unified disabled)
-    vectorStoreProvider: "weaviate"  # Options: "turbopuffer", "weaviate"
-    # Embeddings Configuration
-    embeddings:
-      # -- Embeddings provider (openai, cohere, voyage)
-      provider: "openai"
-      # -- Embeddings model name
-      model: "text-embedding-3-large"  # Default OpenAI model
-      # -- Embedding vector dimensions
-      dimensions: 1024
-    # Unified Search Configuration
-    unified:
-      # -- Enable unified search
-      enabled: true
-      # -- Vector store provider for unified search
-      vectorStoreProvider: "weaviate"  # Options: "turbopuffer", "weaviate"
-      # Unified embeddings configuration
-      embeddings:
-        # -- Embeddings provider for unified search
-        provider: "openai"  # Options: "openai", "cohere", "voyage"
-        # -- Embeddings model for unified search
-        model: "text-embedding-3-large"  # Default OpenAI model
-        # -- Embedding dimensions for unified search
-        dimensions: 1024
-      # -- Index/collection name for tool search
-      indexTool: "ToolDataOpenai"
-      # -- Index/collection name for plan search
-      indexPlan: "UsecasePlansOpenai"
-    # Weaviate Configuration
-    weaviate:
-      # -- Default collection name for Weaviate
-      collection: "ToolSchemas"
-      # -- Weaviate API key (optional, only needed for Weaviate Cloud)
-      # apiKey: ""
-    # Reranker Configuration
-    reranker:
-      # -- Reranker model (format: "provider:model" or just "gemini")
-      model: "openai:gpt-5.2"  # Format: "provider:model" (e.g., "groq:openai/gpt-oss-120b", "openai:gpt-5.2", "gemini:gemini-3-flash-preview")
-      # -- Custom base URL for OpenAI-compatible reranker APIs (optional)
-      openaiCompatBaseUrl: "https://api.openai.com/v1"
-
-# Thermos service configuration (workflow execution service)
-thermos:
-  # -- Number of Thermos pod replicas
-  replicaCount: 2
-  # Thermos container image configuration
-  image:
-    # -- Thermos image repository
-    repository: composio-self-host/thermos
-    # -- Thermos image tag
-    tag: "r20260217_00"
-    # -- Image pull policy
-    pullPolicy: Always
-
-  # Thermos database initialization container
-  dbInit:
-    # -- Enable database initialization
-    enabled: true
-    # Database init container image configuration
-    image:
-      # -- Database init image repository
-      repository: composio-self-host/thermos-db-init
-      # -- Database init image tag
-      tag: "r20260217_00"
-      # -- Image pull policy
-      pullPolicy: Always
-  
-  # Thermos service configuration
-  service:
-    # -- Service type
-    type: ClusterIP
-    # -- Service port
-    port: 8180
-  
-  # Resource requests and limits for Thermos pods
-  resources:
-    requests:
-      # -- Memory request for Thermos
-      memory: "4Gi"
-      # -- CPU request for Thermos
-      cpu: "2"
-    limits:
-      # -- Memory limit for Thermos
-      memory: "5Gi"
-      # -- CPU limit for Thermos
-      cpu: "2"
-  
-  # Horizontal Pod Autoscaler configuration for Thermos
-  autoscaling:
-    # -- Enable HPA
-    enabled: false
-    # -- Minimum number of replicas
-    minReplicas: 2
-    # -- Maximum number of replicas
-    maxReplicas: 10
-    # -- Target CPU utilization percentage
-    targetCPUUtilizationPercentage: 70
-    # -- Target memory utilization percentage
-    targetMemoryUtilizationPercentage: 80
-    # -- Stabilization window for scale down (seconds)
-    scaleDownStabilizationWindowSeconds: 300
-    # -- Scale down percentage
-    scaleDownPercent: 10
-    # -- Scale down period (seconds)
-    scaleDownPeriodSeconds: 60
-    # -- Stabilization window for scale up (seconds)
-    scaleUpStabilizationWindowSeconds: 60
-    # -- Scale up percentage
-    scaleUpPercent: 100
-    # -- Scale up period (seconds)
-    scaleUpPeriodSeconds: 15
-    # -- Number of pods to scale up at once
-    scaleUpPods: 4
-
-# Database initialization job configuration
-dbInit:
-  # -- Admin email for initial setup
-  adminEmail: "hello@composio.dev"
-  # Kubernetes job configuration
-  job:
-    # -- Maximum number of retries for failed jobs
-    backoffLimit: 3
-    # -- Maximum time for job execution (seconds)
-    activeDeadlineSeconds: 2400
-    # -- Job restart policy
-    restartPolicy: OnFailure
-
-# Temporal workflow engine configuration
+# Temporal configuration - Using official helm chart as dependency with external PostgreSQL
 temporal:
-  # -- Override the full name of Temporal resources
-  fullnameOverride: "temporal-stack"
+  fullnameOverride: "temporal-composio"
+  serviceAccount:
+    create: false
+    name: composio-ksa
 
-  # Temporal server configuration
   server:
-    # -- Enable Temporal server
-    enabled: false
-    # Liveness probe configuration
-    livenessProbe:
-      # -- Enable liveness probe
-      enabled: false
+    enabled: true
+    replicaCount: 1
 
-    # Readiness probe configuration
-    readinessProbe:
-      # -- Enable readiness probe
-      enabled: false
-
-    # -- Number of Temporal server replicas
-    replicaCount: 2
-    # Temporal server image configuration
-    image:
-      # -- Temporal server image repository
-      repository: temporalio/server
-      # -- Temporal server image tag
-      tag: 1.28.0
-      # -- Image pull policy
-      pullPolicy: IfNotPresent
-    
-    # Temporal server configuration
     config:
-      # -- Log level (debug, info, warn, error)
       logLevel: "info"
-      # -- Number of history shards (affects scalability)
       numHistoryShards: 512
-      
-      # Persistence configuration for Temporal data
+
+      # Configure persistence to use PostgreSQL from external secret
       persistence:
-        # -- Default persistence store
-        defaultStore: default
-        
-        # Main Temporal database configuration
+        # defaultStore: default
+
+        # Main temporal database
         default:
-          # -- Database driver
           driver: "sql"
-          # SQL database configuration
           sql:
-            # -- SQL driver name
             driver: "postgres12"
-            # -- Database host
-            host: "postgres-new.db"
-            # -- Database port
+            host: "127.0.0.1"
             port: 5432
-            # -- Database name
             database: "temporal"
-            # -- Database user
-            user: "postgres"
-            # -- Secret name containing database password
-            existingSecret: "composio-composio-secrets"
-            # -- Maximum number of database connections
+            user: "composio"
+            existingSecret: "external-postgres-secret"
+            existingSecretPasswordKey: "password"
             maxConns: 20
-            # -- Maximum number of idle connections
             maxIdleConns: 20
-            # -- Maximum connection lifetime
             maxConnLifetime: "1h"
-        
-        # Visibility database configuration (for advanced queries)
+
+        # Visibility database (will be created by schema setup)
         visibility:
-          # -- Database driver
-          driver: "sql" 
-          # SQL database configuration
+          driver: "sql"
           sql:
-            # -- SQL driver name
             driver: "postgres12"
-            # -- Database host
-            host: "postgres-new.db"
-            # -- Database port
+            host: "127.0.0.1"
             port: 5432
-            # -- Database name
             database: "temporal_visibility"
-            # -- Database user
-            user: "postgres"
-            # -- Secret name containing database password
-            existingSecret: "composio-composio-secrets"
-            # -- Maximum number of database connections
+            user: "composio"
+            existingSecret: "external-postgres-secret"
+            existingSecretPasswordKey: "password"
             maxConns: 20
-            # -- Maximum number of idle connections
             maxIdleConns: 20
-            # -- Maximum connection lifetime
             maxConnLifetime: "1h"
-      
-      # Temporal namespace configuration
       namespaces:
-        # -- Enable namespace creation
+        # Enable this to create namespaces
         create: true
-        # -- List of namespaces to create
         namespace:
           - name: default
             retention: 7d
-          - name: batched-polling
-            retention: 10d
-          - name: webhook
-            retention: 10d
+    extraEnv:
+      - name: SQL_TLS_ENABLED
+        value: "false"
+      - name: SQL_TLS_DISABLE_HOST_VERIFICATION
+        value: "true"
 
-    # Temporal frontend service configuration
+    # Frontend service configuration
     frontend:
-      # Liveness probe configuration
-      livenessProbe:
-        # -- Enable liveness probe
-        enabled: false
-
-      # Readiness probe configuration
-      readinessProbe:
-        # -- Enable readiness probe
-        enabled: false
-      
-      # Frontend service configuration
       service:
-        # -- Service type
         type: ClusterIP
-        # -- gRPC port
         port: 7233
-        # -- Membership port
         membershipPort: 6933
-        # -- HTTP port
         httpPort: 7243
 
-  # Temporal database schema setup
-  schema:
-    # Database creation configuration
     createDatabase:
-      # -- Enable database creation
-      enabled: false
-    # Schema setup configuration
+      enabled: true
     setup:
-      # -- Enable schema setup
       enabled: true
-      # -- Maximum retries for schema setup
       backoffLimit: 100
-    # Schema update configuration
     update:
-      # -- Enable schema updates
       enabled: true
-      # -- Maximum retries for schema updates
       backoffLimit: 100
 
-  # Temporal Web UI configuration
-  web:
-    # -- Enable Temporal Web UI
-    enabled: false
-    # -- Number of Web UI replicas
-    replicaCount: 1
-    # Web UI image configuration
-    image:
-      # -- Web UI image repository
-      repository: temporalio/ui
-      # -- Web UI image tag
-      tag: 2.38.3
-      # -- Image pull policy
-      pullPolicy: IfNotPresent
-    # Liveness probe configuration
-    livenessProbe:
-      # -- Enable liveness probe
-      enabled: false
+  # Target the default 'worker'
+  # worker:
+  #   nodeSelector:
+  #     workload-type: temporal
 
-    # Readiness probe configuration
-    readinessProbe:
-      # -- Enable readiness probe
-      enabled: false
-    
-    # Web UI service configuration
-    service:
-      # -- Service type
-      type: ClusterIP
-      # -- Web UI HTTP port
-      port: 8080
-
-  # Temporal admin tools configuration
-  admintools:
-    # Liveness probe configuration
-    livenessProbe:
-      # -- Enable liveness probe
-      enabled: false
-
-    # Readiness probe configuration
-    readinessProbe:
-      # -- Enable readiness probe
-      enabled: false
-
-    # -- Enable admin tools
-    enabled: false
-    # Admin tools image configuration
-    image:
-      # -- Admin tools image repository
-      repository: temporalio/admin-tools
-      # -- Admin tools image tag
-      tag: 1.28.0-tctl-1.18.2-cli-1.3.0
-      # -- Image pull policy
-      pullPolicy: IfNotPresent
-
-  # Cassandra configuration (disabled - using PostgreSQL)
+  # Disable built-in databases (using external PostgreSQL)
   cassandra:
-    # -- Enable Cassandra
     enabled: false
-    image:
-      repo: cassandra
-      tag: 3.11.3
-      pullPolicy: IfNotPresent
-  
-  # MySQL configuration (disabled - using PostgreSQL)
   mysql:
-    # -- Enable MySQL
     enabled: false
-  
-  # Elasticsearch configuration (disabled)
   elasticsearch:
-    # -- Enable Elasticsearch
     enabled: false
-    imageTag: 7.17.3
-    
-  # Prometheus configuration (disabled)
+
+  # Disable additional monitoring for now
   prometheus:
-    # -- Enable Prometheus
     enabled: false
     nodeExporter:
-      # -- Enable node exporter
       enabled: false
-  
-  # Grafana configuration (disabled)
   grafana:
-    # -- Enable Grafana
     enabled: false
-
-# Prometheus monitoring configuration
-prometheus:
-  # -- Enable Prometheus
-  enabled: false
-  # Node exporter configuration
-  nodeExporter:
-    # -- Enable node exporter
-    enabled: false
-  # -- Image pull secrets
-  imagePullSecrets: []
-
-# Grafana dashboard configuration
-grafana:
-  # -- Enable Grafana
-  enabled: false
-  # -- Number of Grafana replicas
-  replicas: 1
-
-# Test framework configuration
-testFramework:
-  # -- Enable test framework
-  enabled: false
-
-# RBAC configuration
-rbac:
-  # -- Create RBAC resources
-  create: false
-  # -- Enable Pod Security Policies
-  pspEnabled: false
-  # -- Use namespaced RBAC
-  namespaced: true
-
-# Elasticsearch configuration (disabled)
-elasticsearch:
-  # -- Enable Elasticsearch
-  enabled: false
-
-# Cassandra configuration (disabled)
-cassandra:
-  # -- Enable Cassandra
-  enabled: false
-
-# Global ingress configuration
-ingress:
-  # -- Enable ingress
-  enabled: false
-
-# Service account configuration
-serviceAccount:
-  # -- Create service account
-  create: true
-  # -- Service account annotations
-  annotations: {}
-  # -- Service account name (generated if not specified)
-  name: ""
-
-# OpenTelemetry observability configuration
-otel:
-  # -- Enable OpenTelemetry
-  enabled: false
-  # OTLP exporter configuration
-  exporter:
-    otlp:
-      # -- gRPC endpoint for OTLP (no protocol prefix needed)
-      endpoint: "composio-otel-collector:4317"
-      # -- Trace endpoint (optional, defaults to endpoint)
-      tracesEndpoint: "http://composio-otel-collector:4318/v1/traces"
-      # -- Metrics endpoint for gRPC (optional, defaults to endpoint)
-      metricsEndpoint: "composio-otel-collector:4317"
-      # -- Use insecure connection
-      insecure: true
-      # -- Optional headers for authentication
-      headers: ""
-  # Trace collection configuration
-  traces:
-    # -- Enable trace collection
-    enabled: true
-    # -- Sampling strategy (always_on, always_off, traceidratio)
-    sampler: "always_on"
-    # -- Sampling ratio (0.0 to 1.0)
-    samplerArg: 1.0
-  # Metrics collection configuration
-  metrics:
-    # -- Enable metrics collection
-    enabled: true
-    # -- Metrics export interval in milliseconds
-    exportInterval: 60000
-  # Log collection configuration
-  logs:
-    # -- Enable log collection via OTEL
-    enabled: false
-  # -- Environment name for telemetry
-  environment: "development"
-  
-  # Service-specific OpenTelemetry configurations
-  apollo:
-    # -- Apollo service name
-    serviceName: "apollo"
-    # -- Apollo service version
-    serviceVersion: "1.0.0"
-    # -- HTTP endpoint for metrics
-    metricsEndpoint: "http://composio-otel-collector:4318/v1/metrics"
-  thermos:
-    # -- Thermos service name
-    serviceName: "thermos"
-    # -- Thermos service version
-    serviceVersion: "1.0.0"
-    # -- HTTP endpoint for metrics
-    metricsEndpoint: "http://composio-otel-collector:4318/v1/metrics"
-  mercury:
-    # -- Mercury service name
-    serviceName: "mercury-openapi"
-    # -- Mercury service version
-    serviceVersion: "1.0.0"
-    # -- HTTP endpoint for metrics
-    metricsEndpoint: "http://composio-otel-collector:4318/v1/metrics"
-  frontend:
-    # -- Frontend service name
-    serviceName: "frontend"
-    # -- Frontend service version
-    serviceVersion: "1.0.0"
-    # -- HTTP endpoint for metrics
-    metricsEndpoint: "http://composio-otel-collector:4318/v1/metrics"
-  
-  # OpenTelemetry Collector configuration
-  collector:
-    # -- Enable OTEL collector
-    enabled: true
-    # -- Number of collector replicas
-    replicaCount: 1
-    # Collector image configuration
-    image:
-      # -- Collector image repository
-      repository: otel/opentelemetry-collector-contrib
-      # -- Collector image tag
-      tag: "0.91.0"
-      # -- Image pull policy
-      pullPolicy: IfNotPresent
-    
-    # Collector service configuration
-    service:
-      # -- Service type
-      type: ClusterIP
-      # Service ports configuration
-      ports:
-        otlp:
-          # -- OTLP gRPC port
-          port: 4317
-          # -- OTLP gRPC target port
-          targetPort: 4317
-          # -- OTLP gRPC protocol
-          protocol: TCP
-        otlp-http:
-          # -- OTLP HTTP port
-          port: 4318
-          # -- OTLP HTTP target port
-          targetPort: 4318
-          # -- OTLP HTTP protocol
-          protocol: TCP
-        jaeger:
-          # -- Jaeger port
-          port: 14250
-          # -- Jaeger target port
-          targetPort: 14250
-          # -- Jaeger protocol
-          protocol: TCP
-        prometheus:
-          # -- Prometheus metrics port
-          port: 8889
-          # -- Prometheus metrics target port
-          targetPort: 8889
-          # -- Prometheus protocol
-          protocol: TCP
-    
-    # Resource requests and limits for collector
-    resources:
-      requests:
-        # -- Memory request for collector
-        memory: "512Mi"
-        # -- CPU request for collector
-        cpu: "500m"
-      limits:
-        # -- Memory limit for collector
-        memory: "1Gi"
-        # -- CPU limit for collector
-        cpu: "1000m"
-    
-    # Google Cloud configuration for OTEL collector
-    googleCloud:
-      # -- Enable Google Cloud integration
-      enabled: false
-      # -- GCP project ID
-      projectId: "self-host-kubernetes"
-      # Service account configuration
-      serviceAccount:
-        # -- Create service account
-        create: false
-        # -- Service account name
-        name: "otel-collector"
-        # -- Service account annotations (for Workload Identity)
-        annotations:
-          iam.gke.io/gcp-service-account: "otel-collector@self-host-kubernetes.iam.gserviceaccount.com"
-    
-    # Collector pipeline configuration
-    config:
-      # Exporters configuration
-      exporters:
-        # Console exporter for debugging
-        debug:
-          # -- Debug verbosity level
-          verbosity: basic
-        # Prometheus exporter for metrics
-        prometheus:
-          # -- Prometheus endpoint
-          endpoint: "0.0.0.0:8889"
-        # Google Cloud exporter for metrics and traces
-        googlecloud:
-          # -- GCP project ID
-          project: "self-host-kubernetes"
-          metric:
-            # -- Custom metrics prefix
-            prefix: "custom.googleapis.com/composio/"
-          trace: {}
-      
-      # Processors for data transformation
-      processors:
-        # Batch processor configuration
-        batch:
-          # -- Batch timeout
-          timeout: 1s
-          # -- Batch size
-          send_batch_size: 1024
-        # Memory limiter configuration
-        memory_limiter:
-          # -- Memory limit in MiB
-          limit_mib: 512
-          # -- Check interval
-          check_interval: 1s
-      
-      # Receivers to collect telemetry data
-      receivers:
-        # OTLP receiver configuration
-        otlp:
-          protocols:
-            grpc:
-              # -- OTLP gRPC endpoint
-              endpoint: "0.0.0.0:4317"
-            http:
-              # -- OTLP HTTP endpoint
-              endpoint: "0.0.0.0:4318"
-        # Jaeger receiver configuration
-        jaeger:
-          protocols:
-            grpc:
-              # -- Jaeger gRPC endpoint
-              endpoint: "0.0.0.0:14250"
-      
-      # Extensions for additional functionality
-      extensions:
-        health_check:
-          # -- Health check endpoint
-          endpoint: "0.0.0.0:13133"
-        pprof:
-          # -- Profiling endpoint
-          endpoint: "0.0.0.0:1777"
-        zpages:
-          # -- Zpages endpoint
-          endpoint: "0.0.0.0:55679"
-      
-      # Service pipelines configuration
-      service:
-        # -- Extensions to enable
-        extensions: [health_check, pprof, zpages]
-        # Pipeline configurations
-        pipelines:
-          traces:
-            # -- Trace receivers
-            receivers: [otlp, jaeger]
-            # -- Trace processors
-            processors: [memory_limiter, batch]
-            # -- Trace exporters
-            exporters: [debug]
-          metrics:
-            # -- Metrics receivers
-            receivers: [otlp]
-            # -- Metrics processors
-            processors: [memory_limiter, batch]
-            # -- Metrics exporters
-            exporters: [debug, prometheus]
-
-# AWS configuration
-aws:
-  # -- AWS region
-  region: us-east-1
-  # S3 configuration
-  s3:
-    # -- S3 bucket name for Lambda functions
-    lambdaBucketName: "tools"
-  # Lambda configuration
-  lambda:
-    # -- Lambda function name
-    functionName: "mercury"
-  bedrock:
-    # -- AWS Bedrock region
-    region: us-east-1
-    # -- AWS Bedrock OpenAI-compatible runtime endpoint
-    endpoint: "https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1"
-    # -- AWS Bedrock secret name
-    secretName: ""
-    
-# Mercury service configuration (OpenAPI tool execution service)
-mercury:
-  # -- Enable Mercury service
-  enabled: true
-  # -- Use Knative for serverless deployment
-  useKnative: false
-  # -- Number of Mercury pod replicas (when not using Knative)
-  replicaCount: 1
-  # Mercury container image configuration
-  image:
-    # -- Mercury image repository
-    repository: composio-self-host/mercury
-    # -- Mercury image tag
-    tag: "r20260217_00"
-    # -- Image pull policy
-    pullPolicy: Always
-
-  # Liveness probe configuration
-  livenessProbe:
-    # -- Enable liveness probe
-    enabled: false
-
-  # Readiness probe configuration
-  readinessProbe:
-    # -- Enable readiness probe
-    enabled: false
-
-  # Mercury service configuration
-  service:
-    # -- Service type
-    type: ClusterIP
-    # -- Service port
-    port: 8080
-  
-  # Knative autoscaling configuration
-  autoscaling:
-    # -- Minimum number of replicas
-    minScale: 1
-    # -- Maximum number of replicas
-    maxScale: 10
-    # -- Target metric value for autoscaling
-    target: 80
-  
-  # -- Container concurrency (0 = unlimited)
-  containerConcurrency: 0
-  # -- Request timeout in seconds
-  timeoutSeconds: 300
-  
-  # Resource requests and limits for Mercury pods
-  resources:
-    requests:
-      # -- Memory request for Mercury
-      memory: "2Gi"
-      # -- CPU request for Mercury
-      cpu: "1"
-    limits:
-      # -- Memory limit for Mercury
-      memory: "4Gi"
-      # -- CPU limit for Mercury
-      cpu: "2"
-      
-  # Knative-specific configuration
-  knative:
-    # -- Minimum number of replicas for Knative
-    minReplicas: 1
-    # -- Initial number of replicas
-    replicas: 2
-    # -- Maximum number of replicas for Knative
-    maxReplicas: 5
-
-  # Security context for Mercury container
-  securityContext:
-    # -- Allow privilege escalation
-    allowPrivilegeEscalation: false
-    # -- Run as non-root user
-    runAsNonRoot: true
-    # -- User ID to run as
-    runAsUser: 1000
-    # Capabilities configuration
-    capabilities:
-      # -- Drop all capabilities
-      drop:
-      - ALL
-    # Seccomp profile
-    seccompProfile:
-      # -- Seccomp profile type
-      type: RuntimeDefault
-  
-  # Ingress configuration for Mercury
-  ingress:
-    # -- Enable ingress
-    enabled: false
-    # -- Ingress class name
-    className: ""
-    # -- Ingress annotations
-    annotations: {}
-    # -- Hostname for Mercury ingress
-    host: ""
-    # -- TLS configuration
-    tls: []
-  
-  # -- Additional volume mounts
-  volumeMounts: []
-  # -- Additional volumes
-  volumes: []
-  
-  # AWS Lambda configuration (alternative to Kubernetes deployment)
-  awsLambda:
-    # -- Enable AWS Lambda deployment
-    enabled: false
-    # Secret reference for Lambda credentials
-    secretRef: 
-      # -- Secret name for Lambda credentials
-      name: "lambda-cred"
-
-# Frontend service configuration (web UI)
-frontend:
-  # -- Enable frontend service
-  enabled: false
-  # -- Number of frontend pod replicas
-  replicaCount: 1
-  # Frontend container image configuration
-  image:
-    # -- Frontend image repository
-    repository: composio-self-host/frontend
-    # -- Frontend image tag
-    tag: "r20260217_00"
-    # -- Image pull policy
-    pullPolicy: Always
-  # Frontend service configuration
-  service:
-    # -- Service type
-    type: ClusterIP
-    # -- Service port
-    port: 3000
-  # Resource requests and limits for frontend pods
-  resources:
-    requests:
-      # -- Memory request for frontend
-      memory: "2Gi"
-      # -- CPU request for frontend
-      cpu: "1"
-    limits:
-      # -- Memory limit for frontend
-      memory: "3Gi"
-      # -- CPU limit for frontend
-      cpu: "1"
-  # Frontend environment variables
-  env:
-    # -- Server port
-    PORT: "3000"
-    # -- Node environment
-    NODE_ENV: "production"
-    # -- Override backend URL (defaults to Apollo service URL)
-    OVERRIDE_BACKEND_URL: ""
-    # -- Disable social login for self-hosted deployments
-    NEXT_PUBLIC_DISABLE_SOCIAL_LOGIN: "true"
-    # -- Enable self-hosted mode
-    NEXT_PUBLIC_SELF_HOSTED: "true"
-  
-  # Ingress configuration for frontend
-  ingress:
-    # -- Enable ingress
-    enabled: false
-    # -- Ingress class name
-    className: ""
-    # -- Ingress annotations
-    annotations: {}
-    # -- Hostname for frontend ingress
-    host: ""
-    # -- TLS configuration
-    tls: []
-
-# Weaviate service configuration (vector database for search)
-weaviate:
-  # -- Enable Weaviate service
-  enabled: true
-  # -- Number of Weaviate pod replicas
-  replicaCount: 1
-  # Weaviate container image configuration
-  image:
-    # -- Weaviate image repository
-    repository: composio-self-host/weaviate
-    # -- Weaviate image tag
-    tag: "r20260217_00"
-    # -- Image pull policy
-    pullPolicy: Always
-  # Weaviate service configuration
-  service:
-    # -- Service type
-    type: ClusterIP
-    # -- HTTP service port
-    port: 8080
-    # -- gRPC service port
-    grpcPort: 50051
-  # Weaviate authentication configuration
-  auth:
-    # -- Enable anonymous access (set to "false" for production)
-    anonymousAccess: "true"
-  # -- Default vectorizer module
-  vectorizer: "none"
-  # -- Enabled Weaviate modules
-  modules: "text2vec-openai,text2vec-cohere,text2vec-huggingface,ref2vec-centroid,generative-openai,qna-openai"
-  # Persistence configuration for Weaviate data
-  persistence:
-    # -- Enable persistent storage
-    enabled: false
-    # -- Size of persistent volume
-    size: "10Gi"
-    # -- Storage class name (empty for default)
-    storageClass: ""
-  # Liveness probe configuration
-  livenessProbe:
-    # -- Initial delay before first probe (seconds)
-    initialDelaySeconds: 60
-    # -- Probe interval (seconds)
-    periodSeconds: 30
-    # -- Probe timeout (seconds)
-    timeoutSeconds: 10
-    # -- Failure threshold
-    failureThreshold: 3
-  # Readiness probe configuration
-  readinessProbe:
-    # -- Initial delay before first probe (seconds)
-    initialDelaySeconds: 30
-    # -- Probe interval (seconds)
-    periodSeconds: 10
-    # -- Probe timeout (seconds)
-    timeoutSeconds: 5
-    # -- Failure threshold
-    failureThreshold: 3
-  # Resource requests and limits for Weaviate pods
-  resources:
-    requests:
-      # -- Memory request for Weaviate
-      memory: "2Gi"
-      # -- CPU request for Weaviate
-      cpu: "1"
-    limits:
-      # -- Memory limit for Weaviate
-      memory: "4Gi"
-      # -- CPU limit for Weaviate
-      cpu: "2"
-  # -- Node selector for pod placement
-  # nodeSelector: {}
-  # -- Tolerations for pod scheduling
-  # tolerations: []
-  # -- Affinity rules for pod placement
-  # affinity: {}
-  # -- Security context for Weaviate container
-  # securityContext: {}
-  # -- Additional environment variables
-  # env: []


### PR DESCRIPTION
## Summary

Glean's deployment customizations for the Composio helm chart, based on the `release-stable` branch.

### Chart structure changes
- Use local redis subchart (`file://./charts/redis`) instead of remote bitnami repo reference
- Pin temporal subchart to v0.64.0
- Remove replicated dependency and all replicated-related templates
- Remove cassandra, elasticsearch subcharts from temporal (unused)
- Remove frontend, database migration, and preflight-checks templates

### New templates added
- **MCP service** (`templates/mcp/`) - MCP configmap and deployment
- **Composio secrets** (`templates/composio-secrets.yaml`) - Centralized secret management
- **PostgreSQL external secret** (`templates/postgres-secret.yaml`) - External DB connection
- **Apollo stack secrets** (`templates/apollo/stack-secrets.yaml`)

### Configuration changes
- Simplified `values.yaml` for Glean deployment
- External PostgreSQL via Kubernetes secret reference instead of embedded database config
- Per-secret lookups in `_helpers.tpl` instead of consolidated core secret pattern
- Namespace defaults to `"composio"` from values instead of `Release.Namespace`
- Removed SMTP URL parsing helpers and replicated registry helpers
- GKE Autopilot compatibility adjustments across templates

## Test plan
- [ ] Verify helm template rendering: `helm template composio ./composio/`
- [ ] Validate chart against target GKE cluster
- [ ] Deploy to staging environment and verify all services start correctly