### PR TITLE
feat(ci): add Slack release notifications with live status updates

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -1,0 +1,109 @@
+name: 'Slack Release Notification'
+description: 'Post or update a Slack message to track release status (yellow → green/red)'
+
+inputs:
+  status:
+    description: 'STARTED, SUCCESS, or FAILURE'
+    required: true
+  slack_bot_token:
+    description: 'Slack Bot Token (requires chat:write scope)'
+    required: true
+  channel:
+    description: 'Slack channel ID'
+    required: true
+    default: 'C093CVARNKC'
+  message_id:
+    description: 'Message timestamp to update (omit to post a new message)'
+    required: false
+    default: ''
+  title:
+    description: 'Header text for the notification'
+    required: true
+  summary:
+    description: 'Body text with release details (supports Slack mrkdwn)'
+    required: true
+
+outputs:
+  message_id:
+    description: 'Slack message timestamp – pass this back to update the message later'
+    value: ${{ steps.slack.outputs.message_id }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: slack
+      shell: bash
+      env:
+        INPUT_STATUS: ${{ inputs.status }}
+        INPUT_CHANNEL: ${{ inputs.channel }}
+        INPUT_MESSAGE_ID: ${{ inputs.message_id }}
+        INPUT_TITLE: ${{ inputs.title }}
+        INPUT_SUMMARY: ${{ inputs.summary }}
+        SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        ACTOR: ${{ github.actor }}
+      run: |
+        set -euo pipefail
+
+        # --- Status → colour + emoji ----------------------------------------
+        case "$INPUT_STATUS" in
+          STARTED) COLOR="#dbab09"; EMOJI="⏳"; STATUS_TEXT="In Progress" ;;
+          SUCCESS) COLOR="#28a745"; EMOJI="✅"; STATUS_TEXT="Succeeded"   ;;
+          FAILURE) COLOR="#cb2431"; EMOJI="❌"; STATUS_TEXT="Failed"      ;;
+          *)       COLOR="#808080"; EMOJI="❓"; STATUS_TEXT="$INPUT_STATUS" ;;
+        esac
+
+        # --- Build the JSON payload with jq ----------------------------------
+        PAYLOAD=$(jq -n \
+          --arg channel  "$INPUT_CHANNEL" \
+          --arg color    "$COLOR" \
+          --arg title    "$EMOJI $INPUT_TITLE" \
+          --arg summary  "$INPUT_SUMMARY" \
+          --arg status   "$STATUS_TEXT" \
+          --arg run_url  "$RUN_URL" \
+          --arg actor    "$ACTOR" \
+          '{
+            channel: $channel,
+            attachments: [{
+              color: $color,
+              blocks: [
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: ("*" + $title + "*") }
+                },
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: $summary }
+                },
+                {
+                  type: "context",
+                  elements: [{
+                    type: "mrkdwn",
+                    text: ("*Status:* " + $status + "  |  *Actor:* " + $actor + "  |  <" + $run_url + "|View Run>")
+                  }]
+                }
+              ]
+            }]
+          }')
+
+        # --- Post new message or update an existing one -----------------------
+        if [ -z "$INPUT_MESSAGE_ID" ]; then
+          API_URL="https://slack.com/api/chat.postMessage"
+        else
+          API_URL="https://slack.com/api/chat.update"
+          PAYLOAD=$(echo "$PAYLOAD" | jq --arg ts "$INPUT_MESSAGE_ID" '. + {ts: $ts}')
+        fi
+
+        RESPONSE=$(curl -sfS -X POST "$API_URL" \
+          -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+          -H "Content-Type: application/json" \
+          -d "$PAYLOAD")
+
+        OK=$(echo "$RESPONSE" | jq -r '.ok')
+        if [ "$OK" != "true" ]; then
+          ERR=$(echo "$RESPONSE" | jq -r '.error // "unknown"')
+          echo "::warning::Slack API error: $ERR"
+        fi
+
+        TS=$(echo "$RESPONSE" | jq -r '.ts // empty')
+        echo "message_id=$TS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Install Replicated CLI
         run: |
           version=$(curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
@@ -31,7 +31,7 @@ jobs:
           tar xf replicated.tar.gz replicated && rm replicated.tar.gz
           sudo mv replicated /usr/local/bin/replicated
           replicated version
-      
+
       - name: Get latest sequence from Unstable
         id: get_sequence
         run: |
@@ -44,15 +44,54 @@ jobs:
           echo "channel_id=$CHANNEL_ID" >> $GITHUB_OUTPUT
           echo "sequence=$LATEST_SEQUENCE" >> $GITHUB_OUTPUT
           echo "version=$NEW_APPVERSION" >> $GITHUB_OUTPUT
+          echo "current_version=$CURRENT_VERSION_CHANNEL" >> $GITHUB_OUTPUT
           echo "Promoting sequence $LATEST_SEQUENCE (version $CURRENT_VERSION) from Unstable to ${{ inputs.channel }}"
         env:
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
           REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
-      
+
+      - name: Notify Slack - Started
+        id: slack
+        uses: ./.github/actions/slack-notify
+        with:
+          status: STARTED
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: C093CVARNKC
+          title: "Promote to ${{ inputs.channel }}"
+          summary: |
+            *Version:* `${{ steps.get_sequence.outputs.current_version }}` → `${{ steps.get_sequence.outputs.version }}`
+            *Source:* Unstable → ${{ inputs.channel }}
+
       - name: Promote from Unstable channel
         env:
           REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
         run: |
-          set -e 
+          set -e
           replicated release promote ${{ steps.get_sequence.outputs.sequence }} ${{ steps.get_sequence.outputs.channel_id }} --version ${{ steps.get_sequence.outputs.version }}
+
+      - name: Notify Slack - Success
+        if: success()
+        uses: ./.github/actions/slack-notify
+        with:
+          status: SUCCESS
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: C093CVARNKC
+          message_id: ${{ steps.slack.outputs.message_id }}
+          title: "Promote to ${{ inputs.channel }}"
+          summary: |
+            *Version:* `${{ steps.get_sequence.outputs.current_version }}` → `${{ steps.get_sequence.outputs.version }}`
+            *Source:* Unstable → ${{ inputs.channel }}
+
+      - name: Notify Slack - Failure
+        if: failure() && steps.slack.outputs.message_id
+        uses: ./.github/actions/slack-notify
+        with:
+          status: FAILURE
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: C093CVARNKC
+          message_id: ${{ steps.slack.outputs.message_id }}
+          title: "Promote to ${{ inputs.channel }}"
+          summary: |
+            *Version:* `${{ steps.get_sequence.outputs.current_version }}` → `${{ steps.get_sequence.outputs.version }}`
+            *Source:* Unstable → ${{ inputs.channel }}

--- a/.github/workflows/replicated-pre-release.yaml
+++ b/.github/workflows/replicated-pre-release.yaml
@@ -11,40 +11,40 @@ jobs:
   release-helm-chart:
     runs-on: ubuntu-latest
     if: |
-      github.event.action == 'prereleased' 
+      github.event.action == 'prereleased'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name }}
-      
+
       - name: Extract version and set promotion channel
         id: metadata
         run: |
           TAG_NAME=${{ github.event.release.tag_name }}
-          
+
           echo "::group::Debug Info"
           echo "Tag: $TAG_NAME"
           echo "Release Name: ${{ github.event.release.name }}"
           echo "Is Prerelease: ${{ github.event.release.prerelease }}"
           echo "::endgroup::"
-          
+
           # Determine promotion channel based on tag pattern
           if [[ "$TAG_NAME" == release-beta-* ]]; then
             PROMOTE="Beta"
           else
             PROMOTE="Unstable"
           fi
-          
+
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "promote=$PROMOTE" >> $GITHUB_OUTPUT
           echo "✅ Tag: $TAG_NAME"
           echo "✅ Promote: $PROMOTE"
-      
+
       - name: Install yq
         uses: mikefarah/yq@v4
-      
+
       - name: Install Replicated CLI
         run: |
           version=$(curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
@@ -54,23 +54,23 @@ jobs:
             -o replicated.tar.gz
           tar xf replicated.tar.gz replicated && rm replicated.tar.gz
           sudo mv replicated /usr/local/bin/replicated
-      
+
       - name: Check replicated
         run: |
           set -e
-          replicated app ls &> /dev/null || exit 1 
+          replicated app ls &> /dev/null || exit 1
         env:
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
-      
+
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
           version: 'latest'
-      
-      - name: Run Helm template  
-        run: | 
+
+      - name: Run Helm template
+        run: |
           helm template composio ./composio
-      
+
       - name: Get and bump version
         id: version
         env:
@@ -84,6 +84,19 @@ jobs:
           echo "new=$NEW_APPVERSION" >> $GITHUB_OUTPUT
           echo "Current version: $CURRENT_APPVERSION"
           echo "New version: $NEW_APPVERSION"
+
+      - name: Notify Slack - Started
+        id: slack
+        uses: ./.github/actions/slack-notify
+        with:
+          status: STARTED
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: C093CVARNKC
+          title: "New ${{ steps.metadata.outputs.promote }} Release"
+          summary: |
+            *Version:* `${{ steps.version.outputs.current }}` → `${{ steps.version.outputs.new }}`
+            *Tag:* `${{ steps.metadata.outputs.tag }}`
+            *Channel:* ${{ steps.metadata.outputs.promote }}
 
       - name: Update Chart.yaml versions
         run: |
@@ -119,12 +132,41 @@ jobs:
         env:
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
           REPLICATED_APP: composio-rodent
+
+      - name: Notify Slack - Success
+        if: success()
+        uses: ./.github/actions/slack-notify
+        with:
+          status: SUCCESS
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: C093CVARNKC
+          message_id: ${{ steps.slack.outputs.message_id }}
+          title: "New ${{ steps.metadata.outputs.promote }} Release"
+          summary: |
+            *Version:* `${{ steps.version.outputs.current }}` → `${{ steps.version.outputs.new }}`
+            *Tag:* `${{ steps.metadata.outputs.tag }}`
+            *Channel:* ${{ steps.metadata.outputs.promote }}
+
+      - name: Notify Slack - Failure
+        if: failure() && steps.slack.outputs.message_id
+        uses: ./.github/actions/slack-notify
+        with:
+          status: FAILURE
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: C093CVARNKC
+          message_id: ${{ steps.slack.outputs.message_id }}
+          title: "New ${{ steps.metadata.outputs.promote }} Release"
+          summary: |
+            *Version:* `${{ steps.version.outputs.current }}` → `${{ steps.version.outputs.new }}`
+            *Tag:* `${{ steps.metadata.outputs.tag }}`
+            *Channel:* ${{ steps.metadata.outputs.promote }}
+
   deploy-to-gke:
     needs: [release-helm-chart]
     if: |
       github.event.action == 'prereleased'
     env:
-      REPLICATED_APP: ${{ secrets.REPLICATED_APP }} 
+      REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
     runs-on: depot-ubuntu-24.04-4
     permissions:
       contents: write
@@ -148,21 +190,21 @@ jobs:
       - name: Install GKE Auth Plugin
         run: |
           echo "🔧 Installing gke-gcloud-auth-plugin..."
-          gcloud components install gke-gcloud-auth-plugin --quiet &> /dev/null || exit 1 
+          gcloud components install gke-gcloud-auth-plugin --quiet &> /dev/null || exit 1
           echo "✅ GKE auth plugin installed successfully"
 
       - name: Configure kubectl for GKE
-        env: 
+        env:
           GKE_CLUSTER_NAME: ${{ secrets.GKE_CLUSTER_NAME }}
           GKE_CLUSTER_ZONE: ${{ secrets.GKE_CLUSTER_ZONE }}
         run: |
-          gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --zone "$GKE_CLUSTER_ZONE" &> /dev/null || exit 1  
+          gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --zone "$GKE_CLUSTER_ZONE" &> /dev/null || exit 1
           echo "✅ Kubectl configured successfully"
 
       - name: Verify GKE Connection
         run: |
           echo "🔍 Verifying GKE cluster connection..."
-          kubectl get namespaces &> /dev/null || exit 1 
+          kubectl get namespaces &> /dev/null || exit 1
           echo "✅ GKE connection verified"
 
       - name: Generate Values Override
@@ -186,16 +228,16 @@ jobs:
 
       - name:  Check replicated
         env:
-          REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }} 
+          REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
         run: |
           set -e
           replicated app ls &> /dev/null || exit 1
-      
+
       - name: Get latest replicated version
         id: get_version
         env:
           REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
-          REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }} 
+          REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
         run: |
           STABLE_VERSION=$(replicated channel ls | grep "Stable" | awk '{print $NF}')
           UNSTABLE_VERSION=$(replicated channel ls | grep "Unstable" | awk '{print $NF}')
@@ -204,16 +246,16 @@ jobs:
           echo "stable=$STABLE_VERSION" >> $GITHUB_OUTPUT
           echo "unstable=$UNSTABLE_VERSION" >> $GITHUB_OUTPUT
 
-      
-      - name: Deploy on kubernetes using replicated 
+
+      - name: Deploy on kubernetes using replicated
         env:
           AUTH_TOKEN: ${{ secrets.REPLICATED_HELM_AUTH_TOKEN }}
-          REPLICATED_USERNAME: ${{ secrets.REPLICATED_USERNAME }} 
+          REPLICATED_USERNAME: ${{ secrets.REPLICATED_USERNAME }}
           HELM_URL: ${{ secrets.HELM_REGISTRY }}
           REPLICATED_REGISTRY: ${{ secrets.REPLICATED_REGISTRY }}
         run: |
 
-          helm registry login $REPLICATED_REGISTRY --username $REPLICATED_USERNAME --password $AUTH_TOKEN 
+          helm registry login $REPLICATED_REGISTRY --username $REPLICATED_USERNAME --password $AUTH_TOKEN
           helm upgrade composio $HELM_URL  \
             --install \
             --create-namespace \
@@ -221,7 +263,7 @@ jobs:
             --values ./values-override.yaml \
             --wait \
             --timeout 20m \
-            --version ${{ steps.get_version.outputs.unstable }} 
+            --version ${{ steps.get_version.outputs.unstable }}
 
       - name: Deployment Summary
         if: success()
@@ -242,26 +284,26 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name }}
-      
+
       - name: Extract version
         id: metadata
         run: |
           TAG_NAME=${{ github.event.release.tag_name }}
-          
+
           echo "::group::Release Info"
           echo "Tag: $TAG_NAME"
           echo "Release Name: ${{ github.event.release.name }}"
           echo "Converting pre-release to stable release"
           echo "::endgroup::"
-          
+
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "promote=Stable" >> $GITHUB_OUTPUT
           echo "✅ Tag: $TAG_NAME"
           echo "✅ Promote: Stable"
-      
+
       - name: Install yq
         uses: mikefarah/yq@v4
-      
+
       - name: Install Replicated CLI
         run: |
           version=$(curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
@@ -271,14 +313,14 @@ jobs:
             -o replicated.tar.gz
           tar xf replicated.tar.gz replicated && rm replicated.tar.gz
           sudo mv replicated /usr/local/bin/replicated
-      
+
       - name: Check replicated
         run: |
           set -e
-          replicated app ls &> /dev/null || exit 1 
+          replicated app ls &> /dev/null || exit 1
         env:
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
-      
+
       - name: Get latest sequence from Unstable
         id: get_sequence
         run: |
@@ -296,17 +338,58 @@ jobs:
         env:
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
           REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
-      
+
+      - name: Notify Slack - Started
+        id: slack
+        uses: ./.github/actions/slack-notify
+        with:
+          status: STARTED
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: C093CVARNKC
+          title: "Promote to Stable"
+          summary: |
+            *Version:* `${{ steps.get_sequence.outputs.stable_version }}` → `${{ steps.get_sequence.outputs.version }}`
+            *Source:* Unstable → Stable
+            *Tag:* `${{ steps.metadata.outputs.tag }}`
+
       - name: Promote from Stable to Unstable
         env:
           REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
           REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
         run: |
-          set -e 
-          replicated release promote ${{ steps.get_sequence.outputs.sequence }} ${{ steps.get_sequence.outputs.channel_id }} --version ${{ steps.get_sequence.outputs.version }} 
+          set -e
+          replicated release promote ${{ steps.get_sequence.outputs.sequence }} ${{ steps.get_sequence.outputs.channel_id }} --version ${{ steps.get_sequence.outputs.version }}
 
       - name: Summary
         run: |
           echo "### Helm Chart Release Created for Stable Channel 🚀" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Version:** ${{ steps.get_sequence.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Notify Slack - Success
+        if: success()
+        uses: ./.github/actions/slack-notify
+        with:
+          status: SUCCESS
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: C093CVARNKC
+          message_id: ${{ steps.slack.outputs.message_id }}
+          title: "Promote to Stable"
+          summary: |
+            *Version:* `${{ steps.get_sequence.outputs.stable_version }}` → `${{ steps.get_sequence.outputs.version }}`
+            *Source:* Unstable → Stable
+            *Tag:* `${{ steps.metadata.outputs.tag }}`
+
+      - name: Notify Slack - Failure
+        if: failure() && steps.slack.outputs.message_id
+        uses: ./.github/actions/slack-notify
+        with:
+          status: FAILURE
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel: C093CVARNKC
+          message_id: ${{ steps.slack.outputs.message_id }}
+          title: "Promote to Stable"
+          summary: |
+            *Version:* `${{ steps.get_sequence.outputs.stable_version }}` → `${{ steps.get_sequence.outputs.version }}`
+            *Source:* Unstable → Stable
+            *Tag:* `${{ steps.metadata.outputs.tag }}`


### PR DESCRIPTION
Add a reusable composite action (.github/actions/slack-notify) that posts a Slack message at job start (yellow) and updates it in-place to green on success or red on failure using chat.postMessage/chat.update APIs.

Applied to release-helm-chart, release-stable, and promote-release jobs targeting #buzz-self-hosted.