### PR TITLE
test(secrets): add secret stripping safety tests for post helm-pull flow

### DIFF
--- a/composio/tests/secret_stripping_test.yaml
+++ b/composio/tests/secret_stripping_test.yaml
@@ -1,0 +1,100 @@
+suite: secret stripping safety tests
+description: |
+  Validates that after running yq commands to strip secrets from values.yaml,
+  no secret resources are rendered. Also validates that secrets injected via
+  --set at deploy time render correctly.
+
+  Post helm-pull strip commands:
+    yq -i '.externalSecrets.ecr.token = "REDACTED--inject-via-ci-cd"' composio/values.yaml
+    yq -i 'del(.global.replicated.dockerconfigjson)' composio/values.yaml
+    yq -i '.externalSecrets.ecr.server = "REDACTED--inject-via-ci-cd" | .externalSecrets.ecr.username = "REDACTED--inject-via-ci-cd"' composio/values.yaml
+
+templates:
+  - ecr-secret.yaml
+  - replicated/replicated-pull-secret.yaml
+
+tests:
+  # ── ECR secret: stripped values should NOT render ──────────────────────
+
+  - it: should not create ecr-secret when token is empty (default values.yaml)
+    set:
+      externalSecrets.ecr.token: ""
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: ecr-secret.yaml
+
+  - it: should still render ecr-secret if REDACTED placeholder is left as token
+    description: |
+      WARNING: The ecr-secret template gates on a truthy token value.
+      A non-empty placeholder like "REDACTED--inject-via-ci-cd" is truthy,
+      so the secret WILL render (with garbage credentials). This test
+      documents that behavior — the recommended strip command should use
+      an empty string instead if you want zero secret rendering.
+    set:
+      externalSecrets.ecr.token: "REDACTED--inject-via-ci-cd"
+      externalSecrets.ecr.server: "REDACTED--inject-via-ci-cd"
+      externalSecrets.ecr.username: "REDACTED--inject-via-ci-cd"
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: ecr-secret.yaml
+
+  # ── Replicated pull secret: stripped values should NOT render ───────────
+
+  - it: should not create replicated-pull-secret when dockerconfigjson is absent
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: replicated/replicated-pull-secret.yaml
+
+  - it: should not create replicated-pull-secret when global.replicated is empty
+    set:
+      global.replicated: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: replicated/replicated-pull-secret.yaml
+
+  # ── ECR secret: injected via --set at deploy time should render ────────
+
+  - it: should create ecr-secret when token is injected via CI/CD
+    set:
+      externalSecrets.ecr.token: "real-ecr-token-from-ci"
+      externalSecrets.ecr.server: "008971668139.dkr.ecr.us-east-1.amazonaws.com"
+      externalSecrets.ecr.username: "AWS"
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: ecr-secret.yaml
+      - isKind:
+          of: Secret
+        template: ecr-secret.yaml
+      - equal:
+          path: type
+          value: kubernetes.io/dockerconfigjson
+        template: ecr-secret.yaml
+      - isNotEmpty:
+          path: data[".dockerconfigjson"]
+        template: ecr-secret.yaml
+
+  # ── Replicated pull secret: injected via --set should render ───────────
+
+  - it: should create replicated-pull-secret when dockerconfigjson is injected via CI/CD
+    set:
+      global.replicated.dockerconfigjson: "eyJhdXRocyI6eyJyZWdpc3RyeS5leGFtcGxlLmNvbSI6e319fQ=="
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: replicated/replicated-pull-secret.yaml
+      - isKind:
+          of: Secret
+        template: replicated/replicated-pull-secret.yaml
+      - equal:
+          path: type
+          value: kubernetes.io/dockerconfigjson
+        template: replicated/replicated-pull-secret.yaml
+      - equal:
+          path: data[".dockerconfigjson"]
+          value: "eyJhdXRocyI6eyJyZWdpc3RyeS5leGFtcGxlLmNvbSI6e319fQ=="
+        template: replicated/replicated-pull-secret.yaml


### PR DESCRIPTION
Add helm-unittest tests that validate the behavior of ECR and Replicated pull secrets after running yq strip commands on values.yaml.

Covers:
- ECR secret is not rendered when token is empty
- ECR secret still renders with REDACTED placeholder (documents truthy gotcha)
- Replicated pull secret is not rendered when dockerconfigjson key is absent
- Replicated pull secret is not rendered when global.replicated is empty
- ECR secret renders correctly when token is injected via --set in CI/CD
- Replicated pull secret renders correctly when dockerconfigjson is injected

Note: The ecr-secret template gates on a truthy token value, so a non-empty placeholder like "REDACTED--inject-via-ci-cd" will still produce a secret with garbage credentials. Prefer stripping to an empty string if zero secret rendering is desired post-strip.

See: https://docs.replicated.com/vendor/helm-image-registry#create-pull-secret