### PR TITLE
fix: harden Temporal infra to prevent cascading failures

### DIFF
--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -47,12 +47,21 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      # Allow 60s for Temporal workers to drain in-flight tasks during shutdown.
+      # Must be greater than thermos WorkerStopTimeout (30s) to avoid SIGKILL mid-drain.
+      terminationGracePeriodSeconds: 60
       containers:
         - name: thermos
           image: "{{ include "chart.registry" . }}/{{ .Values.thermos.image.repository }}:{{ .Values.thermos.image.tag }}"
           imagePullPolicy: {{ .Values.thermos.image.pullPolicy }}
           command: ["/usr/local/bin/thermos", "--cache-dir", "/tmp/.lookup"]
           workingDir: "/tmp"
+          lifecycle:
+            preStop:
+              exec:
+                # Brief delay before SIGTERM so the load balancer deregisters
+                # this pod and stops routing new requests to it.
+                command: ["sleep", "5"]
           {{- with .Values.thermos.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -459,16 +459,18 @@ temporal:
             # -- Secret name containing database password
             existingSecret: "composio-composio-secrets"
             # -- Maximum number of database connections
-            maxConns: 20
+            # Increased from 20 to prevent connection pool exhaustion under load,
+            # which causes cascading "context deadline exceeded" failures across all workflows.
+            maxConns: 100
             # -- Maximum number of idle connections
-            maxIdleConns: 20
-            # -- Maximum connection lifetime
-            maxConnLifetime: "1h"
-        
+            maxIdleConns: 100
+            # -- Maximum connection lifetime (0 = indefinite, reduces connection churn)
+            maxConnLifetime: "0"
+
         # Visibility database configuration (for advanced queries)
         visibility:
           # -- Database driver
-          driver: "sql" 
+          driver: "sql"
           # SQL database configuration
           sql:
             # -- SQL driver name
@@ -484,11 +486,11 @@ temporal:
             # -- Secret name containing database password
             existingSecret: "composio-composio-secrets"
             # -- Maximum number of database connections
-            maxConns: 20
+            maxConns: 100
             # -- Maximum number of idle connections
-            maxIdleConns: 20
-            # -- Maximum connection lifetime
-            maxConnLifetime: "1h"
+            maxIdleConns: 100
+            # -- Maximum connection lifetime (0 = indefinite, reduces connection churn)
+            maxConnLifetime: "0"
       
       # Temporal namespace configuration
       namespaces:


### PR DESCRIPTION
# Description

Hardens Temporal infrastructure configuration to prevent cascading failures observed in Glean's auth refresh issues. Changes address DB connection pool exhaustion and ungraceful pod shutdowns.

**Temporal DB connection pool (values.yaml):**
- `maxConns`: 20 → 100 (default + visibility stores)
- `maxIdleConns`: 20 → 100
- `maxConnLifetime`: "1h" → "0" (indefinite, reduces connection churn)

The default pool of 20 connections was being exhausted under load, causing "context deadline exceeded" errors that cascaded across all Temporal workflows.

**Thermos pod lifecycle (thermos.yaml):**
- Added `terminationGracePeriodSeconds: 60` — gives Temporal workers time to drain in-flight tasks via `WorkerStopTimeout` (30s, set in companion PR ComposioHQ/hermes#8292) before SIGKILL
- Added `preStop` lifecycle hook (`sleep 5`) — allows load balancer to deregister the pod before SIGTERM reaches the container, preventing new requests from being routed to a dying pod

Companion PR: https://github.com/ComposioHQ/hermes/pull/8292

# How did I test this PR
- Verified `values.yaml` changes match Temporal's documented connection pool parameters
- Confirmed `terminationGracePeriodSeconds` (60s) > `WorkerStopTimeout` (30s) to avoid SIGKILL mid-drain
- Validated YAML template indentation and Helm template syntax