### PR TITLE
chore: bump image tags to r20260310_00

### DIFF
--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -131,7 +131,7 @@ apollo:
     # -- Apollo image repository
     repository: composio-self-host/apollo
     # -- Apollo image tag
-    tag: "r20260302_00"
+    tag: "r20260310_00"
     # -- Image pull policy
     pullPolicy: Always
 
@@ -167,7 +167,7 @@ apollo:
       # -- Database init image repository
       repository: composio-self-host/apollo-db-init
       # -- Database init image tag
-      tag: "r20260302_00"
+      tag: "r20260310_00"
       # -- Image pull policy
       pullPolicy: Always
   
@@ -338,7 +338,7 @@ thermos:
     # -- Thermos image repository
     repository: composio-self-host/thermos
     # -- Thermos image tag
-    tag: "r20260302_00"
+    tag: "r20260310_00"
     # -- Image pull policy
     pullPolicy: Always
 
@@ -351,7 +351,7 @@ thermos:
       # -- Database init image repository
       repository: composio-self-host/thermos-db-init
       # -- Database init image tag
-      tag: "r20260302_00"
+      tag: "r20260310_00"
       # -- Image pull policy
       pullPolicy: Always
   
@@ -972,7 +972,7 @@ mercury:
     # -- Mercury image repository
     repository: composio-self-host/mercury
     # -- Mercury image tag
-    tag: "r20260302_00"
+    tag: "r20260310_00"
     # -- Image pull policy
     pullPolicy: Always
 
@@ -1085,7 +1085,7 @@ frontend:
     # -- Frontend image repository
     repository: composio-self-host/frontend
     # -- Frontend image tag
-    tag: "r20260302_00"
+    tag: "r20260310_00"
     # -- Image pull policy
     pullPolicy: Always
   # Frontend service configuration


### PR DESCRIPTION
## Summary
- Bumps all image tags in `composio/values.yaml` from `r20260302_00` to `r20260310_00`
- Affects Apollo, Thermos, and related service images (6 occurrences)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Triggered by: utkarsh@composio.dev | Source: web
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-dff163f4a734