### PR TITLE
chore: bump weaviate image tag to r20260310_00

### DIFF
--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -1143,7 +1143,7 @@ weaviate:
     # -- Weaviate image repository
     repository: composio-self-host/weaviate
     # -- Weaviate image tag
-    tag: "r20260226_01"
+    tag: "r20260310_00"
     # -- Image pull policy
     pullPolicy: Always
   # Weaviate service configuration


### PR DESCRIPTION
# Description
Bump the Weaviate image tag from `r20260226_01` to `r20260310_00` in `composio/values.yaml`.

# How did I test this PR
- Verified the YAML change is valid (single line tag update)
- Confirmed no other references to the old weaviate tag exist in the file

Triggered by: utkarsh@composio.dev | Source: web
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-9d5e50cb8d55