### PR TITLE
chore: bump composio image tags to r20260311_00

### DIFF
--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -131,7 +131,7 @@ apollo:
     # -- Apollo image repository
     repository: composio-self-host/apollo
     # -- Apollo image tag
-    tag: "r20260310_00"
+    tag: "r20260311_00"
     # -- Image pull policy
     pullPolicy: Always
 
@@ -167,7 +167,7 @@ apollo:
       # -- Database init image repository
       repository: composio-self-host/apollo-db-init
       # -- Database init image tag
-      tag: "r20260310_00"
+      tag: "r20260311_00"
       # -- Image pull policy
       pullPolicy: Always
   
@@ -338,7 +338,7 @@ thermos:
     # -- Thermos image repository
     repository: composio-self-host/thermos
     # -- Thermos image tag
-    tag: "r20260310_00"
+    tag: "r20260311_00"
     # -- Image pull policy
     pullPolicy: Always
 
@@ -351,7 +351,7 @@ thermos:
       # -- Database init image repository
       repository: composio-self-host/thermos-db-init
       # -- Database init image tag
-      tag: "r20260310_00"
+      tag: "r20260311_00"
       # -- Image pull policy
       pullPolicy: Always
   
@@ -972,7 +972,7 @@ mercury:
     # -- Mercury image repository
     repository: composio-self-host/mercury
     # -- Mercury image tag
-    tag: "r20260310_00"
+    tag: "r20260311_00"
     # -- Image pull policy
     pullPolicy: Always
 
@@ -1085,7 +1085,7 @@ frontend:
     # -- Frontend image repository
     repository: composio-self-host/frontend
     # -- Frontend image tag
-    tag: "r20260310_00"
+    tag: "r20260311_00"
     # -- Image pull policy
     pullPolicy: Always
   # Frontend service configuration
@@ -1143,7 +1143,7 @@ weaviate:
     # -- Weaviate image repository
     repository: composio-self-host/weaviate
     # -- Weaviate image tag
-    tag: "r20260310_00"
+    tag: "r20260311_00"
     # -- Image pull policy
     pullPolicy: Always
   # Weaviate service configuration


### PR DESCRIPTION
# Description
Bump all composio service image tags from `r20260310_00` to `r20260311_00` in `composio/values.yaml`.

Updated tags:
- `apollo.image.tag`
- `apollo.dbInit.image.tag`
- `thermos.image.tag`
- `thermos.dbInit.image.tag`
- `mercury.image.tag`
- `frontend.image.tag`
- `weaviate.image.tag`

# How did I test this PR
- Verified all 7 occurrences of `r20260310_00` were replaced with `r20260311_00` via `replace_all`
- No other values in the file were modified

Triggered by: utkarsh@composio.dev | Source: web
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-738b993fda06