### PR TITLE
docs: add Temporal workflow metrics reference

### DIFF
--- a/temporal-workflow-metrics.md
+++ b/temporal-workflow-metrics.md
@@ -1,0 +1,32 @@
+# Temporal Workflow Metrics
+
+Thermos uses Temporal Cloud to orchestrate background workflows — auth refresh, trigger processing, cleanup, and MCP toolkit sync. Each workflow emits execution metrics to Datadog (via StatsD) and optionally to OpenTelemetry.
+
+## Metric Overview
+
+All workflows emit three core metrics:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `thermos.workflow.execution.total` | Counter | Incremented on every workflow run. Tagged with `workflow:<name>` and `status:success\|failure`. |
+| `thermos.workflow.execution.duration` | Distribution | Execution duration in milliseconds. Tagged with `workflow:<name>` and `status:success\|failure`. |
+| `thermos.workflow.last_success_epoch` | Gauge | Unix epoch of the last successful run. Used for staleness alerting. |
+
+### Tags
+
+All workflow metrics include:
+- `workflow:<name>` — workflow identifier (see table below)
+- `status:success` or `status:failure` — execution outcome
+
+Some workflows add extra tags (e.g., `toolkit:<slug>`, `trigger_name:<name>`).
+
+## Additional Domain-Specific Metrics
+
+Beyond the three core workflow metrics, each domain emits its own counters:
+
+- **Auth Refresh**: `auth_refresh.workflow.{success,failed,skipped}` (tagged by `app`, `group`)
+- **Webhook Triggers**: `webhook.trigger.{matched,non_matched,tool_error,apollo_error,e2e_latency}`
+- **Polling Triggers**: `polling.trigger.runs.{total,chunked,unchunked,duplicate}`, `polling.trigger.{tool_error,chunk_updates_error,apollo_updates_error,auth_refresh_error}`
+- **Webhook Trigger Refresh**: `webhook.trigger_refresh.{total,success,not_required,failed}`
+- **MCP Toolkit Sync**: `mcp_toolkit_sync.workflow.{completed,failed,skipped,no_change,no_connected_account}`, `mcp_toolkit_sync.tools.synced`
+


### PR DESCRIPTION
## Summary
- Adds `temporal-workflow-metrics.md` documenting the core and domain-specific metrics emitted by Thermos workflows
- Covers the three core metrics (`execution.total`, `execution.duration`, `last_success_epoch`) with their types and tags
- Documents additional domain-specific metrics for auth refresh, webhook/polling triggers, webhook trigger refresh, and MCP toolkit sync

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Cross-check metric names against Thermos source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)