### PR TITLE
fix: remove invalid --release-notes flag from helm upgrade

### DIFF
--- a/.github/workflows/replicated-pre-release.yaml
+++ b/.github/workflows/replicated-pre-release.yaml
@@ -263,7 +263,7 @@ jobs:
             --values ./values-override.yaml \
             --wait \
             --timeout 20m \
-            --version ${{ steps.get_version.outputs.unstable }} --release-notes "${{ github.event.release.body }}"
+            --version ${{ steps.get_version.outputs.unstable }}
 
       - name: Deployment Summary
         if: success()


### PR DESCRIPTION
## Summary
- Removed `--release-notes` flag from the `helm upgrade` command in the `deploy-to-gke` job
- `--release-notes` is a `replicated` CLI flag, not a Helm flag — it was causing `Error: unknown flag: --release-notes` and failing the deployment
- Fixes https://github.com/ComposioHQ/helm-charts/actions/runs/23241944419/job/67560407965

## Test plan
- [ ] Trigger a pre-release and verify the `deploy-to-gke` job completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)