### PR TITLE
[WIP] feat: add non-blocking replication db-init jobs for apollo and thermos

### DIFF
--- a/composio/templates/apollo/apollo-db-init.job.yaml
+++ b/composio/templates/apollo/apollo-db-init.job.yaml
@@ -1,93 +1,102 @@
 {{- if .Values.apollo.dbInit.enabled }}
+{{- $coreSecret := include "composio.coreSecretName" . }}
+{{- $targets := list (dict "suffix" "" "secretName" $coreSecret "postgresUrlKey" "POSTGRES_URL" "encryptionKeyKey" "ENCRYPTION_KEY" "isHook" true) }}
+{{- if .Values.apollo.dbInit.replication.enabled }}
+{{- $repl := .Values.apollo.dbInit.replication }}
+{{- $targets = append $targets (dict "suffix" "-replication" "secretName" $repl.secret.name "postgresUrlKey" ($repl.secret.postgresUrlKey | default "POSTGRES_URL") "encryptionKeyKey" ($repl.secret.encryptionKeyKey | default "ENCRYPTION_KEY") "isHook" false) }}
+{{- end }}
+{{- range $target := $targets }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-apollo-db-init
+  name: {{ $.Release.Name }}-apollo-db-init{{ $target.suffix }}
   labels:
-    app: apollo-db-init
-    release: {{ .Release.Name }}
+    app: apollo-db-init{{ $target.suffix }}
+    release: {{ $.Release.Name }}
+  {{- if $target.isHook }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- end }}
 spec:
   ttlSecondsAfterFinished: 86400
   template:
     metadata:
-      name: {{ .Release.Name }}-apollo-db-init
+      name: {{ $.Release.Name }}-apollo-db-init{{ $target.suffix }}
       labels:
-        app: apollo-db-init
-        release: {{ .Release.Name }}
+        app: apollo-db-init{{ $target.suffix }}
+        release: {{ $.Release.Name }}
     spec:
-      {{- if .Values.apollo.serviceAccount.enabled }}
-      serviceAccountName: {{ .Values.apollo.serviceAccount.name  }}
+      {{- if $.Values.apollo.serviceAccount.enabled }}
+      serviceAccountName: {{ $.Values.apollo.serviceAccount.name  }}
       {{- end }}
-      {{- if .Values.replicated.enabled }}
-      {{- include "replicated.imagePullSecrets" . | nindent 6 }}
+      {{- if $.Values.replicated.enabled }}
+      {{- include "replicated.imagePullSecrets" $ | nindent 6 }}
       {{- end }}
-      {{- if not .Values.replicated.enabled }}
-      {{- if .Values.global.imagePullSecrets }}
+      {{- if not $.Values.replicated.enabled }}
+      {{- if $.Values.global.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+        {{- toYaml $.Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
       {{- end }}
-      {{- with .Values.apollo.dbInit.podSecurityContext }}
+      {{- with $.Values.apollo.dbInit.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      restartPolicy: {{ .Values.dbInit.job.restartPolicy | default "OnFailure" }}
-      {{- with .Values.apollo.nodeSelector }}
+      restartPolicy: {{ $.Values.dbInit.job.restartPolicy | default "OnFailure" }}
+      {{- with $.Values.apollo.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.apollo.affinity }}
+      {{- with $.Values.apollo.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.apollo.tolerations }}
+      {{- with $.Values.apollo.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.apollo.dbInit.additionalInitContainers }}
+      {{- with $.Values.apollo.dbInit.additionalInitContainers }}
       initContainers:
 {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       containers:
-        - name: apollo-db-init
-          image: "{{ include "chart.registry" . }}/{{ .Values.apollo.dbInit.image.repository }}:{{ .Values.apollo.dbInit.image.tag }}"
-          imagePullPolicy: {{ .Values.apollo.dbInit.image.pullPolicy }}
-          {{- with .Values.apollo.dbInit.containerSecurityContext }}
+        - name: apollo-db-init{{ $target.suffix }}
+          image: "{{ include "chart.registry" $ }}/{{ $.Values.apollo.dbInit.image.repository }}:{{ $.Values.apollo.dbInit.image.tag }}"
+          imagePullPolicy: {{ $.Values.apollo.dbInit.image.pullPolicy }}
+          {{- with $.Values.apollo.dbInit.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- $coreSecret := include "composio.coreSecretName" . }}
             - name: APOLLO_SECRETS_DIR
-              value: {{ .Values.apollo.secretsDir | quote }}
+              value: {{ $.Values.apollo.secretsDir | quote }}
             # Apollo database URL
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: POSTGRES_URL
+                  name: {{ $target.secretName }}
+                  key: {{ $target.postgresUrlKey }}
                   optional: true
             - name: ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: ENCRYPTION_KEY
+                  name: {{ $target.secretName }}
+                  key: {{ $target.encryptionKeyKey }}
                   optional: true
             - name: ORG_API_KEY_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: ENCRYPTION_KEY
+                  name: {{ $target.secretName }}
+                  key: {{ $target.encryptionKeyKey }}
                   optional: true
             - name: ADMIN_EMAIL
-              value: {{ .Values.dbInit.adminEmail | default "hello@composio.dev" | quote }}
+              value: {{ $.Values.dbInit.adminEmail | default "hello@composio.dev" | quote }}
           volumeMounts:
             - name: apollo-secrets
-              mountPath: {{ .Values.apollo.secretsDir | quote }}
+              mountPath: {{ $.Values.apollo.secretsDir | quote }}
               readOnly: true
           resources:
             requests:
@@ -99,6 +108,7 @@ spec:
       volumes:
         - name: apollo-secrets
           emptyDir: {}
-  backoffLimit: {{ .Values.dbInit.job.backoffLimit | default 3 }}
-  activeDeadlineSeconds: {{ .Values.dbInit.job.activeDeadlineSeconds | default 300 }}
+  backoffLimit: {{ $.Values.dbInit.job.backoffLimit | default 3 }}
+  activeDeadlineSeconds: {{ $.Values.dbInit.job.activeDeadlineSeconds | default 300 }}
+{{- end }}
 {{- end }}

--- a/composio/templates/thermos/thermos-db-init-job.yaml
+++ b/composio/templates/thermos/thermos-db-init-job.yaml
@@ -1,89 +1,98 @@
 {{- if .Values.thermos.dbInit.enabled }}
+{{- $coreSecret := include "composio.coreSecretName" . }}
+{{- $targets := list (dict "suffix" "" "secretName" $coreSecret "thermosDbUrlKey" "THERMOS_DATABASE_URL" "isHook" true) }}
+{{- if .Values.thermos.dbInit.replication.enabled }}
+{{- $repl := .Values.thermos.dbInit.replication }}
+{{- $targets = append $targets (dict "suffix" "-replication" "secretName" $repl.secret.name "thermosDbUrlKey" ($repl.secret.thermosDbUrlKey | default "THERMOS_DATABASE_URL") "isHook" false) }}
+{{- end }}
+{{- range $target := $targets }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-thermos-db-init
+  name: {{ $.Release.Name }}-thermos-db-init{{ $target.suffix }}
   labels:
-    app: thermos-db-init
-    release: {{ .Release.Name }}
+    app: thermos-db-init{{ $target.suffix }}
+    release: {{ $.Release.Name }}
+  {{- if $target.isHook }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- end }}
 spec:
   ttlSecondsAfterFinished: 86400
   template:
     metadata:
-      name: {{ .Release.Name }}-thermos-db-init
+      name: {{ $.Release.Name }}-thermos-db-init{{ $target.suffix }}
       labels:
-        app: thermos-db-init
-        release: {{ .Release.Name }}
+        app: thermos-db-init{{ $target.suffix }}
+        release: {{ $.Release.Name }}
     spec:
-      {{- if .Values.replicated.enabled }}
-      {{- include "replicated.imagePullSecrets" . | nindent 6 }}
+      {{- if $.Values.replicated.enabled }}
+      {{- include "replicated.imagePullSecrets" $ | nindent 6 }}
       {{- end }}
-      {{- if not .Values.replicated.enabled }}
-      {{- if .Values.global.imagePullSecrets }}
+      {{- if not $.Values.replicated.enabled }}
+      {{- if $.Values.global.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+        {{- toYaml $.Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
       {{- end }}
-      {{- with .Values.thermos.dbInit.podSecurityContext }}
+      {{- with $.Values.thermos.dbInit.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      restartPolicy: {{ .Values.dbInit.job.restartPolicy | default "OnFailure" }}
-      {{- with .Values.thermos.nodeSelector }}
+      restartPolicy: {{ $.Values.dbInit.job.restartPolicy | default "OnFailure" }}
+      {{- with $.Values.thermos.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.thermos.affinity }}
+      {{- with $.Values.thermos.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.thermos.tolerations }}
+      {{- with $.Values.thermos.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.thermos.dbInit.additionalInitContainers }}
+      {{- with $.Values.thermos.dbInit.additionalInitContainers }}
       initContainers:
 {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       containers:
-        - name: thermos-db-init
-          image: "{{ include "chart.registry" . }}/{{ .Values.thermos.dbInit.image.repository }}:{{ .Values.thermos.dbInit.image.tag }}"
-          imagePullPolicy: {{ .Values.thermos.dbInit.image.pullPolicy }}
-          {{- with .Values.thermos.dbInit.containerSecurityContext }}
+        - name: thermos-db-init{{ $target.suffix }}
+          image: "{{ include "chart.registry" $ }}/{{ $.Values.thermos.dbInit.image.repository }}:{{ $.Values.thermos.dbInit.image.tag }}"
+          imagePullPolicy: {{ $.Values.thermos.dbInit.image.pullPolicy }}
+          {{- with $.Values.thermos.dbInit.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- $coreSecret := include "composio.coreSecretName" . }}
             - name: THERMOS_SECRET_DIR
-              value: {{ .Values.thermos.secretsDir | quote }}
+              value: {{ $.Values.thermos.secretsDir | quote }}
             # Thermos database URL
             - name: POSTGRES_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: THERMOS_DATABASE_URL
+                  name: {{ $target.secretName }}
+                  key: {{ $target.thermosDbUrlKey }}
                   optional: true
             # Keep DATABASE_URL for backward compatibility with Atlas
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: THERMOS_DATABASE_URL
+                  name: {{ $target.secretName }}
+                  key: {{ $target.thermosDbUrlKey }}
                   optional: true
             - name: ADMIN_EMAIL
-              value: {{ .Values.dbInit.adminEmail | default "hello@composio.dev" | quote }}
-            {{- if .Values.thermos.dbInit.extraAtlasFlags }}
+              value: {{ $.Values.dbInit.adminEmail | default "hello@composio.dev" | quote }}
+            {{- if $.Values.thermos.dbInit.extraAtlasFlags }}
             - name: EXTRA_ATLAS_FLAGS
-              value: {{ .Values.thermos.dbInit.extraAtlasFlags | quote }}
+              value: {{ $.Values.thermos.dbInit.extraAtlasFlags | quote }}
             {{- end }}
           volumeMounts:
             - name: thermos-secrets
-              mountPath: {{ .Values.thermos.secretsDir | quote }}
+              mountPath: {{ $.Values.thermos.secretsDir | quote }}
               readOnly: true
           resources:
             requests:
@@ -95,6 +104,7 @@ spec:
       volumes:
         - name: thermos-secrets
           emptyDir: {}
-  backoffLimit: {{ .Values.dbInit.job.backoffLimit | default 3 }}
-  activeDeadlineSeconds: {{ .Values.dbInit.job.activeDeadlineSeconds | default 300 }}
+  backoffLimit: {{ $.Values.dbInit.job.backoffLimit | default 3 }}
+  activeDeadlineSeconds: {{ $.Values.dbInit.job.activeDeadlineSeconds | default 300 }}
+{{- end }}
 {{- end }}

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -216,6 +216,19 @@ apollo:
       pullPolicy: Always
     # -- Additional init containers for Apollo DB init. Mount `apollo-secrets` to populate `.Values.apollo.secretsDir`.
     additionalInitContainers: []
+    ## Replication database initialization (non-blocking)
+    ## Runs as a regular Job alongside the deployment, does not block helm install/upgrade.
+    replication:
+      # -- Enable replication database initialization
+      enabled: false
+      ## Secret containing replication database credentials
+      secret:
+        # -- Name of the Kubernetes secret for replication DB
+        name: ""
+        # -- Key in the secret containing the PostgreSQL URL
+        postgresUrlKey: "POSTGRES_URL"
+        # -- Key in the secret containing the encryption key
+        encryptionKeyKey: "ENCRYPTION_KEY"
   
   # Apollo service configuration
   service:
@@ -406,6 +419,17 @@ thermos:
       pullPolicy: Always
     # -- Additional init containers for Thermos DB init. Mount `thermos-secrets` to populate `.Values.thermos.secretsDir`.
     additionalInitContainers: []
+    ## Replication database initialization (non-blocking)
+    ## Runs as a regular Job alongside the deployment, does not block helm install/upgrade.
+    replication:
+      # -- Enable replication database initialization
+      enabled: false
+      ## Secret containing replication database credentials
+      secret:
+        # -- Name of the Kubernetes secret for replication DB
+        name: ""
+        # -- Key in the secret containing the Thermos database URL
+        thermosDbUrlKey: "THERMOS_DATABASE_URL"
   
   # Thermos service configuration
   service:

--- a/docs/replication-db-init-adhoc.md
+++ b/docs/replication-db-init-adhoc.md
@@ -1,0 +1,190 @@
+# Running Replication DB Init Jobs Ad-Hoc via kubectl
+
+This guide covers running apollo-db-init and thermos-db-init against a replication database without deploying helm chart changes.
+
+## Prerequisites
+
+- `kubectl` configured with access to your cluster
+- The replication database is accessible from the cluster
+- You know the namespace where Composio is deployed (examples use `composio`)
+
+## 1. Create the Replication Database Secret
+
+Create a secret with the replication database credentials. Use a different secret name from the primary to avoid conflicts.
+
+```bash
+kubectl create secret generic replication-db-secrets \
+  -n composio \
+  --from-literal=POSTGRES_URL="postgresql://<user>:<password>@<replication-host>:<port>/composiodb" \
+  --from-literal=THERMOS_DATABASE_URL="postgresql://<user>:<password>@<replication-host>:<port>/thermosdb" \
+  --from-literal=ENCRYPTION_KEY="<your-encryption-key>"
+```
+
+Replace the placeholders:
+- `<user>` / `<password>` — replication DB credentials
+- `<replication-host>` / `<port>` — replication DB host and port
+- `<your-encryption-key>` — same encryption key used by the primary (required for apollo)
+
+## 2. Run Apollo DB Init on Replication
+
+```bash
+kubectl create job apollo-db-init-replication -n composio --image="008971668139.dkr.ecr.us-east-1.amazonaws.com/composio-self-host/apollo-db-init:r20260318_04" \
+  --dry-run=client -o yaml | kubectl patch --type merge --local -o yaml -p '
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 2400
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: apollo-db-init-replication
+        image: "008971668139.dkr.ecr.us-east-1.amazonaws.com/composio-self-host/apollo-db-init:r20260318_04"
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: replication-db-secrets
+              key: POSTGRES_URL
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: replication-db-secrets
+              key: ENCRYPTION_KEY
+        - name: ORG_API_KEY_ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: replication-db-secrets
+              key: ENCRYPTION_KEY
+        - name: ADMIN_EMAIL
+          value: "hello@composio.dev"
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+          limits:
+            cpu: 1000m
+            memory: 1Gi' -f - | kubectl apply -n composio -f -
+```
+
+Or apply the YAML directly:
+
+```bash
+cat <<'EOF' | kubectl apply -n composio -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: apollo-db-init-replication
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 2400
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      restartPolicy: OnFailure
+      imagePullSecrets:
+        - name: ecr-secret
+      containers:
+        - name: apollo-db-init-replication
+          image: "008971668139.dkr.ecr.us-east-1.amazonaws.com/composio-self-host/apollo-db-init:r20260318_04"
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: replication-db-secrets
+                  key: POSTGRES_URL
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: replication-db-secrets
+                  key: ENCRYPTION_KEY
+            - name: ORG_API_KEY_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: replication-db-secrets
+                  key: ENCRYPTION_KEY
+            - name: ADMIN_EMAIL
+              value: "hello@composio.dev"
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+EOF
+```
+
+## 3. Run Thermos DB Init on Replication
+
+```bash
+cat <<'EOF' | kubectl apply -n composio -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: thermos-db-init-replication
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 2400
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      restartPolicy: OnFailure
+      imagePullSecrets:
+        - name: ecr-secret
+      containers:
+        - name: thermos-db-init-replication
+          image: "008971668139.dkr.ecr.us-east-1.amazonaws.com/composio-self-host/thermos-db-init:r20260318_04"
+          env:
+            - name: POSTGRES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: replication-db-secrets
+                  key: THERMOS_DATABASE_URL
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: replication-db-secrets
+                  key: THERMOS_DATABASE_URL
+            - name: ADMIN_EMAIL
+              value: "hello@composio.dev"
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+EOF
+```
+
+## 4. Monitor the Jobs
+
+```bash
+# Watch job status
+kubectl get jobs -n composio -l 'app in (apollo-db-init-replication, thermos-db-init-replication)' -w
+
+# Check logs
+kubectl logs -n composio job/apollo-db-init-replication -f
+kubectl logs -n composio job/thermos-db-init-replication -f
+```
+
+## 5. Cleanup
+
+Jobs auto-delete after 24 hours (`ttlSecondsAfterFinished: 86400`). To remove manually:
+
+```bash
+kubectl delete job apollo-db-init-replication thermos-db-init-replication -n composio
+```
+
+To remove the secret (if no longer needed):
+
+```bash
+kubectl delete secret replication-db-secrets -n composio
+```
+
+## Notes
+
+- These jobs run independently of helm install/upgrade — they do not block application deployment.
+- If you need to re-run a job, delete the existing one first (`kubectl delete job <name> -n composio`) and re-apply.
+- Update the image tag to match your current release when running against newer versions.
+- The `imagePullSecrets` reference (`ecr-secret`) must already exist in the namespace. Adjust if your cluster uses a different pull secret name.


### PR DESCRIPTION
Allow running database migrations against a replication database in addition to the primary. Replication jobs are optional (disabled by default) and run as regular Jobs (non-blocking), so they do not delay helm install/upgrade.