### PR TITLE
feat: add service account support for thermos, mercury, weaviate, and frontend

### DIFF
--- a/composio/templates/frontend/frontend.yaml
+++ b/composio/templates/frontend/frontend.yaml
@@ -25,6 +25,9 @@ spec:
         {{- include "composio.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: frontend
     spec:
+      {{- if .Values.frontend.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.frontend.serviceAccount.name }}
+      {{- end }}
       {{- if .Values.replicated.enabled }}
       {{- include "replicated.imagePullSecrets" . | nindent 6 }}
       {{- end }}

--- a/composio/templates/frontend/service-account.yaml
+++ b/composio/templates/frontend/service-account.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.frontend.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.frontend.serviceAccount.name }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    {{- with .Values.frontend.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.frontend.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/composio/templates/mercury/mercury.yaml
+++ b/composio/templates/mercury/mercury.yaml
@@ -20,6 +20,9 @@ spec:
         {{- include "composio.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: mercury
     spec:
+      {{- if .Values.mercury.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.mercury.serviceAccount.name }}
+      {{- end }}
       {{- if .Values.replicated.enabled }}
       {{- include "replicated.imagePullSecrets" . | nindent 6 }}
       {{- end }}

--- a/composio/templates/mercury/service-account.yaml
+++ b/composio/templates/mercury/service-account.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.mercury.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.mercury.serviceAccount.name }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    {{- with .Values.mercury.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: mercury
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.mercury.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/composio/templates/thermos/service-account.yaml
+++ b/composio/templates/thermos/service-account.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.thermos.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.thermos.serviceAccount.name }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    {{- with .Values.thermos.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: thermos
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.thermos.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/composio/templates/thermos/thermos-db-init-job.yaml
+++ b/composio/templates/thermos/thermos-db-init-job.yaml
@@ -19,6 +19,9 @@ spec:
         app: thermos-db-init
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.thermos.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.thermos.serviceAccount.name }}
+      {{- end }}
       {{- if .Values.replicated.enabled }}
       {{- include "replicated.imagePullSecrets" . | nindent 6 }}
       {{- end }}

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -22,6 +22,9 @@ spec:
         app: thermos
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.thermos.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.thermos.serviceAccount.name }}
+      {{- end }}
       {{- if .Values.replicated.enabled }}
       {{- include "replicated.imagePullSecrets" . | nindent 6 }}
       {{- end }}

--- a/composio/templates/weaviate/service-account.yaml
+++ b/composio/templates/weaviate/service-account.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.weaviate.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.weaviate.serviceAccount.name }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    {{- with .Values.weaviate.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: weaviate
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.weaviate.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/composio/templates/weaviate/weaviate.yaml
+++ b/composio/templates/weaviate/weaviate.yaml
@@ -24,6 +24,9 @@ spec:
         {{- include "composio.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: weaviate
     spec:
+      {{- if .Values.weaviate.serviceAccount.enabled }}
+      serviceAccountName: {{ .Values.weaviate.serviceAccount.name }}
+      {{- end }}
       {{- if .Values.replicated.enabled }}
       {{- include "replicated.imagePullSecrets" . | nindent 6 }}
       {{- end }}

--- a/composio/tests/apollo_test.yaml
+++ b/composio/tests/apollo_test.yaml
@@ -22,6 +22,32 @@ tests:
           path: metadata.labels.release
           value: RELEASE-NAME
 
+  - it: should not set serviceAccountName when SA is disabled
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      redis.enabled: true
+      externalRedis.enabled: false
+      apollo.serviceAccount.enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.serviceAccountName
+
+  - it: should set serviceAccountName when SA is enabled
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      redis.enabled: true
+      externalRedis.enabled: false
+      apollo.serviceAccount.enabled: true
+      apollo.serviceAccount.name: apollo-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: apollo-sa
+
   - it: should have correct replica count
     documentSelector:
       path: kind

--- a/composio/tests/db_init_test.yaml
+++ b/composio/tests/db_init_test.yaml
@@ -41,6 +41,24 @@ tests:
           path: spec.ttlSecondsAfterFinished
           value: 86400
 
+  - it: should not set serviceAccountName when SA is disabled
+    set:
+      apollo.dbInit.enabled: true
+      apollo.serviceAccount.enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.serviceAccountName
+
+  - it: should set serviceAccountName when SA is enabled
+    set:
+      apollo.dbInit.enabled: true
+      apollo.serviceAccount.enabled: true
+      apollo.serviceAccount.name: apollo-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: apollo-sa
+
   - it: should have correct labels
     set:
       apollo.dbInit.enabled: true
@@ -241,6 +259,24 @@ tests:
       - equal:
           path: spec.ttlSecondsAfterFinished
           value: 86400
+
+  - it: should not set serviceAccountName when SA is disabled
+    set:
+      thermos.dbInit.enabled: true
+      thermos.serviceAccount.enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.serviceAccountName
+
+  - it: should set serviceAccountName when SA is enabled
+    set:
+      thermos.dbInit.enabled: true
+      thermos.serviceAccount.enabled: true
+      thermos.serviceAccount.name: thermos-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: thermos-sa
 
   - it: should have correct labels
     set:

--- a/composio/tests/frontend_test.yaml
+++ b/composio/tests/frontend_test.yaml
@@ -25,6 +25,30 @@ tests:
           path: metadata.labels["app.kubernetes.io/component"]
           value: frontend
 
+  - it: should not set serviceAccountName when SA is disabled
+    set:
+      frontend.enabled: true
+      frontend.image.repository: test-frontend
+      frontend.image.tag: "v1.0.0"
+      frontend.serviceAccount.enabled: false
+    documentIndex: 0
+    asserts:
+      - isNull:
+          path: spec.template.spec.serviceAccountName
+
+  - it: should set serviceAccountName when SA is enabled
+    set:
+      frontend.enabled: true
+      frontend.image.repository: test-frontend
+      frontend.image.tag: "v1.0.0"
+      frontend.serviceAccount.enabled: true
+      frontend.serviceAccount.name: frontend-sa
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: frontend-sa
+
   - it: should have correct replica count
     set:
       frontend.enabled: true

--- a/composio/tests/mercury_test.yaml
+++ b/composio/tests/mercury_test.yaml
@@ -35,6 +35,32 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should not set serviceAccountName when SA is disabled
+    set:
+      mercury.enabled: true
+      mercury.useKnative: false
+      mercury.serviceAccount.enabled: false
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - isNull:
+          path: spec.template.spec.serviceAccountName
+
+  - it: should set serviceAccountName when SA is enabled
+    set:
+      mercury.enabled: true
+      mercury.useKnative: false
+      mercury.serviceAccount.enabled: true
+      mercury.serviceAccount.name: mercury-sa
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: mercury-sa
+
   - it: should use correct replica count
     set:
       mercury.enabled: true

--- a/composio/tests/service_account_test.yaml
+++ b/composio/tests/service_account_test.yaml
@@ -68,3 +68,291 @@ tests:
       - equal:
           path: metadata.annotations["iam.gke.io/gcp-service-account"]
           value: "my-sa@my-project.iam.gserviceaccount.com"
+
+---
+suite: test thermos service account
+templates:
+  - thermos/service-account.yaml
+tests:
+  - it: should not create service account when disabled
+    set:
+      thermos.serviceAccount.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create service account when enabled
+    set:
+      thermos.serviceAccount.enabled: true
+      thermos.serviceAccount.name: thermos-sa
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: thermos-sa
+
+  - it: should have correct labels
+    set:
+      thermos.serviceAccount.enabled: true
+      thermos.serviceAccount.name: thermos-sa
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: thermos
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should include custom labels when provided
+    set:
+      thermos.serviceAccount.enabled: true
+      thermos.serviceAccount.name: thermos-sa
+      thermos.serviceAccount.labels:
+        custom-label: custom-value
+        environment: production
+    asserts:
+      - equal:
+          path: metadata.labels["custom-label"]
+          value: custom-value
+      - equal:
+          path: metadata.labels["environment"]
+          value: production
+
+  - it: should include annotations when provided
+    set:
+      thermos.serviceAccount.enabled: true
+      thermos.serviceAccount.name: thermos-sa
+      thermos.serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/thermos-role"
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: "arn:aws:iam::123456789:role/thermos-role"
+
+  - it: should support GCP workload identity annotation
+    set:
+      thermos.serviceAccount.enabled: true
+      thermos.serviceAccount.name: thermos-sa
+      thermos.serviceAccount.annotations:
+        iam.gke.io/gcp-service-account: "thermos@my-project.iam.gserviceaccount.com"
+    asserts:
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: "thermos@my-project.iam.gserviceaccount.com"
+
+---
+suite: test mercury service account
+templates:
+  - mercury/service-account.yaml
+tests:
+  - it: should not create service account when disabled
+    set:
+      mercury.serviceAccount.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create service account when enabled
+    set:
+      mercury.serviceAccount.enabled: true
+      mercury.serviceAccount.name: mercury-sa
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: mercury-sa
+
+  - it: should have correct labels
+    set:
+      mercury.serviceAccount.enabled: true
+      mercury.serviceAccount.name: mercury-sa
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: mercury
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should include custom labels when provided
+    set:
+      mercury.serviceAccount.enabled: true
+      mercury.serviceAccount.name: mercury-sa
+      mercury.serviceAccount.labels:
+        custom-label: custom-value
+        environment: production
+    asserts:
+      - equal:
+          path: metadata.labels["custom-label"]
+          value: custom-value
+      - equal:
+          path: metadata.labels["environment"]
+          value: production
+
+  - it: should include annotations when provided
+    set:
+      mercury.serviceAccount.enabled: true
+      mercury.serviceAccount.name: mercury-sa
+      mercury.serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/mercury-role"
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: "arn:aws:iam::123456789:role/mercury-role"
+
+  - it: should support GCP workload identity annotation
+    set:
+      mercury.serviceAccount.enabled: true
+      mercury.serviceAccount.name: mercury-sa
+      mercury.serviceAccount.annotations:
+        iam.gke.io/gcp-service-account: "mercury@my-project.iam.gserviceaccount.com"
+    asserts:
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: "mercury@my-project.iam.gserviceaccount.com"
+
+---
+suite: test weaviate service account
+templates:
+  - weaviate/service-account.yaml
+tests:
+  - it: should not create service account when disabled
+    set:
+      weaviate.serviceAccount.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create service account when enabled
+    set:
+      weaviate.serviceAccount.enabled: true
+      weaviate.serviceAccount.name: weaviate-sa
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: weaviate-sa
+
+  - it: should have correct labels
+    set:
+      weaviate.serviceAccount.enabled: true
+      weaviate.serviceAccount.name: weaviate-sa
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: weaviate
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should include custom labels when provided
+    set:
+      weaviate.serviceAccount.enabled: true
+      weaviate.serviceAccount.name: weaviate-sa
+      weaviate.serviceAccount.labels:
+        custom-label: custom-value
+        environment: production
+    asserts:
+      - equal:
+          path: metadata.labels["custom-label"]
+          value: custom-value
+      - equal:
+          path: metadata.labels["environment"]
+          value: production
+
+  - it: should include annotations when provided
+    set:
+      weaviate.serviceAccount.enabled: true
+      weaviate.serviceAccount.name: weaviate-sa
+      weaviate.serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/weaviate-role"
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: "arn:aws:iam::123456789:role/weaviate-role"
+
+  - it: should support GCP workload identity annotation
+    set:
+      weaviate.serviceAccount.enabled: true
+      weaviate.serviceAccount.name: weaviate-sa
+      weaviate.serviceAccount.annotations:
+        iam.gke.io/gcp-service-account: "weaviate@my-project.iam.gserviceaccount.com"
+    asserts:
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: "weaviate@my-project.iam.gserviceaccount.com"
+
+---
+suite: test frontend service account
+templates:
+  - frontend/service-account.yaml
+tests:
+  - it: should not create service account when disabled
+    set:
+      frontend.serviceAccount.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create service account when enabled
+    set:
+      frontend.serviceAccount.enabled: true
+      frontend.serviceAccount.name: frontend-sa
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: frontend-sa
+
+  - it: should have correct labels
+    set:
+      frontend.serviceAccount.enabled: true
+      frontend.serviceAccount.name: frontend-sa
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: frontend
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should include custom labels when provided
+    set:
+      frontend.serviceAccount.enabled: true
+      frontend.serviceAccount.name: frontend-sa
+      frontend.serviceAccount.labels:
+        custom-label: custom-value
+        environment: production
+    asserts:
+      - equal:
+          path: metadata.labels["custom-label"]
+          value: custom-value
+      - equal:
+          path: metadata.labels["environment"]
+          value: production
+
+  - it: should include annotations when provided
+    set:
+      frontend.serviceAccount.enabled: true
+      frontend.serviceAccount.name: frontend-sa
+      frontend.serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/frontend-role"
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: "arn:aws:iam::123456789:role/frontend-role"
+
+  - it: should support GCP workload identity annotation
+    set:
+      frontend.serviceAccount.enabled: true
+      frontend.serviceAccount.name: frontend-sa
+      frontend.serviceAccount.annotations:
+        iam.gke.io/gcp-service-account: "frontend@my-project.iam.gserviceaccount.com"
+    asserts:
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: "frontend@my-project.iam.gserviceaccount.com"

--- a/composio/tests/thermos_test.yaml
+++ b/composio/tests/thermos_test.yaml
@@ -19,6 +19,28 @@ tests:
           path: metadata.labels.release
           value: RELEASE-NAME
 
+  - it: should not set serviceAccountName when SA is disabled
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      thermos.serviceAccount.enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.serviceAccountName
+
+  - it: should set serviceAccountName when SA is enabled
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      thermos.serviceAccount.enabled: true
+      thermos.serviceAccount.name: thermos-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: thermos-sa
+
   - it: should have correct replica count
     documentSelector:
       path: kind

--- a/composio/tests/weaviate_test.yaml
+++ b/composio/tests/weaviate_test.yaml
@@ -25,6 +25,30 @@ tests:
           path: metadata.labels["app.kubernetes.io/component"]
           value: weaviate
 
+  - it: should not set serviceAccountName when SA is disabled
+    set:
+      weaviate.enabled: true
+      weaviate.image.repository: test-weaviate
+      weaviate.image.tag: "v1.0.0"
+      weaviate.serviceAccount.enabled: false
+    documentIndex: 0
+    asserts:
+      - isNull:
+          path: spec.template.spec.serviceAccountName
+
+  - it: should set serviceAccountName when SA is enabled
+    set:
+      weaviate.enabled: true
+      weaviate.image.repository: test-weaviate
+      weaviate.image.tag: "v1.0.0"
+      weaviate.serviceAccount.enabled: true
+      weaviate.serviceAccount.name: weaviate-sa
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: weaviate-sa
+
   - it: should have correct replica count
     set:
       weaviate.enabled: true

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -1223,6 +1223,16 @@ weaviate:
     tag: "r20260318_04"
     # -- Image pull policy
     pullPolicy: Always
+  serviceAccount:
+    # -- Enable service account creation
+    enabled: false
+    # -- Name of the service account to create or use
+    name: "composio-weaviate"
+    # -- Annotations to add to the service account
+    annotations: {}
+    # -- Labels to add to the service account
+    labels: {}
+
   # Weaviate service configuration
   service:
     # -- Service type

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -1165,6 +1165,17 @@ frontend:
   secretsDir: "/etc/secrets/frontend"
   # -- Additional init containers for Frontend. Mount `frontend-secrets` to populate `.Values.frontend.secretsDir`.
   additionalInitContainers: []
+
+  serviceAccount:
+    # -- Enable service account creation
+    enabled: false
+    # -- Name of the service account to create or use
+    name: "composio-frontend"
+    # -- Annotations to add to the service account
+    annotations: {}
+    # -- Labels to add to the service account
+    labels: {}
+
   # Frontend service configuration
   service:
     # -- Service type

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -389,6 +389,16 @@ thermos:
   # -- Additional init containers for Thermos. Mount `thermos-secrets` to populate `.Values.thermos.secretsDir`.
   additionalInitContainers: []
 
+  serviceAccount:
+    # -- Enable service account creation
+    enabled: false
+    # -- Name of the service account to create or use
+    name: "composio-thermos"
+    # -- Annotations to add to the service account
+    annotations: {}
+    # -- Labels to add to the service account
+    labels: {}
+
   # Thermos database initialization container
   dbInit:
     # -- Enable database initialization
@@ -1028,6 +1038,16 @@ mercury:
   secretsDir: "/etc/secrets/mercury"
   # -- Additional init containers for Mercury. Mount `mercury-secrets` to populate `.Values.mercury.secretsDir`.
   additionalInitContainers: []
+
+  serviceAccount:
+    # -- Enable service account creation
+    enabled: false
+    # -- Name of the service account to create or use
+    name: "composio-mercury"
+    # -- Annotations to add to the service account
+    annotations: {}
+    # -- Labels to add to the service account
+    labels: {}
 
   # Liveness probe configuration
   livenessProbe:


### PR DESCRIPTION
## Summary
- Add service account configuration (template, values, deployment ref) for **thermos**, **mercury**, **weaviate**, and **frontend**, matching the existing apollo pattern
- Each service gets a `serviceAccount` block in values.yaml (default `enabled: false`), a `service-account.yaml` template, and `serviceAccountName` in its deployment spec
- Thermos db-init job also references the thermos service account when enabled

## Test plan
- [ ] `helm template` renders without errors with SA disabled (default)
- [ ] `helm template --set <service>.serviceAccount.enabled=true` creates the ServiceAccount resource and sets `serviceAccountName` in deployment
- [ ] Verify no regression on existing apollo SA behavior
- [ ] Run `./run-tests.sh` to ensure existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)