### PR TITLE
feat(ci): add DevSecOps security scanning workflows

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,3 @@
+paths-ignore:
+  - "**/*.md"
+  - "docs/**"

--- a/.github/semgrep-rules/helm-security.yaml
+++ b/.github/semgrep-rules/helm-security.yaml
@@ -1,0 +1,79 @@
+rules:
+  - id: helm-privileged-container
+    patterns:
+      - pattern: "privileged: true"
+    message: >
+      Container is running in privileged mode. Privileged containers have full
+      access to the host and should be avoided. Set `privileged: false` or
+      remove the field entirely.
+    severity: ERROR
+    languages: [generic]
+    metadata:
+      cwe:
+        - "CWE-250: Execution with Unnecessary Privileges"
+      category: security
+      technology:
+        - kubernetes
+        - helm
+
+  - id: helm-host-network
+    patterns:
+      - pattern: "hostNetwork: true"
+    message: >
+      Pod is configured to use the host network namespace. This allows the pod
+      to access all network interfaces on the host and can be used to sniff
+      traffic. Set `hostNetwork: false` or remove the field.
+    severity: WARNING
+    languages: [generic]
+    metadata:
+      cwe:
+        - "CWE-668: Exposure of Resource to Wrong Sphere"
+      category: security
+      technology:
+        - kubernetes
+        - helm
+
+  - id: helm-no-resource-limits
+    patterns:
+      - pattern: |
+          containers:
+            - ...
+              name: $NAME
+      - pattern-not: |
+          containers:
+            - ...
+              name: $NAME
+              ...
+              resources:
+                ...
+                limits:
+                  ...
+    message: >
+      Container '$NAME' does not have resource limits configured. Without
+      resource limits, a container can consume all available resources on the
+      node. Add `resources.limits.cpu` and `resources.limits.memory`.
+    severity: WARNING
+    languages: [generic]
+    metadata:
+      category: security
+      technology:
+        - kubernetes
+        - helm
+
+  - id: helm-run-as-root
+    pattern-either:
+      - pattern: "runAsUser: 0"
+      - pattern: "runAsNonRoot: false"
+    message: >
+      Container or pod security context allows running as root. Running
+      containers as root increases the attack surface. Set `runAsNonRoot: true`
+      and use a non-zero `runAsUser`.
+    severity: WARNING
+    languages: [generic]
+    metadata:
+      cwe:
+        - "CWE-250: Execution with Unnecessary Privileges"
+      category: security
+      technology:
+        - kubernetes
+        - helm

--- a/.github/workflows/sast-semgrep.yml
+++ b/.github/workflows/sast-semgrep.yml
@@ -1,0 +1,47 @@
+name: "SAST - Semgrep IaC Security Scan"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    name: Semgrep IaC Scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Semgrep scan
+        run: |
+          semgrep scan \
+            --config "p/kubernetes" \
+            --config "p/dockerfile" \
+            --config ".github/semgrep-rules" \
+            --exclude "node_modules" \
+            --sarif \
+            --output semgrep-results.sarif \
+            --error \
+            --severity ERROR \
+            .
+
+      - name: Upload SARIF results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep-results.sarif
+          category: semgrep-iac

--- a/.github/workflows/security-helm.yml
+++ b/.github/workflows/security-helm.yml
@@ -1,0 +1,88 @@
+name: "Helm Chart Security Scanning"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  kubesec:
+    name: Kubesec Template Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: "v3.14.0"
+
+      - name: Install kubesec
+        run: |
+          curl -sSL https://github.com/controlplaneio/kubesec/releases/download/v2.14.0/kubesec_linux_amd64.tar.gz | tar xz
+          sudo mv kubesec /usr/local/bin/
+
+      - name: Render Helm templates
+        run: |
+          mkdir -p rendered
+          helm template composio composio/ \
+            --values composio/values.yaml \
+            --output-dir rendered
+
+      - name: Split and scan rendered templates with kubesec
+        run: |
+          exit_code=0
+          find rendered -name '*.yaml' -type f | while read -r file; do
+            echo "=== Scanning: $file ==="
+            # Split multi-document YAML files into individual resources
+            csplit --quiet --prefix="$file.part" --suffix-format='%03d.yaml' \
+              "$file" '/^---$/' '{*}' 2>/dev/null || true
+
+            for part in "$file".part*.yaml; do
+              [ -f "$part" ] || continue
+              # Skip empty files or files with only comments/separators
+              if grep -qE '^\s*(kind|apiVersion):' "$part"; then
+                echo "--- Scanning resource: $part ---"
+                kubesec scan "$part" || exit_code=1
+              fi
+              rm -f "$part"
+            done
+          done
+          exit $exit_code
+
+  checkov:
+    name: Checkov Helm Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Checkov scan
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: composio/
+          framework: helm
+          soft_fail: true
+          output_format: sarif
+          output_file_path: checkov-results.sarif
+
+      - name: Upload SARIF results to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: checkov-results.sarif
+          category: checkov-helm


### PR DESCRIPTION
## Summary
- Add **Semgrep SAST** with Kubernetes and Dockerfile rulesets + 4 custom Helm security rules (privileged containers, host network, missing resource limits, run-as-root)
- Add **Checkov** for Helm chart misconfiguration detection (soft-fail with SARIF upload)
- Add **Kubesec** for rendered Kubernetes template security scanning
- Enable **GitHub native secret scanning push protection**, validity checks, and non-provider patterns
- Add `secret_scanning.yml` to exclude docs from false positives

## Test plan
- [ ] Verify Semgrep workflow runs on a test PR with Kubernetes rules
- [ ] Verify Checkov scans Helm charts and uploads SARIF to Security tab
- [ ] Verify Kubesec renders and scans templates without errors
- [ ] Verify secret scanning push protection blocks a test secret push

🤖 Generated with [Claude Code](https://claude.com/claude-code)