### PR TITLE
fix: replicated pull secret and thermos encryption env vars

### DIFF
--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -359,6 +359,11 @@ Image pull secrets
     {{- $pullSecrets = append $pullSecrets "replicated-pull-secret" -}}
   {{- end -}}
 
+  {{/* always include replicated-pull-secret when replicated is enabled */}}
+  {{- if ((.Values.replicated).enabled) }}
+    {{- $pullSecrets = append $pullSecrets "replicated-pull-secret" -}}
+  {{- end -}}
+
 
   {{- if (not (empty $pullSecrets)) -}}
 imagePullSecrets:

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -107,6 +107,18 @@ spec:
                   name: {{ $coreSecret }}
                   key: THERMOS_DATABASE_URL
                   optional: true
+            - name: WEBHOOK_PAYLOAD_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $coreSecret }}
+                  key: WEBHOOK_PAYLOAD_ENCRYPTION_KEY
+                  optional: true
+            - name: POLLING_TRIGGER_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $coreSecret }}
+                  key: POLLING_TRIGGER_ENCRYPTION_KEY
+                  optional: true
             {{- if .Values.thermos.env }}
             {{- toYaml .Values.thermos.env | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
## Summary
- **replicated.imagePullSecrets helper**: Added fallback to include `replicated-pull-secret` when `replicated.enabled` is true, not only when `global.replicated.dockerconfigjson` is explicitly set. This fixes pre-upgrade hook pods (e.g. `apollo-db-init`) failing to pull images through the Replicated proxy.
- **thermos deployment**: Added `WEBHOOK_PAYLOAD_ENCRYPTION_KEY` and `POLLING_TRIGGER_ENCRYPTION_KEY` env vars from the core secret, required by the latest thermos build (`r20260324_03`).

## Context
During the `r20260324_03` rollout, two issues surfaced:
1. Helm pre-upgrade hooks failed with `400 Bad Request` because hook job pods only had `ecr-secret` as imagePullSecret — `replicated-pull-secret` was missing since `global.replicated.dockerconfigjson` wasn't set in values.
2. Thermos crashed on startup with `WEBHOOK_PAYLOAD_ENCRYPTION_KEY is required but not set` and `POLLING_TRIGGER_ENCRYPTION_KEY is required but not set`.

## Test plan
- [ ] `helm lint composio/` passes
- [ ] `helm template` with `replicated.enabled=true` includes `replicated-pull-secret` in all pod specs (including hook jobs) even without `global.replicated.dockerconfigjson`
- [ ] Thermos deployment template includes both new env vars from core secret
- [ ] Deploy to test cluster and verify all pods come up on new image tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)