### PR TITLE
fix: rename APOLLO_SECRETS_DIR to APOLLO_SECRET_DIR to match start.sh

### DIFF
--- a/composio/templates/apollo/apollo-db-init.job.yaml
+++ b/composio/templates/apollo/apollo-db-init.job.yaml
@@ -62,7 +62,7 @@ spec:
           {{- end }}
           env:
             {{- $coreSecret := include "composio.coreSecretName" . }}
-            - name: APOLLO_SECRETS_DIR
+            - name: APOLLO_SECRET_DIR
               value: {{ .Values.apollo.secretsDir | quote }}
             # Apollo database URL
             - name: DATABASE_URL

--- a/composio/templates/apollo/apollo.yaml
+++ b/composio/templates/apollo/apollo.yaml
@@ -108,7 +108,7 @@ spec:
                 name: {{ .Release.Name }}-apollo-config
           env:
             {{- $coreSecret := include "composio.coreSecretName" . }}
-            - name: APOLLO_SECRETS_DIR
+            - name: APOLLO_SECRET_DIR
               value: {{ .Values.apollo.secretsDir | quote }}
             {{- if eq .Values.apollo.objectStorage.backend "s3"}}
             - name: S3_ACCESS_KEY_ID

--- a/composio/tests/apollo_test.yaml
+++ b/composio/tests/apollo_test.yaml
@@ -164,7 +164,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: APOLLO_SECRETS_DIR
+            name: APOLLO_SECRET_DIR
             value: /etc/secrets/apollo
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -240,7 +240,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: APOLLO_SECRETS_DIR
+            name: APOLLO_SECRET_DIR
             value: /var/run/apollo-secrets
       - contains:
           path: spec.template.spec.containers[0].volumeMounts

--- a/composio/tests/db_init_test.yaml
+++ b/composio/tests/db_init_test.yaml
@@ -132,7 +132,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: APOLLO_SECRETS_DIR
+            name: APOLLO_SECRET_DIR
             value: /etc/secrets/apollo
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -178,7 +178,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: APOLLO_SECRETS_DIR
+            name: APOLLO_SECRET_DIR
             value: /var/run/apollo-secrets
       - contains:
           path: spec.template.spec.containers[0].volumeMounts

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -174,7 +174,7 @@ apollo:
     tag: "r20260325_04"
     # -- Image pull policy
     pullPolicy: Always
-  # -- Directory exposed to Apollo containers via APOLLO_SECRETS_DIR.
+  # -- Directory exposed to Apollo containers via APOLLO_SECRET_DIR.
   secretsDir: "/etc/secrets/apollo"
   # -- Additional init containers for Apollo. Mount `apollo-secrets` to populate `.Values.apollo.secretsDir`.
   additionalInitContainers: []


### PR DESCRIPTION
# Description
Fix env var name mismatch between the Helm chart and the Apollo startup scripts.

The Helm chart was setting `APOLLO_SECRETS_DIR` (with S), but `start.sh` and `init_start.sh` in `hermes/self-host/` read `APOLLO_SECRET_DIR` (without S). The mismatch was masked by the default fallback value being the same path (`/etc/secrets/apollo`), but should be fixed for correctness. This also aligns Apollo with Thermos, which already uses `THERMOS_SECRET_DIR` (without S) consistently.

**Files changed:**
- `composio/templates/apollo/apollo.yaml` — env var name fix
- `composio/templates/apollo/apollo-db-init.job.yaml` — env var name fix
- `composio/values.yaml` — comment fix
- `composio/tests/apollo_test.yaml` — updated test assertions
- `composio/tests/db_init_test.yaml` — updated test assertions

# How did I test this PR
- Ran `helm unittest composio -f tests/apollo_test.yaml -f tests/db_init_test.yaml`
- db_init tests pass (18/18); apollo_test has 17 pre-existing failures unrelated to this change (same failures on `release-stable` before this PR)
- Verified no remaining occurrences of `APOLLO_SECRETS_DIR` in the repo
- Confirmed `hermes/self-host/start.sh` and `init_start.sh` both read `APOLLO_SECRET_DIR` (without S)

Triggered by: utkarsh@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-f758a741a6ab