### PR TITLE
feat: add serviceAccount.create flag to skip SA creation when using existing accounts

### DIFF
--- a/composio/templates/apollo/service-account.yaml
+++ b/composio/templates/apollo/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.apollo.serviceAccount.enabled -}}
+{{- if and .Values.apollo.serviceAccount.enabled .Values.apollo.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/composio/templates/frontend/service-account.yaml
+++ b/composio/templates/frontend/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.frontend.serviceAccount.enabled -}}
+{{- if and .Values.frontend.serviceAccount.enabled .Values.frontend.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/composio/templates/mercury/service-account.yaml
+++ b/composio/templates/mercury/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mercury.serviceAccount.enabled -}}
+{{- if and .Values.mercury.serviceAccount.enabled .Values.mercury.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/composio/templates/thermos/service-account.yaml
+++ b/composio/templates/thermos/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.thermos.serviceAccount.enabled -}}
+{{- if and .Values.thermos.serviceAccount.enabled .Values.thermos.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/composio/templates/weaviate/service-account.yaml
+++ b/composio/templates/weaviate/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.weaviate.serviceAccount.enabled -}}
+{{- if and .Values.weaviate.serviceAccount.enabled .Values.weaviate.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -180,11 +180,12 @@ apollo:
   additionalInitContainers: []
 
   serviceAccount:
-    # -- Enable service account creation
+    # -- Whether the deployment should use a service account. When false, no serviceAccountName is set on the pod.
     enabled: true
-    # -- Create the service account. Set to false to use an existing service account
+    # -- Whether the chart should create the service account. Set to false if the service account already exists
+    # -- (e.g. managed externally via IAM or another chart). Requires enabled: true to take effect.
     create: true
-    # -- Name of the service account to create or use
+    # -- Name of the service account. Used for both creation (when create: true) and reference in the pod spec.
     name: "composio-apollo"
     # -- Annotations to add to the service account
     annotations: {}
@@ -395,11 +396,12 @@ thermos:
   additionalInitContainers: []
 
   serviceAccount:
-    # -- Enable service account creation
+    # -- Whether the deployment should use a service account. When false, no serviceAccountName is set on the pod.
     enabled: false
-    # -- Create the service account. Set to false to use an existing service account
-    create: false
-    # -- Name of the service account to create or use
+    # -- Whether the chart should create the service account. Set to false if the service account already exists
+    # -- (e.g. managed externally via IAM or another chart). Requires enabled: true to take effect.
+    create: true
+    # -- Name of the service account. Used for both creation (when create: true) and reference in the pod spec.
     name: "composio-thermos"
     # -- Annotations to add to the service account
     annotations: {}
@@ -1047,11 +1049,12 @@ mercury:
   additionalInitContainers: []
 
   serviceAccount:
-    # -- Enable service account creation
+    # -- Whether the deployment should use a service account. When false, no serviceAccountName is set on the pod.
     enabled: false
-    # -- Create the service account. Set to false to use an existing service account
-    create: false
-    # -- Name of the service account to create or use
+    # -- Whether the chart should create the service account. Set to false if the service account already exists
+    # -- (e.g. managed externally via IAM or another chart). Requires enabled: true to take effect.
+    create: true
+    # -- Name of the service account. Used for both creation (when create: true) and reference in the pod spec.
     name: "composio-mercury"
     # -- Annotations to add to the service account
     annotations: {}
@@ -1176,11 +1179,12 @@ frontend:
   additionalInitContainers: []
 
   serviceAccount:
-    # -- Enable service account creation
+    # -- Whether the deployment should use a service account. When false, no serviceAccountName is set on the pod.
     enabled: false
-    # -- Create the service account. Set to false to use an existing service account
-    create: false
-    # -- Name of the service account to create or use
+    # -- Whether the chart should create the service account. Set to false if the service account already exists
+    # -- (e.g. managed externally via IAM or another chart). Requires enabled: true to take effect.
+    create: true
+    # -- Name of the service account. Used for both creation (when create: true) and reference in the pod spec.
     name: "composio-frontend"
     # -- Annotations to add to the service account
     annotations: {}
@@ -1246,11 +1250,12 @@ weaviate:
     # -- Image pull policy
     pullPolicy: Always
   serviceAccount:
-    # -- Enable service account creation
+    # -- Whether the deployment should use a service account. When false, no serviceAccountName is set on the pod.
     enabled: false
-    # -- Create the service account. Set to false to use an existing service account
-    create: false
-    # -- Name of the service account to create or use
+    # -- Whether the chart should create the service account. Set to false if the service account already exists
+    # -- (e.g. managed externally via IAM or another chart). Requires enabled: true to take effect.
+    create: true
+    # -- Name of the service account. Used for both creation (when create: true) and reference in the pod spec.
     name: "composio-weaviate"
     # -- Annotations to add to the service account
     annotations: {}

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -182,6 +182,8 @@ apollo:
   serviceAccount:
     # -- Enable service account creation
     enabled: true
+    # -- Create the service account. Set to false to use an existing service account
+    create: true
     # -- Name of the service account to create or use
     name: "composio-apollo"
     # -- Annotations to add to the service account
@@ -395,6 +397,8 @@ thermos:
   serviceAccount:
     # -- Enable service account creation
     enabled: false
+    # -- Create the service account. Set to false to use an existing service account
+    create: true
     # -- Name of the service account to create or use
     name: "composio-thermos"
     # -- Annotations to add to the service account
@@ -1045,6 +1049,8 @@ mercury:
   serviceAccount:
     # -- Enable service account creation
     enabled: false
+    # -- Create the service account. Set to false to use an existing service account
+    create: true
     # -- Name of the service account to create or use
     name: "composio-mercury"
     # -- Annotations to add to the service account
@@ -1172,6 +1178,8 @@ frontend:
   serviceAccount:
     # -- Enable service account creation
     enabled: false
+    # -- Create the service account. Set to false to use an existing service account
+    create: true
     # -- Name of the service account to create or use
     name: "composio-frontend"
     # -- Annotations to add to the service account
@@ -1240,6 +1248,8 @@ weaviate:
   serviceAccount:
     # -- Enable service account creation
     enabled: false
+    # -- Create the service account. Set to false to use an existing service account
+    create: true
     # -- Name of the service account to create or use
     name: "composio-weaviate"
     # -- Annotations to add to the service account

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -398,7 +398,7 @@ thermos:
     # -- Enable service account creation
     enabled: false
     # -- Create the service account. Set to false to use an existing service account
-    create: true
+    create: false
     # -- Name of the service account to create or use
     name: "composio-thermos"
     # -- Annotations to add to the service account
@@ -1050,7 +1050,7 @@ mercury:
     # -- Enable service account creation
     enabled: false
     # -- Create the service account. Set to false to use an existing service account
-    create: true
+    create: false
     # -- Name of the service account to create or use
     name: "composio-mercury"
     # -- Annotations to add to the service account
@@ -1179,7 +1179,7 @@ frontend:
     # -- Enable service account creation
     enabled: false
     # -- Create the service account. Set to false to use an existing service account
-    create: true
+    create: false
     # -- Name of the service account to create or use
     name: "composio-frontend"
     # -- Annotations to add to the service account
@@ -1249,7 +1249,7 @@ weaviate:
     # -- Enable service account creation
     enabled: false
     # -- Create the service account. Set to false to use an existing service account
-    create: true
+    create: false
     # -- Name of the service account to create or use
     name: "composio-weaviate"
     # -- Annotations to add to the service account


### PR DESCRIPTION
## Summary
- Adds a `create` field (default: `true`) to `serviceAccount` config for all services: `apollo`, `thermos`, `mercury`, `frontend`, `weaviate`
- Templates now gate SA creation on `enabled && create`, so setting `create: false` skips resource creation while still using the provided `name`
- No breaking change — existing deployments default to `create: true` and behavior is unchanged

## Usage
To bring an existing service account:
```yaml
apollo:
  serviceAccount:
    enabled: true
    create: false
    name: "my-existing-sa"
```

## Test plan
- [ ] `helm template` with default values renders SA resources as before
- [ ] `helm template` with `serviceAccount.create: false` omits the SA resource but the deployment still references the name

🤖 Generated with [Claude Code](https://claude.com/claude-code)