### PR TITLE
feat: add optional TRIGGER_ENCRYPTION_KEY support for thermos

### DIFF
--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -107,6 +107,18 @@ spec:
                   name: {{ $coreSecret }}
                   key: THERMOS_DATABASE_URL
                   optional: true
+            - name: POLLING_TRIGGER_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $coreSecret }}
+                  key: TRIGGER_ENCRYPTION_KEY
+                  optional: true
+            - name: WEBHOOK_PAYLOAD_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $coreSecret }}
+                  key: TRIGGER_ENCRYPTION_KEY
+                  optional: true
             {{- if .Values.thermos.env }}
             {{- toYaml .Values.thermos.env | nindent 12 }}
             {{- end }}

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -111,13 +111,13 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ $coreSecret }}
-                  key: TRIGGER_ENCRYPTION_KEY
+                  key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
                   optional: true
             - name: WEBHOOK_PAYLOAD_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ $coreSecret }}
-                  key: TRIGGER_ENCRYPTION_KEY
+                  key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
                   optional: true
             {{- if .Values.thermos.env }}
             {{- toYaml .Values.thermos.env | nindent 12 }}


### PR DESCRIPTION
# Description
Adds support for mapping the existing `TEMPORAL_TRIGGER_ENCRYPTION_KEY` from `composio-secrets` to two thermos environment variables:
- `POLLING_TRIGGER_ENCRYPTION_KEY` — used for polling trigger payload encryption
- `WEBHOOK_PAYLOAD_ENCRYPTION_KEY` — used for webhook payload encryption

Both reference `TEMPORAL_TRIGGER_ENCRYPTION_KEY` (the chart's established secret key name, consistent with helpers, preflight checks, and docs). The `optional: true` flag ensures existing deployments without this key continue to work.

# How did I test this PR
- Verified YAML indentation is consistent with existing secret references in the template
- Confirmed the pattern matches existing `secretKeyRef` usage (`COMPOSIO_ADMIN_TOKEN`, `THERMOS_DATABASE_URL`)
- Verified `TEMPORAL_TRIGGER_ENCRYPTION_KEY` is the correct key name per `_helpers.tpl`, `preflight-config.yaml`, and docs
- CI: helm lint, template validation, and unit tests all pass

Triggered by: utkarsh@composio.dev | Source: web
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-d4c7e6a92367