### PR TITLE
feat: add scheduling and image flexibility to otel-collector

### DIFF
--- a/composio/templates/otel-collector.yaml
+++ b/composio/templates/otel-collector.yaml
@@ -73,14 +73,24 @@ spec:
       {{- end }}
       {{- if .Values.otel.collector.googleCloud.serviceAccount.create }}
       serviceAccountName: {{ .Release.Name }}-{{ .Values.otel.collector.googleCloud.serviceAccount.name }}
+      {{- else if .Values.otel.collector.serviceAccountName }}
+      serviceAccountName: {{ .Values.otel.collector.serviceAccountName }}
       {{- end }}
       {{- with .Values.otel.collector.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.otel.collector.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.otel.collector.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: otel-collector
-          image: "{{ .Values.otel.collector.image.repository }}:{{ .Values.otel.collector.image.tag }}"
+          image: "{{ .Values.otel.collector.image.imageName | default (printf "%s:%s" .Values.otel.collector.image.repository .Values.otel.collector.image.tag) }}"
           imagePullPolicy: {{ .Values.otel.collector.image.pullPolicy }}
           {{- with .Values.otel.collector.containerSecurityContext }}
           securityContext:

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -808,8 +808,16 @@ otel:
       repository: otel/opentelemetry-collector-contrib
       # -- Collector image tag
       tag: "0.91.0"
+      # -- Full image name (overrides repository:tag when set)
+      imageName: ""
       # -- Image pull policy
       pullPolicy: IfNotPresent
+    # -- Existing service account name (used when googleCloud.serviceAccount.create is false)
+    serviceAccountName: ""
+    # -- Node selector for collector pods
+    nodeSelector: {}
+    # -- Tolerations for collector pods
+    tolerations: []
     # Collector service configuration
     service:
       # -- Service type


### PR DESCRIPTION
## Summary

Adds optional scheduling and image configuration to the otel-collector deployment:

- **`serviceAccountName`**: Use a pre-existing service account when `googleCloud.serviceAccount.create` is `false` (e.g. GKE Workload Identity)
- **`nodeSelector`** / **`tolerations`**: Schedule collector pods on dedicated node pools
- **`image.imageName`**: Override the default `repository:tag` pattern with a full image URI

## Backward compatibility

All fields are optional with safe defaults that preserve existing behavior:

| Field | Default | Effect when unset |
|-------|---------|-------------------|
| `serviceAccountName` | `""` | No SA set (unchanged) |
| `nodeSelector` | `{}` | No node affinity (unchanged) |
| `tolerations` | `[]` | No tolerations (unchanged) |
| `image.imageName` | `""` | Falls through to `repository:tag` (unchanged) |

## Test plan

- [ ] `helm template composio composio/ --debug` renders without errors
- [ ] `helm lint composio/` passes
- [ ] Existing deployments without these fields behave identically
- [ ] Setting `otel.collector.serviceAccountName=my-sa` injects the SA into the pod spec
- [ ] Setting `otel.collector.nodeSelector` and `tolerations` produces correct pod scheduling
- [ ] Setting `otel.collector.image.imageName` overrides the image reference