### PR TITLE
Disable telemetry for weaviate

### DIFF
--- a/composio/templates/weaviate/weaviate.yaml
+++ b/composio/templates/weaviate/weaviate.yaml
@@ -64,6 +64,8 @@ spec:
           env:
             - name: AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED
               value: {{ .Values.weaviate.auth.anonymousAccess | default "true" | quote }}
+            - name: DISABLE_TELEMETRY
+              value: true
             - name: PERSISTENCE_DATA_PATH
               value: "/var/lib/weaviate"
             - name: DEFAULT_VECTORIZER_MODULE


### PR DESCRIPTION
Disable telemetry that is enabled by weaviate by default - https://docs.weaviate.io/deploy/configuration/telemetry