### PR TITLE
chore: add thermos-toolkit-registry to nightly release workflow

### DIFF
--- a/.github/workflows/nighty-release.yml
+++ b/.github/workflows/nighty-release.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: "latest"
+      thermos_toolkit_registry_image_tag:
+        description: "ECR source tag for thermos-toolkit-registry (default latest)."
+        required: false
+        type: string
+        default: "latest"
 
 permissions:
   contents: write
@@ -54,7 +59,7 @@ jobs:
       retagged_images: ${{ steps.retag.outputs.retagged_images }}
     env:
       AWS_REGION: ${{ secrets.AWS_REGION }}
-      IMAGE_REPOS: "apollo frontend apollo-db-init thermos thermos-db-init mercury weaviate"
+      IMAGE_REPOS: "apollo frontend apollo-db-init thermos thermos-db-init mercury weaviate thermos-toolkit-registry"
       # Per-repo ECR source tags (manual runs only; empty on schedule). Empty = use "latest".
       SOURCE_TAG_APOLLO: ${{ github.event.inputs.apollo_image_tag || '' }}
       SOURCE_TAG_APOLLO_DB_INIT: ${{ github.event.inputs.apollo_db_init_image_tag || '' }}
@@ -63,6 +68,7 @@ jobs:
       SOURCE_TAG_MERCURY: ${{ github.event.inputs.mercury_image_tag || '' }}
       SOURCE_TAG_FRONTEND: ${{ github.event.inputs.frontend_image_tag || '' }}
       SOURCE_TAG_WEAVIATE: ${{ github.event.inputs.weaviate_image_tag || '' }}
+      SOURCE_TAG_THERMOS_TOOLKIT_REGISTRY: ${{ github.event.inputs.thermos_toolkit_registry_image_tag || '' }}
     permissions:
       id-token: write
     steps:
@@ -176,6 +182,7 @@ jobs:
               mercury) v="${SOURCE_TAG_MERCURY:-}" ;;
               frontend) v="${SOURCE_TAG_FRONTEND:-}" ;;
               weaviate) v="${SOURCE_TAG_WEAVIATE:-}" ;;
+              thermos-toolkit-registry) v="${SOURCE_TAG_THERMOS_TOOLKIT_REGISTRY:-}" ;;
               *) v="" ;;
             esac
             if [[ -n "${v}" ]]; then
@@ -358,6 +365,7 @@ jobs:
           yq eval -i '.mercury.image.tag = strenv(RELEASE_TAG)' ./values.yaml
           yq eval -i '.frontend.image.tag = strenv(RELEASE_TAG)' ./values.yaml
           yq eval -i '.weaviate.image.tag = strenv(RELEASE_TAG)' ./values.yaml
+          yq eval -i '.toolkitRegistry.image.tag = strenv(RELEASE_TAG)' ./values.yaml
           cd -
 
           cd ./manifests


### PR DESCRIPTION
# Description
Include the new `thermos-toolkit-registry` ECR image in the nightly release pipeline. PR #231 adds a toolkit registry component (`composio-self-host/thermos-toolkit-registry`) to the Helm chart; this PR ensures the nightly release workflow also retags and updates that image alongside the existing service images.

Changes to `.github/workflows/nighty-release.yml`:
- Add `thermos_toolkit_registry_image_tag` workflow_dispatch input for manual override
- Add `thermos-toolkit-registry` to `IMAGE_REPOS` list for ECR retagging
- Add `SOURCE_TAG_THERMOS_TOOLKIT_REGISTRY` env var and `resolve_source_tag` case
- Add `yq` command to update `toolkitRegistry.image.tag` in `values.yaml`

Depends on #231 (which adds the `toolkitRegistry` section to `values.yaml`).

# How did I test this PR
- Reviewed the workflow YAML for consistency with existing image patterns (apollo, thermos, mercury, etc.)
- Verified the `yq` path (`toolkitRegistry.image.tag`) matches the `values.yaml` key added in PR #231
- Confirmed all four integration points (input, env var, resolve function, yq update) are wired correctly

Triggered by: Utkarsh Dixit utkarsh@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-8e989edd7635