### PR TITLE
Set default THERMOS_MODE to all in chart config

### DIFF
--- a/composio/templates/thermos/thermos-config.yaml
+++ b/composio/templates/thermos/thermos-config.yaml
@@ -5,6 +5,7 @@ metadata:
 data:
   PORT: "8180"
   HOST: "0.0.0.0"
+  THERMOS_MODE: "all"
   APOLLO_ENDPOINT: {{ printf "http://%s-apollo:9900" .Release.Name | quote }}
   COMPOSIO_ENV: "production"
   LOG_ENCODING: "json"

--- a/composio/templates/thermos/thermos-misc-workers.yaml
+++ b/composio/templates/thermos/thermos-misc-workers.yaml
@@ -137,7 +137,7 @@ spec:
                   optional: true
             {{- if .Values.toolkitRegistry.enabled }}
             - name: TOOLKIT_REGISTRY_DB_URL
-              value: {{ printf "postgresql://%s:%s@%s-toolkit-registry:%v/%s?sslmode=disable" .Values.toolkitRegistry.auth.username .Values.toolkitRegistry.auth.password .Release.Name (.Values.toolkitRegistry.service.port | int) .Values.toolkitRegistry.database.name | quote }}
+              value: {{ printf "postgresql://%s@%s-toolkit-registry:%v/%s?sslmode=disable" .Values.toolkitRegistry.auth.username .Release.Name (.Values.toolkitRegistry.service.port | int) .Values.toolkitRegistry.database.name | quote }}
             {{- end }}
             {{- if .Values.thermosMiscWorkers.env }}
             {{- toYaml .Values.thermosMiscWorkers.env | nindent 12 }}

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -132,7 +132,7 @@ spec:
                   optional: true
             {{- if .Values.toolkitRegistry.enabled }}
             - name: TOOLKIT_REGISTRY_DB_URL
-              value: {{ printf "postgresql://%s:%s@%s-toolkit-registry:%v/%s?sslmode=disable" .Values.toolkitRegistry.auth.username .Values.toolkitRegistry.auth.password .Release.Name (.Values.toolkitRegistry.service.port | int) .Values.toolkitRegistry.database.name | quote }}
+              value: {{ printf "postgresql://%s@%s-toolkit-registry:%v/%s?sslmode=disable" .Values.toolkitRegistry.auth.username .Release.Name (.Values.toolkitRegistry.service.port | int) .Values.toolkitRegistry.database.name | quote }}
             {{- end }}
             {{- if .Values.thermos.env }}
             {{- toYaml .Values.thermos.env | nindent 12 }}

--- a/composio/tests/thermos_configmap_test.yaml
+++ b/composio/tests/thermos_configmap_test.yaml
@@ -1,0 +1,17 @@
+suite: test thermos configmap
+templates:
+  - thermos/thermos-config.yaml
+tests:
+  - it: should create thermos configmap
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-thermos-config
+
+  - it: should default the main thermos mode to all
+    asserts:
+      - equal:
+          path: data.THERMOS_MODE
+          value: "all"

--- a/composio/tests/thermos_test.yaml
+++ b/composio/tests/thermos_test.yaml
@@ -225,7 +225,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: TOOLKIT_REGISTRY_DB_URL
-            value: postgresql://registry_reader:registry_reader@RELEASE-NAME-toolkit-registry:5432/thermos?sslmode=disable
+            value: postgresql://registry_reader@RELEASE-NAME-toolkit-registry:5432/thermos?sslmode=disable
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-toolkit-registry
@@ -371,7 +371,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: TOOLKIT_REGISTRY_DB_URL
-            value: postgresql://registry_reader:registry_reader@RELEASE-NAME-toolkit-registry:5432/thermos?sslmode=disable
+            value: postgresql://registry_reader@RELEASE-NAME-toolkit-registry:5432/thermos?sslmode=disable
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-toolkit-registry


### PR DESCRIPTION
# Description
- set `THERMOS_MODE` to `all` in the shared Thermos configmap used by the main Thermos deployment
- leave misc workers unchanged, since they already override `THERMOS_MODE` to `miscellaneous_worker` in the deployment
- add a focused configmap chart test for the default Thermos mode

# How did I test this PR
- `cd composio && ./run-tests.sh thermos`
- `git diff --check origin/release-stable...HEAD`