### PR TITLE
feat(thermos-db-init): pass TOOLKIT_REGISTRY_ENABLED env (IMIN-354)

### DIFF
--- a/composio/templates/thermos/thermos-db-init-job.yaml
+++ b/composio/templates/thermos/thermos-db-init-job.yaml
@@ -80,6 +80,12 @@ spec:
                   optional: true
             - name: ADMIN_EMAIL
               value: {{ .Values.dbInit.adminEmail | default "hello@composio.dev" | quote }}
+            # When toolkit-registry sidecar is enabled (default), thermos-db-init
+            # runs Atlas migrations only — toolkit data is served by the standalone
+            # thermos-toolkit-registry Postgres. When disabled, the init container
+            # restores the SQL dump baked into the image into DATABASE_URL.
+            - name: TOOLKIT_REGISTRY_ENABLED
+              value: {{ .Values.toolkitRegistry.enabled | quote }}
             {{- if .Values.thermos.dbInit.extraAtlasFlags }}
             - name: EXTRA_ATLAS_FLAGS
               value: {{ .Values.thermos.dbInit.extraAtlasFlags | quote }}

--- a/composio/templates/thermos/thermos-db-init-job.yaml
+++ b/composio/templates/thermos/thermos-db-init-job.yaml
@@ -80,12 +80,22 @@ spec:
                   optional: true
             - name: ADMIN_EMAIL
               value: {{ .Values.dbInit.adminEmail | default "hello@composio.dev" | quote }}
-            # When toolkit-registry sidecar is enabled (default), thermos-db-init
-            # runs Atlas migrations only — toolkit data is served by the standalone
-            # thermos-toolkit-registry Postgres. When disabled, the init container
-            # restores the SQL dump baked into the image into DATABASE_URL.
+            # When toolkit-registry sidecar is enabled (default), the
+            # thermos-db-init job runs Atlas migrations only — toolkit data is
+            # served by the standalone thermos-toolkit-registry Postgres. When
+            # disabled, the db-init container also restores the SQL dump baked
+            # into the image into DATABASE_URL.
+            #
+            # Defaults to "true" when the toolkitRegistry stanza is absent.
+            # Note: `default true X` doesn't help here because Helm's default
+            # treats `false` as the zero value, so `false` would round-trip to
+            # `true`. Use explicit hasKey instead.
+            {{- $registryEnabled := true -}}
+            {{- if and .Values.toolkitRegistry (hasKey .Values.toolkitRegistry "enabled") -}}
+              {{- $registryEnabled = .Values.toolkitRegistry.enabled -}}
+            {{- end }}
             - name: TOOLKIT_REGISTRY_ENABLED
-              value: {{ .Values.toolkitRegistry.enabled | quote }}
+              value: {{ $registryEnabled | quote }}
             {{- if .Values.thermos.dbInit.extraAtlasFlags }}
             - name: EXTRA_ATLAS_FLAGS
               value: {{ .Values.thermos.dbInit.extraAtlasFlags | quote }}

--- a/composio/tests/db_init_test.yaml
+++ b/composio/tests/db_init_test.yaml
@@ -429,6 +429,17 @@ tests:
             name: TOOLKIT_REGISTRY_ENABLED
             value: "false"
 
+  - it: should default TOOLKIT_REGISTRY_ENABLED=true when toolkitRegistry stanza is omitted
+    set:
+      thermos.dbInit.enabled: true
+      toolkitRegistry: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_ENABLED
+            value: "true"
+
 ---
 suite: test postgres init job
 templates:

--- a/composio/tests/db_init_test.yaml
+++ b/composio/tests/db_init_test.yaml
@@ -408,6 +408,27 @@ tests:
           path: spec.activeDeadlineSeconds
           value: 2400
 
+  - it: should set TOOLKIT_REGISTRY_ENABLED=true by default
+    set:
+      thermos.dbInit.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_ENABLED
+            value: "true"
+
+  - it: should set TOOLKIT_REGISTRY_ENABLED=false when toolkitRegistry is disabled
+    set:
+      thermos.dbInit.enabled: true
+      toolkitRegistry.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_ENABLED
+            value: "false"
+
 ---
 suite: test postgres init job
 templates:


### PR DESCRIPTION
# Description

Adds the helm wiring for [IMIN-354](https://linear.app/composio/issue/IMIN-354/restore-thermos-db-init-behavior-in-non-registry-mode). Companion to [hermes #9660](https://github.com/ComposioHQ/hermes/pull/9660) which makes the matching change in \`apps/thermos/onprem/start.sh\` so the new env var has an effect.

The thermos-db-init Job now receives \`TOOLKIT_REGISTRY_ENABLED\` derived from \`.Values.toolkitRegistry.enabled\` (default \`true\`):

- \`true\`: db-init runs Atlas migrations only — toolkit data is served by the standalone toolkit-registry Postgres sidecar (current behavior, no change for existing installs).
- \`false\`: db-init runs migrations and then \`psql -f\` the SQL dump baked into the image to populate \`DATABASE_URL\` directly, so deployments without the registry sidecar get toolkit data colocated with their primary Thermos DB.

Note: the dump is only baked into the image when the hermes-side build passes \`SOURCE_DB\` (production self-hosted CI does this; local dev builds bake an empty placeholder). When \`TOOLKIT_REGISTRY_ENABLED=false\` and the dump is empty, \`start.sh\` logs a warning and skips the restore — no breakage.

## Sequencing

This PR is safe to land before the new image is built. Older db-init images simply ignore the new env var; behavior is unchanged. The new behavior only kicks in once an image built from hermes #9660 is referenced via \`thermos.dbInit.image.tag\` (a separate follow-up PR will bump the tag once the self-hosted release lands).

## Files changed

- \`composio/templates/thermos/thermos-db-init-job.yaml\` — adds the new env var with a comment explaining the dual mode.
- \`composio/tests/db_init_test.yaml\` — adds two unit tests: \`TOOLKIT_REGISTRY_ENABLED=true\` by default, \`false\` when \`toolkitRegistry.enabled=false\`.

# How did I test this PR

- \`helm lint composio/\` — clean.
- \`helm unittest composio/ -f tests/db_init_test.yaml\` — 43/43 passing including the two new cases.
- \`helm template\` rendered with \`toolkitRegistry.enabled=false\` confirms:
  - thermos-db-init Job env contains \`TOOLKIT_REGISTRY_ENABLED=\"false\"\`
  - No toolkit-registry Deployment is rendered (count = 0)
  - Thermos has no \`wait-for-toolkit-registry\` init container
  - Thermos has no \`TOOLKIT_REGISTRY_DB_URL\` env var
- Default-mode render unchanged: \`TOOLKIT_REGISTRY_ENABLED=\"true\"\`, registry Deployment + init container + env var all still present.
- E2E: a new optional \`non-registry-mode\` scenario in [onprem-testbed#TBD](#) installs this chart with \`toolkitRegistry.enabled=false\`, asserts toolkit row counts in the destination Postgres, and runs HACKERNEWS_GET_FRONTPAGE end-to-end. It is gated by the new \`include_optional_scenarios\` workflow input — run it via \`replicated-cmx-harness\` before cutting a release.

**Pre-existing CI:** \`Lint Charts\` is red on every PR/merge to \`release-stable\` since #244 (image-tag mismatch in \`thermos_test.yaml\`). Not related to this change — flagged here so reviewers don't try to fix it.