### PR TITLE
feat: add nodeSelector and tolerations to toolkit-registry

### DIFF
--- a/composio/templates/thermos/toolkit-registry.yaml
+++ b/composio/templates/thermos/toolkit-registry.yaml
@@ -31,6 +31,14 @@ spec:
       initContainers:
 {{ tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
+      {{- with .Values.toolkitRegistry.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.toolkitRegistry.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: toolkit-registry
           image: {{ include "composio.imageReference" (dict "image" .Values.toolkitRegistry.image "context" .) | quote }}

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -503,6 +503,10 @@ toolkitRegistry:
   initContainers: []
   # -- Additional environment variables for toolkit registry pods
   env: []
+  # -- Node selector for toolkit registry pods
+  nodeSelector: {}
+  # -- Tolerations for toolkit registry pods
+  tolerations: []
   resources:
     requests:
       cpu: "250m"


### PR DESCRIPTION
Adds optional nodeSelector and tolerations fields to the toolkit-registry deployment, mirroring #209.