### PR TITLE
feat(thermos): bound toolkit-registry wait and log on success

### DIFF
--- a/composio/templates/thermos/thermos-misc-workers.yaml
+++ b/composio/templates/thermos/thermos-misc-workers.yaml
@@ -60,7 +60,19 @@ spec:
           command:
             - sh
             - -c
-            - until pg_isready -h {{ .Release.Name }}-toolkit-registry -p {{ .Values.toolkitRegistry.service.port | int }} -U {{ .Values.toolkitRegistry.auth.username }} -d {{ .Values.toolkitRegistry.database.name }}; do echo "waiting for toolkit registry"; sleep 2; done
+            - |
+              i=0
+              max_attempts=60
+              until pg_isready -h {{ .Release.Name }}-toolkit-registry -p {{ .Values.toolkitRegistry.service.port | int }} -U {{ .Values.toolkitRegistry.auth.username }} -d {{ .Values.toolkitRegistry.database.name }}; do
+                i=$((i+1))
+                if [ "$i" -ge "$max_attempts" ]; then
+                  echo "toolkit registry not ready after $max_attempts attempts, giving up"
+                  exit 1
+                fi
+                echo "waiting for toolkit registry (attempt $i/$max_attempts)"
+                sleep 2
+              done
+              echo "toolkit registry is ready after $i attempt(s)"
         {{- end }}
         {{- with .Values.thermosMiscWorkers.additionalInitContainers }}
 {{ tpl (toYaml .) $ | nindent 8 }}

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -59,7 +59,19 @@ spec:
           command:
             - sh
             - -c
-            - until pg_isready -h {{ .Release.Name }}-toolkit-registry -p {{ .Values.toolkitRegistry.service.port | int }} -U {{ .Values.toolkitRegistry.auth.username }} -d {{ .Values.toolkitRegistry.database.name }}; do echo "waiting for toolkit registry"; sleep 2; done
+            - |
+              i=0
+              max_attempts=60
+              until pg_isready -h {{ .Release.Name }}-toolkit-registry -p {{ .Values.toolkitRegistry.service.port | int }} -U {{ .Values.toolkitRegistry.auth.username }} -d {{ .Values.toolkitRegistry.database.name }}; do
+                i=$((i+1))
+                if [ "$i" -ge "$max_attempts" ]; then
+                  echo "toolkit registry not ready after $max_attempts attempts, giving up"
+                  exit 1
+                fi
+                echo "waiting for toolkit registry (attempt $i/$max_attempts)"
+                sleep 2
+              done
+              echo "toolkit registry is ready after $i attempt(s)"
         {{- end }}
         {{- with .Values.thermos.additionalInitContainers }}
 {{ tpl (toYaml .) $ | nindent 8 }}

--- a/composio/tests/thermos_test.yaml
+++ b/composio/tests/thermos_test.yaml
@@ -233,6 +233,30 @@ tests:
           path: spec.template.spec.initContainers[0].image
           pattern: ".*/composio-self-host/thermos-toolkit-registry:[^/]+$"
 
+  - it: should bound the toolkit registry wait and log on success
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].command[0]
+          value: sh
+      - equal:
+          path: spec.template.spec.initContainers[0].command[1]
+          value: -c
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "max_attempts=60"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "toolkit registry not ready after \\$max_attempts attempts, giving up"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "exit 1"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "toolkit registry is ready after \\$i attempt\\(s\\)"
+
   - it: should append thermos additional init containers after toolkit registry wait
     documentSelector:
       path: kind
@@ -390,3 +414,26 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[1].name
           value: custom-misc-init
+
+  - it: should bound the misc worker toolkit registry wait and log on success
+    set:
+      thermosMiscWorkers.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].command[0]
+          value: sh
+      - equal:
+          path: spec.template.spec.initContainers[0].command[1]
+          value: -c
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "max_attempts=60"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "toolkit registry not ready after \\$max_attempts attempts, giving up"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "exit 1"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "toolkit registry is ready after \\$i attempt\\(s\\)"


### PR DESCRIPTION
# Description

The thermos pods (Apollo-facing thermos + thermos-misc-workers) use a `wait-for-toolkit-registry` init container that polls the toolkit-registry Postgres with an unbounded `until pg_isready ... ; sleep 2; done` loop. There are two problems:

1. **No success signal.** When the loop exits, the next thing in the logs is whatever the main `thermos` container prints — there's nothing in the init container's own logs confirming the wait actually finished, only a stream of `waiting for toolkit registry` lines that abruptly stops.
2. **No upper bound.** If the toolkit registry is genuinely broken / unreachable, the init container loops forever and the pod just sits in `Init:0/1` without ever surfacing a failure, so the deployment never rolls back or fires liveness/readiness alerts.

This PR:

- Caps the wait at **60 attempts × 2s = ~120s**, exiting non-zero with `toolkit registry not ready after $max_attempts attempts, giving up` when exceeded. Kubernetes will restart the init container per the pod's restart policy, surfacing the failure in pod status and events.
- Logs `toolkit registry is ready after $i attempt(s)` once `pg_isready` succeeds, so the success transition is visible in `kubectl logs <pod> -c wait-for-toolkit-registry`.
- Counter messages now include `(attempt $i/$max_attempts)` so each line is useful on its own.

Applied to both `thermos.yaml` and `thermos-misc-workers.yaml`.

# How did I test this PR

- `helm lint composio/` → clean (only the pre-existing icon-recommended INFO).
- `helm template . --debug --dry-run` (default values and with `thermosMiscWorkers.enabled=true`) → renders without error.
- Verified rendered manifests by hand:
  ```
  - sh
  - -c
  - |
    i=0
    max_attempts=60
    until pg_isready -h my-release-toolkit-registry -p 5432 -U registry_reader -d thermos; do
      i=$((i+1))
      if [ "$i" -ge "$max_attempts" ]; then
        echo "toolkit registry not ready after $max_attempts attempts, giving up"
        exit 1
      fi
      echo "waiting for toolkit registry (attempt $i/$max_attempts)"
      sleep 2
    done
    echo "toolkit registry is ready after $i attempt(s)"
  ```
- `helm unittest . -f 'tests/*_test.yaml'` → **321 tests pass across 45 suites** (including 2 new assertions covering the bounded wait + success-log for both deployments).

Triggered by: Rohan Prabhu rohan.prabhu@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-501f4606354b