### PR TITLE
feat: add affinity to toolkit-registry + lint scheduling on every chart pod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,9 @@ jobs:
           helm dependency update
           helm template . --debug --dry-run
 
+      - name: Lint pod scheduling (affinity + tolerations)
+        run: python3 composio/scripts/lint_pod_scheduling.py
+
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 0.7.2
 

--- a/composio/scripts/lint_pod_scheduling.py
+++ b/composio/scripts/lint_pod_scheduling.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Lint check: every Deployment / StatefulSet / DaemonSet in this chart must
+expose both `affinity` and `tolerations` so operators can pin or repel pods.
+
+Scans the first-party templates under composio/templates/ (subcharts under
+composio/charts/ are vendored and excluded). For each pod-bearing kind the
+template must contain a Helm-guarded block of the form:
+
+    {{- with .Values.<path>.affinity }}
+    affinity:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+
+and the equivalent `tolerations:` block. The check is intentionally textual
+(rather than rendering with `helm template`) because the `with` guards omit
+the field entirely when the value is empty -- which is the default -- so a
+rendered-output check would silently pass for templates that lack the block.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+POD_KIND_RE = re.compile(r"^kind:\s+(Deployment|StatefulSet|DaemonSet)\s*$", re.MULTILINE)
+AFFINITY_RE = re.compile(r"^\s*affinity:\s*$", re.MULTILINE)
+TOLERATIONS_RE = re.compile(r"^\s*tolerations:\s*$", re.MULTILINE)
+
+
+def find_chart_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in [here.parent, *here.parents]:
+        if (parent / "Chart.yaml").exists():
+            return parent
+    raise SystemExit("could not locate chart root (Chart.yaml) above this script")
+
+
+def template_files(chart_root: Path) -> list[Path]:
+    return sorted(p for p in (chart_root / "templates").rglob("*.yaml") if p.is_file())
+
+
+def check_template(path: Path) -> list[str]:
+    text = path.read_text()
+    if not POD_KIND_RE.search(text):
+        return []
+    failures: list[str] = []
+    if not AFFINITY_RE.search(text):
+        failures.append("missing pod-spec `affinity:` block")
+    if not TOLERATIONS_RE.search(text):
+        failures.append("missing pod-spec `tolerations:` block")
+    return failures
+
+
+def main() -> int:
+    chart_root = find_chart_root()
+    failures: dict[Path, list[str]] = {}
+    checked = 0
+    for path in template_files(chart_root):
+        problems = check_template(path)
+        if problems is None:
+            continue
+        if POD_KIND_RE.search(path.read_text()):
+            checked += 1
+            if problems:
+                failures[path] = problems
+
+    if failures:
+        print("Pod scheduling lint FAILED:")
+        for path, problems in failures.items():
+            rel = path.relative_to(chart_root.parent)
+            for problem in problems:
+                print(f"  {rel}: {problem}")
+        print(
+            "\nEvery Deployment/StatefulSet/DaemonSet must expose both `affinity` and "
+            "`tolerations` via a `{{- with .Values.<path>.affinity }}` / `tolerations` "
+            "block so operators can pin or repel pods."
+        )
+        return 1
+
+    print(f"Pod scheduling lint OK ({checked} workload templates checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/composio/templates/otel-collector.yaml
+++ b/composio/templates/otel-collector.yaml
@@ -84,6 +84,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.otel.collector.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.otel.collector.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/composio/templates/thermos/toolkit-registry.yaml
+++ b/composio/templates/thermos/toolkit-registry.yaml
@@ -35,6 +35,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.toolkitRegistry.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.toolkitRegistry.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/composio/tests/otel_collector_test.yaml
+++ b/composio/tests/otel_collector_test.yaml
@@ -110,3 +110,24 @@ tests:
             operator: Equal
             value: telemetry
             effect: NoSchedule
+
+  - it: should apply affinity when configured
+    set:
+      otel.enabled: true
+      otel.collector.enabled: true
+      otel.collector.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: kubernetes.io/arch

--- a/composio/tests/thermos_test.yaml
+++ b/composio/tests/thermos_test.yaml
@@ -380,6 +380,36 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should apply nodeSelector, affinity, and tolerations to toolkit registry pod
+    documentIndex: 0
+    set:
+      toolkitRegistry.nodeSelector:
+        disktype: ssd
+      toolkitRegistry.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+      toolkitRegistry.tolerations:
+        - key: dedicated
+          operator: Equal
+          value: toolkit-registry
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: kubernetes.io/arch
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: dedicated
+
 ---
 suite: test thermos misc workers deployment
 templates:

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -505,6 +505,8 @@ toolkitRegistry:
   env: []
   # -- Node selector for toolkit registry pods
   nodeSelector: {}
+  # -- Affinity rules for toolkit registry pods
+  affinity: {}
   # -- Tolerations for toolkit registry pods
   tolerations: []
   resources:

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -917,6 +917,8 @@ otel:
     serviceAccountName: ""
     # -- Node selector for collector pods
     nodeSelector: {}
+    # -- Affinity rules for collector pods
+    affinity: {}
     # -- Tolerations for collector pods
     tolerations: []
     # Collector service configuration


### PR DESCRIPTION
# Description

This PR has two parts:

## 1. Add `affinity` support to the toolkit-registry pod

Mirrors the existing `nodeSelector` / `tolerations` support added in #263 by exposing an optional `affinity` field on the `toolkit-registry` deployment, matching the order used in `thermos.yaml` (`nodeSelector → affinity → tolerations`). Operators running the registry on dedicated nodes can now express required/preferred affinity rules instead of relying on `nodeSelector` + `tolerations` alone.

## 2. Lint check + CI gate enforcing scheduling fields on every pod

Adds `composio/scripts/lint_pod_scheduling.py` — a zero-dependency Python script that scans first-party chart templates and **fails the build if any `Deployment` / `StatefulSet` / `DaemonSet` is missing either an `affinity:` or `tolerations:` block in its pod spec.** The check is text-based rather than render-based: with `{{- with .Values.<path>.affinity }}` guards, the field is omitted when the default is empty, which would silently pass a render-only check.

Wired into the existing required `lint-test` job in `.github/workflows/ci.yaml` (runs on `pull_request`), so missing scheduling fields will block merge.

While adding the lint, found that `templates/otel-collector.yaml` had `tolerations` but no `affinity` — added it so the new check passes, and added a unit test for `otel.collector.affinity` rendering.

### Files changed

- `composio/templates/thermos/toolkit-registry.yaml` — render `affinity:` from `.Values.toolkitRegistry.affinity`.
- `composio/templates/otel-collector.yaml` — render `affinity:` from `.Values.otel.collector.affinity`.
- `composio/values.yaml` — new `toolkitRegistry.affinity: {}` and `otel.collector.affinity: {}` values.
- `composio/scripts/lint_pod_scheduling.py` — new lint script.
- `.github/workflows/ci.yaml` — new `Lint pod scheduling (affinity + tolerations)` step in the existing `lint-test` job.
- `composio/tests/thermos_test.yaml` — unit test for toolkit-registry `nodeSelector`/`affinity`/`tolerations`.
- `composio/tests/otel_collector_test.yaml` — unit test for otel-collector affinity.

# How did I test this PR

```
$ helm lint composio
1 chart(s) linted, 0 chart(s) failed

$ helm template composio > /dev/null
(clean exit)

$ python3 composio/scripts/lint_pod_scheduling.py
Pod scheduling lint OK (8 workload templates checked)

$ helm unittest composio -f 'tests/*_test.yaml'
Charts:      1 passed, 1 total
Test Suites: 45 passed, 45 total
Tests:       322 passed, 322 total
```

Negative-case verification: temporarily removed the `affinity` block from `otel-collector.yaml`, re-ran the lint, and confirmed it exits 1 with:
```
Pod scheduling lint FAILED:
  composio/templates/otel-collector.yaml: missing pod-spec `affinity:` block
```

Also rendered the toolkit-registry and otel-collector templates with `--set` overrides for `affinity.nodeAffinity...` and confirmed the `affinity:` block appears in the pod spec exactly as specified.

Triggered by: rohan.prabhu@composio.dev | Source: slack
Session: https://zen-api-production-4c98.up.railway.app/dashboard/#/chat/zen-6949a231f383