### PR TITLE
chore: Removed unused namespaces 'batched-polling' and 'webhook' from…

### DIFF
--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -658,10 +658,6 @@ temporal:
         namespace:
           - name: default
             retention: 7d
-          - name: batched-polling
-            retention: 10d
-          - name: webhook
-            retention: 10d
           - name: timer-shards
             retention: 10d
     # Temporal frontend service configuration


### PR DESCRIPTION
… values.yaml

Removed unused namespaces 'batched-polling' and 'webhook' from values.yaml.