### PR TITLE
feat: add per-service Apollo admin token env vars

### DIFF
--- a/composio/templates/apollo/apollo.yaml
+++ b/composio/templates/apollo/apollo.yaml
@@ -218,6 +218,18 @@ spec:
                   name: {{ $coreSecret }}
                   key: COMPOSIO_ADMIN_TOKEN
                   optional: true
+            - name: APOLLO_ADMIN_TOKEN_THERMOS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $coreSecret }}
+                  key: COMPOSIO_ADMIN_TOKEN
+                  optional: true
+            - name: APOLLO_ADMIN_TOKEN_MERCURY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $coreSecret }}
+                  key: COMPOSIO_ADMIN_TOKEN
+                  optional: true
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/composio/templates/mercury/mercury-service.yaml
+++ b/composio/templates/mercury/mercury-service.yaml
@@ -82,6 +82,12 @@ spec:
                   name: {{ $coreSecret }}
                   key: COMPOSIO_ADMIN_TOKEN
                   optional: true
+            - name: APOLLO_ADMIN_TOKEN_MERCURY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $coreSecret }}
+                  key: COMPOSIO_ADMIN_TOKEN
+                  optional: true
             - name: USE_APOLLO_GET_DOWNLOAD_URL_API
               value: "true"
             {{- with .Values.mercury.env }}

--- a/composio/templates/mercury/mercury.yaml
+++ b/composio/templates/mercury/mercury.yaml
@@ -93,6 +93,12 @@ spec:
                   name: {{ $coreSecret }}
                   key: COMPOSIO_ADMIN_TOKEN
                   optional: true
+            - name: APOLLO_ADMIN_TOKEN_MERCURY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $coreSecret }}
+                  key: COMPOSIO_ADMIN_TOKEN
+                  optional: true
             {{- if .Values.otel.enabled }}
             # OTEL Resource attributes
             - name: OTEL_RESOURCE_ATTRIBUTES

--- a/composio/templates/thermos/thermos-misc-workers.yaml
+++ b/composio/templates/thermos/thermos-misc-workers.yaml
@@ -126,6 +126,12 @@ spec:
                   name: {{ $coreSecret }}
                   key: COMPOSIO_ADMIN_TOKEN
                   optional: true
+            - name: APOLLO_ADMIN_TOKEN_THERMOS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $coreSecret }}
+                  key: COMPOSIO_ADMIN_TOKEN
+                  optional: true
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -121,6 +121,12 @@ spec:
                   name: {{ $coreSecret }}
                   key: COMPOSIO_ADMIN_TOKEN
                   optional: true
+            - name: APOLLO_ADMIN_TOKEN_THERMOS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $coreSecret }}
+                  key: COMPOSIO_ADMIN_TOKEN
+                  optional: true
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## What

Adds per-service Apollo admin token environment variables that mirror the existing `APOLLO_ADMIN_TOKEN`:

- **Apollo** (`apollo/apollo.yaml`): adds `APOLLO_ADMIN_TOKEN_THERMOS` and `APOLLO_ADMIN_TOKEN_MERCURY`
- **Mercury** (`mercury/mercury.yaml` + Knative `mercury/mercury-service.yaml`): adds `APOLLO_ADMIN_TOKEN_MERCURY`
- **Thermos** (`thermos/thermos.yaml` + `thermos/thermos-misc-workers.yaml`): adds `APOLLO_ADMIN_TOKEN_THERMOS`

## How

Each new var sources from the **same** `COMPOSIO_ADMIN_TOKEN` key in the core secret (`secret.name`, default `composio-composio-secrets`) with `optional: true`, exactly like the existing `APOLLO_ADMIN_TOKEN`. They therefore always carry the same value as `APOLLO_ADMIN_TOKEN` — no change to the secret itself is required.

All deployment variants are covered (standard + Knative for Mercury; main + misc-workers for Thermos).

## Validation

- `helm template` renders cleanly for both standard and Knative (`mercury.useKnative=true`) paths
- Confirmed no other YAML in the repo injects the admin token and was missed
- 5 files changed, +36 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)