### PR TITLE
fix: handle special db characters in helm chart

### DIFF
--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -77,21 +77,18 @@ false
 {{- end -}}
 {{- end -}}
 
-{{- define "composio.toolkitRegistryDbEnv" -}}
-- name: TOOLKIT_REGISTRY_DB_URL
-  value: {{ printf "postgresql://%s@%s-toolkit-registry:%v/%s?sslmode=disable" .Values.toolkitRegistry.auth.username .Release.Name (.Values.toolkitRegistry.service.port | int) .Values.toolkitRegistry.database.name | quote }}
-- name: TOOLKIT_REGISTRY_DB_HOST
-  value: {{ printf "%s-toolkit-registry" .Release.Name | quote }}
-- name: TOOLKIT_REGISTRY_DB_PORT
-  value: {{ .Values.toolkitRegistry.service.port | quote }}
-- name: TOOLKIT_REGISTRY_DB_USER
-  value: {{ .Values.toolkitRegistry.auth.username | quote }}
-- name: TOOLKIT_REGISTRY_DB_PASSWORD
-  value: {{ .Values.toolkitRegistry.auth.password | quote }}
-- name: TOOLKIT_REGISTRY_DB_NAME
-  value: {{ .Values.toolkitRegistry.database.name | quote }}
-- name: TOOLKIT_REGISTRY_DB_SSLMODE
-  value: "disable"
+{{- define "composio.uriComponent" -}}
+{{- . | toString | replace "%" "%25" | replace "\n" "%0A" | replace "\r" "%0D" | replace "\t" "%09" | replace " " "%20" | replace "!" "%21" | replace "\"" "%22" | replace "#" "%23" | replace "$" "%24" | replace "&" "%26" | replace "'" "%27" | replace "(" "%28" | replace ")" "%29" | replace "*" "%2A" | replace "+" "%2B" | replace "," "%2C" | replace "/" "%2F" | replace ":" "%3A" | replace ";" "%3B" | replace "<" "%3C" | replace "=" "%3D" | replace ">" "%3E" | replace "?" "%3F" | replace "@" "%40" | replace "[" "%5B" | replace "\\" "%5C" | replace "]" "%5D" | replace "^" "%5E" | replace "`" "%60" | replace "{" "%7B" | replace "|" "%7C" | replace "}" "%7D" -}}
+{{- end -}}
+
+{{- define "composio.shellQuote" -}}
+{{- printf "'%s'" (replace "'" "'\"'\"'" (. | toString)) -}}
+{{- end -}}
+
+{{- define "composio.toolkitRegistryDbUrl" -}}
+{{- $user := include "composio.uriComponent" .Values.toolkitRegistry.auth.username -}}
+{{- $database := include "composio.uriComponent" .Values.toolkitRegistry.database.name -}}
+{{- printf "postgresql://%s@%s-toolkit-registry:%v/%s?sslmode=disable" $user .Release.Name (.Values.toolkitRegistry.service.port | int) $database -}}
 {{- end -}}
 
 {{- define "temporal-encryption-key" -}}

--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -77,6 +77,23 @@ false
 {{- end -}}
 {{- end -}}
 
+{{- define "composio.toolkitRegistryDbEnv" -}}
+- name: TOOLKIT_REGISTRY_DB_URL
+  value: {{ printf "postgresql://%s@%s-toolkit-registry:%v/%s?sslmode=disable" .Values.toolkitRegistry.auth.username .Release.Name (.Values.toolkitRegistry.service.port | int) .Values.toolkitRegistry.database.name | quote }}
+- name: TOOLKIT_REGISTRY_DB_HOST
+  value: {{ printf "%s-toolkit-registry" .Release.Name | quote }}
+- name: TOOLKIT_REGISTRY_DB_PORT
+  value: {{ .Values.toolkitRegistry.service.port | quote }}
+- name: TOOLKIT_REGISTRY_DB_USER
+  value: {{ .Values.toolkitRegistry.auth.username | quote }}
+- name: TOOLKIT_REGISTRY_DB_PASSWORD
+  value: {{ .Values.toolkitRegistry.auth.password | quote }}
+- name: TOOLKIT_REGISTRY_DB_NAME
+  value: {{ .Values.toolkitRegistry.database.name | quote }}
+- name: TOOLKIT_REGISTRY_DB_SSLMODE
+  value: "disable"
+{{- end -}}
+
 {{- define "temporal-encryption-key" -}}
 {{- $coreName := include "composio.coreSecretName" . -}}
 {{- $core := lookup "v1" "Secret" .Release.Namespace $coreName -}}

--- a/composio/templates/database/postgres-init-job.yaml
+++ b/composio/templates/database/postgres-init-job.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.databaseMigration.enabled }}
+{{- $databaseMigrationUser := printf "\"%s\"" (replace "\"" "\"\"" .Values.databaseMigration.user) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -60,45 +61,45 @@ spec:
           CREATE DATABASE thermosdb;
 
           -- Alter Database
-          ALTER DATABASE composiodb OWNER TO {{ .Values.databaseMigration.user }};
+          ALTER DATABASE composiodb OWNER TO {{ $databaseMigrationUser }};
           {{- if eq (include "composio.temporalEnabled" .) "true" }}
-          ALTER DATABASE temporal OWNER TO {{ .Values.databaseMigration.user }};
-          ALTER DATABASE temporal_visibility OWNER TO {{ .Values.databaseMigration.user }};
+          ALTER DATABASE temporal OWNER TO {{ $databaseMigrationUser }};
+          ALTER DATABASE temporal_visibility OWNER TO {{ $databaseMigrationUser }};
           {{- end }}
-          ALTER DATABASE thermosdb OWNER TO {{ .Values.databaseMigration.user }};
+          ALTER DATABASE thermosdb OWNER TO {{ $databaseMigrationUser }};
 
           -- Grant privileges on thermosdb
           \c thermosdb
-          GRANT ALL PRIVILEGES ON DATABASE thermosdb TO {{ .Values.databaseMigration.user }};
-          GRANT ALL PRIVILEGES ON SCHEMA public TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {{ .Values.databaseMigration.user }};
+          GRANT ALL PRIVILEGES ON DATABASE thermosdb TO {{ $databaseMigrationUser }};
+          GRANT ALL PRIVILEGES ON SCHEMA public TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {{ $databaseMigrationUser }};
 
           -- Grant privileges on composiodb
           \c composiodb
-          GRANT ALL PRIVILEGES ON DATABASE composiodb TO {{ .Values.databaseMigration.user }};
-          GRANT ALL PRIVILEGES ON SCHEMA public TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {{ .Values.databaseMigration.user }};
+          GRANT ALL PRIVILEGES ON DATABASE composiodb TO {{ $databaseMigrationUser }};
+          GRANT ALL PRIVILEGES ON SCHEMA public TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {{ $databaseMigrationUser }};
 
           {{- if eq (include "composio.temporalEnabled" .) "true" }}
           -- Grant privileges on temporal
           \c temporal
-          GRANT ALL PRIVILEGES ON DATABASE temporal TO {{ .Values.databaseMigration.user }};
-          GRANT ALL PRIVILEGES ON SCHEMA public TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {{ .Values.databaseMigration.user }};
+          GRANT ALL PRIVILEGES ON DATABASE temporal TO {{ $databaseMigrationUser }};
+          GRANT ALL PRIVILEGES ON SCHEMA public TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {{ $databaseMigrationUser }};
 
           -- Grant privileges on temporal_visibility
           \c temporal_visibility
-          GRANT ALL PRIVILEGES ON DATABASE temporal_visibility TO {{ .Values.databaseMigration.user }};
-          GRANT ALL PRIVILEGES ON SCHEMA public TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {{ .Values.databaseMigration.user }};
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {{ .Values.databaseMigration.user }};
+          GRANT ALL PRIVILEGES ON DATABASE temporal_visibility TO {{ $databaseMigrationUser }};
+          GRANT ALL PRIVILEGES ON SCHEMA public TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO {{ $databaseMigrationUser }};
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO {{ $databaseMigrationUser }};
           {{- end }}
 
           -- Grant database creation privilege

--- a/composio/templates/preflight-checks/preflight-db-connection.yaml
+++ b/composio/templates/preflight-checks/preflight-db-connection.yaml
@@ -86,9 +86,9 @@ stringData:
             key: "{{ .Values.databaseMigration.password.key }}"
             outcomes:
               - warn:
-                  message: "Missing PostgreSQL password Secret {{ .Values.secret.name }} or key {{ .Values.databaseMigration.password.key }}."
+                  message: {{ printf "Missing PostgreSQL password Secret %s or key %s." .Values.secret.name .Values.databaseMigration.password.key | quote }}
               - pass:
-                  message: "Found PostgreSQL password Secret {{ .Values.secret.name }} (key {{ .Values.databaseMigration.password.key }})."
+                  message: {{ printf "Found PostgreSQL password Secret %s (key %s)." .Values.secret.name .Values.databaseMigration.password.key | quote }}
         - textAnalyze:
             checkName: "PostgreSQL connection is valid"
             fileName: "/validate-postgres-connection.log"
@@ -96,22 +96,22 @@ stringData:
             outcomes:
               - pass:
                   when: "Result == OK"
-                  message: "PostgreSQL connection successful to {{ .Values.databaseMigration.host }}:{{ .Values.databaseMigration.port }}."
+                  message: {{ printf "PostgreSQL connection successful to %s:%s." .Values.databaseMigration.host .Values.databaseMigration.port | quote }}
               - fail:
                   when: "Result == AUTH_FAILED"
-                  message: "PostgreSQL authentication failed. Check username ({{ .Values.databaseMigration.user }}) and password in secret {{ .Values.secret.name }}."
+                  message: {{ printf "PostgreSQL authentication failed. Check username (%s) and password in secret %s." .Values.databaseMigration.user .Values.secret.name | quote }}
               - fail:
                   when: "Result == CONNECTION_FAILED"
-                  message: "Cannot connect to PostgreSQL at {{ .Values.databaseMigration.host }}:{{ .Values.databaseMigration.port }}. Check host, port, and network connectivity."
+                  message: {{ printf "Cannot connect to PostgreSQL at %s:%s. Check host, port, and network connectivity." .Values.databaseMigration.host .Values.databaseMigration.port | quote }}
               - fail:
                   when: "Result == USER_NOT_FOUND"
-                  message: "PostgreSQL user '{{ .Values.databaseMigration.user }}' does not exist on the database server."
+                  message: {{ printf "PostgreSQL user '%s' does not exist on the database server." .Values.databaseMigration.user | quote }}
               - fail:
                   when: "Result == DB_NOT_FOUND"
                   message: "PostgreSQL database 'postgres' does not exist. This is unusual and may indicate server misconfiguration."
               - warn:
                   when: "Result == MISSING_PASSWORD"
-                  message: "PostgreSQL password not found in secret {{ .Values.secret.name }}."
+                  message: {{ printf "PostgreSQL password not found in secret %s." .Values.secret.name | quote }}
               - fail:
                   when: "Result == MISSING_CONFIG"
                   message: "PostgreSQL connection configuration incomplete. Check host, port, and user values."

--- a/composio/templates/thermos/thermos-misc-workers.yaml
+++ b/composio/templates/thermos/thermos-misc-workers.yaml
@@ -60,15 +60,13 @@ spec:
         - name: wait-for-toolkit-registry
           image: {{ include "composio.imageReference" (dict "image" .Values.toolkitRegistry.image "context" .) | quote }}
           imagePullPolicy: {{ .Values.toolkitRegistry.image.pullPolicy }}
-          env:
-{{ include "composio.toolkitRegistryDbEnv" . | indent 12 }}
           command:
             - sh
             - -c
             - |
               i=0
               max_attempts=60
-              until pg_isready -h "$TOOLKIT_REGISTRY_DB_HOST" -p "$TOOLKIT_REGISTRY_DB_PORT" -U "$TOOLKIT_REGISTRY_DB_USER" -d "$TOOLKIT_REGISTRY_DB_NAME"; do
+              until pg_isready -h {{ printf "%s-toolkit-registry" .Release.Name | quote }} -p {{ .Values.toolkitRegistry.service.port | quote }} -U {{ include "composio.shellQuote" .Values.toolkitRegistry.auth.username }} -d {{ include "composio.shellQuote" .Values.toolkitRegistry.database.name }}; do
                 i=$((i+1))
                 if [ "$i" -ge "$max_attempts" ]; then
                   echo "toolkit registry not ready after $max_attempts attempts, giving up"
@@ -159,7 +157,8 @@ spec:
                   key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
                   optional: true
             {{- if .Values.toolkitRegistry.enabled }}
-{{ include "composio.toolkitRegistryDbEnv" . | indent 12 }}
+            - name: TOOLKIT_REGISTRY_DB_URL
+              value: {{ include "composio.toolkitRegistryDbUrl" . | quote }}
             {{- end }}
             {{- if .Values.thermosMiscWorkers.env }}
             {{- toYaml .Values.thermosMiscWorkers.env | nindent 12 }}

--- a/composio/templates/thermos/thermos-misc-workers.yaml
+++ b/composio/templates/thermos/thermos-misc-workers.yaml
@@ -60,13 +60,15 @@ spec:
         - name: wait-for-toolkit-registry
           image: {{ include "composio.imageReference" (dict "image" .Values.toolkitRegistry.image "context" .) | quote }}
           imagePullPolicy: {{ .Values.toolkitRegistry.image.pullPolicy }}
+          env:
+{{ include "composio.toolkitRegistryDbEnv" . | indent 12 }}
           command:
             - sh
             - -c
             - |
               i=0
               max_attempts=60
-              until pg_isready -h {{ .Release.Name }}-toolkit-registry -p {{ .Values.toolkitRegistry.service.port | int }} -U {{ .Values.toolkitRegistry.auth.username }} -d {{ .Values.toolkitRegistry.database.name }}; do
+              until pg_isready -h "$TOOLKIT_REGISTRY_DB_HOST" -p "$TOOLKIT_REGISTRY_DB_PORT" -U "$TOOLKIT_REGISTRY_DB_USER" -d "$TOOLKIT_REGISTRY_DB_NAME"; do
                 i=$((i+1))
                 if [ "$i" -ge "$max_attempts" ]; then
                   echo "toolkit registry not ready after $max_attempts attempts, giving up"
@@ -157,8 +159,7 @@ spec:
                   key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
                   optional: true
             {{- if .Values.toolkitRegistry.enabled }}
-            - name: TOOLKIT_REGISTRY_DB_URL
-              value: {{ printf "postgresql://%s@%s-toolkit-registry:%v/%s?sslmode=disable" .Values.toolkitRegistry.auth.username .Release.Name (.Values.toolkitRegistry.service.port | int) .Values.toolkitRegistry.database.name | quote }}
+{{ include "composio.toolkitRegistryDbEnv" . | indent 12 }}
             {{- end }}
             {{- if .Values.thermosMiscWorkers.env }}
             {{- toYaml .Values.thermosMiscWorkers.env | nindent 12 }}

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -59,13 +59,15 @@ spec:
         - name: wait-for-toolkit-registry
           image: {{ include "composio.imageReference" (dict "image" .Values.toolkitRegistry.image "context" .) | quote }}
           imagePullPolicy: {{ .Values.toolkitRegistry.image.pullPolicy }}
+          env:
+{{ include "composio.toolkitRegistryDbEnv" . | indent 12 }}
           command:
             - sh
             - -c
             - |
               i=0
               max_attempts=60
-              until pg_isready -h {{ .Release.Name }}-toolkit-registry -p {{ .Values.toolkitRegistry.service.port | int }} -U {{ .Values.toolkitRegistry.auth.username }} -d {{ .Values.toolkitRegistry.database.name }}; do
+              until pg_isready -h "$TOOLKIT_REGISTRY_DB_HOST" -p "$TOOLKIT_REGISTRY_DB_PORT" -U "$TOOLKIT_REGISTRY_DB_USER" -d "$TOOLKIT_REGISTRY_DB_NAME"; do
                 i=$((i+1))
                 if [ "$i" -ge "$max_attempts" ]; then
                   echo "toolkit registry not ready after $max_attempts attempts, giving up"
@@ -152,8 +154,7 @@ spec:
                   key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
                   optional: true
             {{- if .Values.toolkitRegistry.enabled }}
-            - name: TOOLKIT_REGISTRY_DB_URL
-              value: {{ printf "postgresql://%s@%s-toolkit-registry:%v/%s?sslmode=disable" .Values.toolkitRegistry.auth.username .Release.Name (.Values.toolkitRegistry.service.port | int) .Values.toolkitRegistry.database.name | quote }}
+{{ include "composio.toolkitRegistryDbEnv" . | indent 12 }}
             {{- end }}
             {{- if .Values.thermos.env }}
             {{- toYaml .Values.thermos.env | nindent 12 }}

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -59,15 +59,13 @@ spec:
         - name: wait-for-toolkit-registry
           image: {{ include "composio.imageReference" (dict "image" .Values.toolkitRegistry.image "context" .) | quote }}
           imagePullPolicy: {{ .Values.toolkitRegistry.image.pullPolicy }}
-          env:
-{{ include "composio.toolkitRegistryDbEnv" . | indent 12 }}
           command:
             - sh
             - -c
             - |
               i=0
               max_attempts=60
-              until pg_isready -h "$TOOLKIT_REGISTRY_DB_HOST" -p "$TOOLKIT_REGISTRY_DB_PORT" -U "$TOOLKIT_REGISTRY_DB_USER" -d "$TOOLKIT_REGISTRY_DB_NAME"; do
+              until pg_isready -h {{ printf "%s-toolkit-registry" .Release.Name | quote }} -p {{ .Values.toolkitRegistry.service.port | quote }} -U {{ include "composio.shellQuote" .Values.toolkitRegistry.auth.username }} -d {{ include "composio.shellQuote" .Values.toolkitRegistry.database.name }}; do
                 i=$((i+1))
                 if [ "$i" -ge "$max_attempts" ]; then
                   echo "toolkit registry not ready after $max_attempts attempts, giving up"
@@ -154,7 +152,8 @@ spec:
                   key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
                   optional: true
             {{- if .Values.toolkitRegistry.enabled }}
-{{ include "composio.toolkitRegistryDbEnv" . | indent 12 }}
+            - name: TOOLKIT_REGISTRY_DB_URL
+              value: {{ include "composio.toolkitRegistryDbUrl" . | quote }}
             {{- end }}
             {{- if .Values.thermos.env }}
             {{- toYaml .Values.thermos.env | nindent 12 }}

--- a/composio/templates/thermos/toolkit-registry.yaml
+++ b/composio/templates/thermos/toolkit-registry.yaml
@@ -58,9 +58,15 @@ spec:
           readinessProbe:
             exec:
               command:
-                - sh
-                - -c
-                - pg_isready -h 127.0.0.1 -p 5432 -U {{ .Values.toolkitRegistry.auth.username }} -d {{ .Values.toolkitRegistry.database.name }}
+                - pg_isready
+                - -h
+                - "127.0.0.1"
+                - -p
+                - "5432"
+                - -U
+                - {{ .Values.toolkitRegistry.auth.username | quote }}
+                - -d
+                - {{ .Values.toolkitRegistry.database.name | quote }}
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5
@@ -68,9 +74,15 @@ spec:
           livenessProbe:
             exec:
               command:
-                - sh
-                - -c
-                - pg_isready -h 127.0.0.1 -p 5432 -U {{ .Values.toolkitRegistry.auth.username }} -d {{ .Values.toolkitRegistry.database.name }}
+                - pg_isready
+                - -h
+                - "127.0.0.1"
+                - -p
+                - "5432"
+                - -U
+                - {{ .Values.toolkitRegistry.auth.username | quote }}
+                - -d
+                - {{ .Values.toolkitRegistry.database.name | quote }}
             initialDelaySeconds: 15
             periodSeconds: 20
             timeoutSeconds: 5

--- a/composio/tests/db_init_test.yaml
+++ b/composio/tests/db_init_test.yaml
@@ -573,6 +573,21 @@ tests:
           path: spec.template.spec.containers[0].args[2]
           pattern: 'CREATE DATABASE composiodb;'
 
+  - it: should quote database migration user as a SQL identifier
+    set:
+      databaseMigration.enabled: true
+      databaseMigration.user: user-name
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'ALTER DATABASE composiodb OWNER TO "user-name";'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'GRANT ALL PRIVILEGES ON DATABASE thermosdb TO "user-name";'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO "user-name";'
+
   - it: should run before db-init jobs (lower hook weight)
     set:
       databaseMigration.enabled: true

--- a/composio/tests/preflight_test.yaml
+++ b/composio/tests/preflight_test.yaml
@@ -30,6 +30,18 @@ tests:
           path: stringData["preflight.yaml"]
           pattern: '(?s)analyzers:\s*\[\]'
 
+  - it: should escape database migration values in postgres preflight messages
+    set:
+      databaseMigration.enabled: true
+      databaseMigration.user: user"name
+    asserts:
+      - matchRegex:
+          path: stringData["preflight.yaml"]
+          pattern: 'message: "PostgreSQL authentication failed\. Check username \(user\\"name\)'
+      - matchRegex:
+          path: stringData["preflight.yaml"]
+          pattern: 'message: "PostgreSQL user ''user\\"name'' does not exist on the database server\."'
+
 ---
 suite: test openai preflight secret checks
 templates:

--- a/composio/tests/thermos_test.yaml
+++ b/composio/tests/thermos_test.yaml
@@ -226,12 +226,59 @@ tests:
           content:
             name: TOOLKIT_REGISTRY_DB_URL
             value: postgresql://registry_reader@RELEASE-NAME-toolkit-registry:5432/thermos?sslmode=disable
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_DB_HOST
+            value: RELEASE-NAME-toolkit-registry
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_DB_USER
+            value: registry_reader
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_DB_PASSWORD
+            value: registry_reader
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_DB_NAME
+            value: thermos
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_DB_SSLMODE
+            value: disable
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-toolkit-registry
       - matchRegex:
           path: spec.template.spec.initContainers[0].image
           pattern: ".*/composio-self-host/thermos-toolkit-registry:[^/]+$"
+
+  - it: should pass toolkit registry wait configuration through env vars
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      toolkitRegistry.auth.username: user$name
+      toolkitRegistry.database.name: thermos db
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_DB_USER
+            value: user$name
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_DB_NAME
+            value: thermos db
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'pg_isready -h "\$TOOLKIT_REGISTRY_DB_HOST" -p "\$TOOLKIT_REGISTRY_DB_PORT" -U "\$TOOLKIT_REGISTRY_DB_USER" -d "\$TOOLKIT_REGISTRY_DB_NAME"'
 
   - it: should bound the toolkit registry wait and log on success
     documentSelector:
@@ -352,6 +399,31 @@ tests:
           value: 5432
         documentIndex: 1
 
+  - it: should pass toolkit registry probe arguments without shell interpolation
+    documentIndex: 0
+    set:
+      toolkitRegistry.auth.username: user$name
+      toolkitRegistry.database.name: thermos db
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[0]
+          value: pg_isready
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[6]
+          value: user$name
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[8]
+          value: thermos db
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[0]
+          value: pg_isready
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[6]
+          value: user$name
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[8]
+          value: thermos db
+
   - it: should allow toolkit registry init containers and env
     documentIndex: 0
     set:
@@ -426,9 +498,39 @@ tests:
           content:
             name: TOOLKIT_REGISTRY_DB_URL
             value: postgresql://registry_reader@RELEASE-NAME-toolkit-registry:5432/thermos?sslmode=disable
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_DB_HOST
+            value: RELEASE-NAME-toolkit-registry
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_DB_USER
+            value: registry_reader
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-toolkit-registry
+
+  - it: should pass misc worker toolkit registry wait configuration through env vars
+    set:
+      thermosMiscWorkers.enabled: true
+      toolkitRegistry.auth.username: user$name
+      toolkitRegistry.database.name: thermos db
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_DB_USER
+            value: user$name
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: TOOLKIT_REGISTRY_DB_NAME
+            value: thermos db
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'pg_isready -h "\$TOOLKIT_REGISTRY_DB_HOST" -p "\$TOOLKIT_REGISTRY_DB_PORT" -U "\$TOOLKIT_REGISTRY_DB_USER" -d "\$TOOLKIT_REGISTRY_DB_NAME"'
 
   - it: should append misc worker additional init containers after toolkit registry wait
     set:

--- a/composio/tests/thermos_test.yaml
+++ b/composio/tests/thermos_test.yaml
@@ -226,31 +226,6 @@ tests:
           content:
             name: TOOLKIT_REGISTRY_DB_URL
             value: postgresql://registry_reader@RELEASE-NAME-toolkit-registry:5432/thermos?sslmode=disable
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_DB_HOST
-            value: RELEASE-NAME-toolkit-registry
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_DB_USER
-            value: registry_reader
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_DB_PASSWORD
-            value: registry_reader
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_DB_NAME
-            value: thermos
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_DB_SSLMODE
-            value: disable
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-toolkit-registry
@@ -258,27 +233,22 @@ tests:
           path: spec.template.spec.initContainers[0].image
           pattern: ".*/composio-self-host/thermos-toolkit-registry:[^/]+$"
 
-  - it: should pass toolkit registry wait configuration through env vars
+  - it: should percent-encode toolkit registry db url and shell-quote wait configuration
     documentSelector:
       path: kind
       value: Deployment
     set:
-      toolkitRegistry.auth.username: user$name
-      toolkitRegistry.database.name: thermos db
+      toolkitRegistry.auth.username: user$name@example.com
+      toolkitRegistry.database.name: thermos db/prod
     asserts:
       - contains:
-          path: spec.template.spec.initContainers[0].env
+          path: spec.template.spec.containers[0].env
           content:
-            name: TOOLKIT_REGISTRY_DB_USER
-            value: user$name
-      - contains:
-          path: spec.template.spec.initContainers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_DB_NAME
-            value: thermos db
+            name: TOOLKIT_REGISTRY_DB_URL
+            value: postgresql://user%24name%40example.com@RELEASE-NAME-toolkit-registry:5432/thermos%20db%2Fprod?sslmode=disable
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: 'pg_isready -h "\$TOOLKIT_REGISTRY_DB_HOST" -p "\$TOOLKIT_REGISTRY_DB_PORT" -U "\$TOOLKIT_REGISTRY_DB_USER" -d "\$TOOLKIT_REGISTRY_DB_NAME"'
+          pattern: 'pg_isready -h "RELEASE-NAME-toolkit-registry" -p "5432" -U ''user\$name@example\.com'' -d ''thermos db/prod'''
 
   - it: should bound the toolkit registry wait and log on success
     documentSelector:
@@ -498,39 +468,24 @@ tests:
           content:
             name: TOOLKIT_REGISTRY_DB_URL
             value: postgresql://registry_reader@RELEASE-NAME-toolkit-registry:5432/thermos?sslmode=disable
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_DB_HOST
-            value: RELEASE-NAME-toolkit-registry
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_DB_USER
-            value: registry_reader
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-toolkit-registry
 
-  - it: should pass misc worker toolkit registry wait configuration through env vars
+  - it: should percent-encode misc worker toolkit registry db url and shell-quote wait configuration
     set:
       thermosMiscWorkers.enabled: true
-      toolkitRegistry.auth.username: user$name
-      toolkitRegistry.database.name: thermos db
+      toolkitRegistry.auth.username: user$name@example.com
+      toolkitRegistry.database.name: thermos db/prod
     asserts:
       - contains:
-          path: spec.template.spec.initContainers[0].env
+          path: spec.template.spec.containers[0].env
           content:
-            name: TOOLKIT_REGISTRY_DB_USER
-            value: user$name
-      - contains:
-          path: spec.template.spec.initContainers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_DB_NAME
-            value: thermos db
+            name: TOOLKIT_REGISTRY_DB_URL
+            value: postgresql://user%24name%40example.com@RELEASE-NAME-toolkit-registry:5432/thermos%20db%2Fprod?sslmode=disable
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: 'pg_isready -h "\$TOOLKIT_REGISTRY_DB_HOST" -p "\$TOOLKIT_REGISTRY_DB_PORT" -U "\$TOOLKIT_REGISTRY_DB_USER" -d "\$TOOLKIT_REGISTRY_DB_NAME"'
+          pattern: 'pg_isready -h "RELEASE-NAME-toolkit-registry" -p "5432" -U ''user\$name@example\.com'' -d ''thermos db/prod'''
 
   - it: should append misc worker additional init containers after toolkit registry wait
     set:


### PR DESCRIPTION
# Description

Fixes special-character handling for database-related Helm rendering.

Changes:
- Quote `databaseMigration.user` as a PostgreSQL identifier in the DB init SQL so usernames like `user-name` do not break `ALTER DATABASE`, `GRANT`, or `ALTER DEFAULT PRIVILEGES`.
- Escape dynamic Postgres preflight analyzer messages so usernames containing quotes do not produce invalid embedded YAML.
- Add discrete toolkit registry DB env vars for Thermos and misc workers.
- Quote toolkit registry `pg_isready` shell variable usage.
- Switch toolkit registry probes to direct argv-style `pg_isready` execution instead of `sh -c`.

# How did I test this PR

- `helm lint .`
- `helm unittest . -f 'tests/*_test.yaml'`
- Rendered chart with special characters in toolkit registry DB values to verify valid output.