### PR TITLE
Enable Mercury bundle signature verification

### DIFF
--- a/composio/README.md
+++ b/composio/README.md
@@ -102,6 +102,8 @@ A Helm chart for Composio
 | mercury.autoscaling.target | int | `80` | Target metric value for autoscaling |
 | mercury.awsLambda.enabled | bool | `false` | Enable AWS Lambda deployment |
 | mercury.awsLambda.secretRef.name | string | `"lambda-cred"` | Secret name for Lambda credentials |
+| mercury.bundleSignatureVerification.enabled | bool | `true` | Enable strict runtime verification of signed module bundles. |
+| mercury.bundleSignatureVerification.publicKeyBase64 | string | `"/avANrHX/zfDqUOu3U2URZsWy7mJrkbidGs4Wvh8rFA="` | Base64-encoded public verification key for module bundle signatures. This is not a signing key. |
 | mercury.containerConcurrency | int | `0` | Container concurrency (0 = unlimited) |
 | mercury.enabled | bool | `true` | Enable Mercury service |
 | mercury.fileStorage | string | `"s3"` | Mercury file storage backend. Valid values are "s3" or "base64". Renders FILE_BACKEND. |

--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -172,36 +172,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Mercury module bundle signature verification rendered as ConfigMap data.
-*/}}
-{{- define "composio.mercury.bundleSignatureConfigData" -}}
-{{- if .Values.mercury.bundleSignatureVerification.enabled -}}
-DISABLE_BUNDLE_SIGNATURE_VERIFICATION: "false"
-MODULE_BUNDLE_REQUIRE_SIGNATURE: "true"
-MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64: {{ .Values.mercury.bundleSignatureVerification.publicKeyBase64 | quote }}
-{{- else -}}
-DISABLE_BUNDLE_SIGNATURE_VERIFICATION: "true"
-{{- end -}}
-{{- end }}
-
-{{/*
-Mercury module bundle signature verification rendered as container env entries.
-*/}}
-{{- define "composio.mercury.bundleSignatureEnv" -}}
-{{- if .Values.mercury.bundleSignatureVerification.enabled -}}
-- name: DISABLE_BUNDLE_SIGNATURE_VERIFICATION
-  value: "false"
-- name: MODULE_BUNDLE_REQUIRE_SIGNATURE
-  value: "true"
-- name: MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64
-  value: {{ .Values.mercury.bundleSignatureVerification.publicKeyBase64 | quote }}
-{{- else -}}
-- name: DISABLE_BUNDLE_SIGNATURE_VERIFICATION
-  value: "true"
-{{- end -}}
-{{- end }}
-
-{{/*
 Render a PodDisruptionBudget from a common shape.
 Expected keys:
 - root: chart root context

--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -172,6 +172,36 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Mercury module bundle signature verification rendered as ConfigMap data.
+*/}}
+{{- define "composio.mercury.bundleSignatureConfigData" -}}
+{{- if .Values.mercury.bundleSignatureVerification.enabled -}}
+DISABLE_BUNDLE_SIGNATURE_VERIFICATION: "false"
+MODULE_BUNDLE_REQUIRE_SIGNATURE: "true"
+MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64: {{ .Values.mercury.bundleSignatureVerification.publicKeyBase64 | quote }}
+{{- else -}}
+DISABLE_BUNDLE_SIGNATURE_VERIFICATION: "true"
+{{- end -}}
+{{- end }}
+
+{{/*
+Mercury module bundle signature verification rendered as container env entries.
+*/}}
+{{- define "composio.mercury.bundleSignatureEnv" -}}
+{{- if .Values.mercury.bundleSignatureVerification.enabled -}}
+- name: DISABLE_BUNDLE_SIGNATURE_VERIFICATION
+  value: "false"
+- name: MODULE_BUNDLE_REQUIRE_SIGNATURE
+  value: "true"
+- name: MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64
+  value: {{ .Values.mercury.bundleSignatureVerification.publicKeyBase64 | quote }}
+{{- else -}}
+- name: DISABLE_BUNDLE_SIGNATURE_VERIFICATION
+  value: "true"
+{{- end -}}
+{{- end }}
+
+{{/*
 Render a PodDisruptionBudget from a common shape.
 Expected keys:
 - root: chart root context

--- a/composio/templates/mercury/mercury-configmap.yaml
+++ b/composio/templates/mercury/mercury-configmap.yaml
@@ -14,6 +14,7 @@ data:
   AWS_S3_CUSTOM_TOOLS_BUCKET: "tools"
   SELF_HOSTED: "true"
   FILE_BACKEND: {{ .Values.mercury.fileStorage | default "s3" | quote }}
+{{ include "composio.mercury.bundleSignatureConfigData" . | indent 2 }}
   BACKEND_URL: {{ printf "http://%s-apollo:9900" .Release.Name | quote }}
   APOLLO_URL: {{ printf "http://%s-apollo:9900" .Release.Name | quote }}
   AWS_S3_ENDPOINT: "http://{{ .Release.Name }}-minio:9000"

--- a/composio/templates/mercury/mercury-configmap.yaml
+++ b/composio/templates/mercury/mercury-configmap.yaml
@@ -14,12 +14,15 @@ data:
   AWS_S3_CUSTOM_TOOLS_BUCKET: "tools"
   SELF_HOSTED: "true"
   FILE_BACKEND: {{ .Values.mercury.fileStorage | default "s3" | quote }}
-{{ include "composio.mercury.bundleSignatureConfigData" . | indent 2 }}
+  DISABLE_BUNDLE_SIGNATURE_VERIFICATION: {{ ternary "false" "true" .Values.mercury.bundleSignatureVerification.enabled | quote }}
+  MODULE_BUNDLE_REQUIRE_SIGNATURE: {{ ternary "true" "false" .Values.mercury.bundleSignatureVerification.enabled | quote }}
+  MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64: {{ ternary .Values.mercury.bundleSignatureVerification.publicKeyBase64 "" .Values.mercury.bundleSignatureVerification.enabled | quote }}
   BACKEND_URL: {{ printf "http://%s-apollo:9900" .Release.Name | quote }}
   APOLLO_URL: {{ printf "http://%s-apollo:9900" .Release.Name | quote }}
   AWS_S3_ENDPOINT: "http://{{ .Release.Name }}-minio:9000"
   AWS_S3_ENDPOINT_URL: "http://{{ .Release.Name }}-minio:9000"
   AWS_S3_FORCE_PATH_STYLE: "true"
+  USE_APOLLO_GET_DOWNLOAD_URL_API: "true"
   {{- if .Values.otel.enabled }}
   OTEL_ENABLED: {{ .Values.otel.enabled | toString | quote }}
   OTEL_SERVICE_NAME: {{ .Values.otel.mercury.serviceName | default "mercury-openapi" | quote }}
@@ -30,7 +33,6 @@ data:
   OTEL_TRACES_ENABLED: {{ .Values.otel.traces.enabled | toString | quote }}
   OTEL_METRICS_ENABLED: {{ .Values.otel.metrics.enabled | toString | quote }}
   OTEL_METRIC_EXPORT_INTERVAL: {{ .Values.otel.metrics.exportInterval | toString | quote }}
-  USE_APOLLO_GET_DOWNLOAD_URL_API: "true"
   OTEL_RESOURCE_ATTRIBUTES: "service.name={{ .Values.otel.mercury.serviceName | default "mercury-openapi" }},service.version={{ .Values.otel.mercury.serviceVersion | default "1.0.0" }},deployment.environment={{ .Values.otel.environment | default .Values.global.environment | default "development" }}"
   {{- end }}
 {{- end }}

--- a/composio/templates/mercury/mercury-service.yaml
+++ b/composio/templates/mercury/mercury-service.yaml
@@ -64,6 +64,7 @@ spec:
               value: "true"
             - name: FILE_BACKEND
               value: {{ .Values.mercury.fileStorage | default "s3" | quote }}
+{{ include "composio.mercury.bundleSignatureEnv" . | indent 12 }}
             - name: MERCURY_SECRETS_DIR
               value: {{ .Values.mercury.secretsDir | quote }}
             - name: OPENAI_API_KEY

--- a/composio/templates/mercury/mercury-service.yaml
+++ b/composio/templates/mercury/mercury-service.yaml
@@ -58,13 +58,11 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-mercury-config
           env:
             {{- $coreSecret := include "composio.coreSecretName" . }}
-            - name: SELF_HOSTED
-              value: "true"
-            - name: FILE_BACKEND
-              value: {{ .Values.mercury.fileStorage | default "s3" | quote }}
-{{ include "composio.mercury.bundleSignatureEnv" . | indent 12 }}
             - name: MERCURY_SECRETS_DIR
               value: {{ .Values.mercury.secretsDir | quote }}
             - name: OPENAI_API_KEY
@@ -73,10 +71,6 @@ spec:
                   name: {{ .Values.openAI.secretRef }}
                   key: {{ .Values.openAI.key }}
                   optional: true
-            - name: BACKEND_URL
-              value: {{ printf "http://%s-apollo:9900" .Release.Name | quote }}
-            - name: APOLLO_URL
-              value: {{ printf "http://%s-apollo:9900" .Release.Name | quote }}
             - name: APOLLO_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -89,8 +83,6 @@ spec:
                   name: {{ $coreSecret }}
                   key: COMPOSIO_ADMIN_TOKEN
                   optional: true
-            - name: USE_APOLLO_GET_DOWNLOAD_URL_API
-              value: "true"
             {{- with .Values.mercury.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/composio/tests/mercury_test.yaml
+++ b/composio/tests/mercury_test.yaml
@@ -299,10 +299,12 @@ tests:
       - equal:
           path: data.DISABLE_BUNDLE_SIGNATURE_VERIFICATION
           value: "true"
-      - isNull:
+      - equal:
           path: data.MODULE_BUNDLE_REQUIRE_SIGNATURE
-      - isNull:
+          value: "false"
+      - equal:
           path: data.MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64
+          value: ""
 
 ---
 suite: test mercury service
@@ -376,6 +378,17 @@ tests:
           path: metadata.labels["app.kubernetes.io/component"]
           value: mercury
 
+  - it: should load shared mercury runtime config from configmap for knative
+    set:
+      mercury.enabled: true
+      mercury.useKnative: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: RELEASE-NAME-mercury-config
+
   - it: should not create knative mercury service when disabled
     set:
       mercury.enabled: false
@@ -429,49 +442,6 @@ tests:
                 name: composio-composio-secrets
                 key: OPENAI_API_KEY
                 optional: true
-
-  - it: should enable strict module bundle signature verification for knative
-    set:
-      mercury.enabled: true
-      mercury.useKnative: true
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: DISABLE_BUNDLE_SIGNATURE_VERIFICATION
-            value: "false"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MODULE_BUNDLE_REQUIRE_SIGNATURE
-            value: "true"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64
-            value: "/avANrHX/zfDqUOu3U2URZsWy7mJrkbidGs4Wvh8rFA="
-
-  - it: should allow disabling module bundle signature verification for knative
-    set:
-      mercury.enabled: true
-      mercury.useKnative: true
-      mercury.bundleSignatureVerification.enabled: false
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: DISABLE_BUNDLE_SIGNATURE_VERIFICATION
-            value: "true"
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MODULE_BUNDLE_REQUIRE_SIGNATURE
-            value: "true"
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64
-            value: "/avANrHX/zfDqUOu3U2URZsWy7mJrkbidGs4Wvh8rFA="
 
   - it: should render additional mercury init containers for knative
     set:
@@ -562,15 +532,3 @@ tests:
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
           value: mercury-secret
-
-  - it: should set file backend for knative from mercury fileStorage
-    set:
-      mercury.enabled: true
-      mercury.useKnative: true
-      mercury.fileStorage: base64
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: FILE_BACKEND
-            value: base64

--- a/composio/tests/mercury_test.yaml
+++ b/composio/tests/mercury_test.yaml
@@ -277,6 +277,33 @@ tests:
           path: data.FILE_BACKEND
           value: base64
 
+  - it: should enable strict module bundle signature verification by default
+    set:
+      mercury.enabled: true
+    asserts:
+      - equal:
+          path: data.DISABLE_BUNDLE_SIGNATURE_VERIFICATION
+          value: "false"
+      - equal:
+          path: data.MODULE_BUNDLE_REQUIRE_SIGNATURE
+          value: "true"
+      - equal:
+          path: data.MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64
+          value: "/avANrHX/zfDqUOu3U2URZsWy7mJrkbidGs4Wvh8rFA="
+
+  - it: should allow disabling module bundle signature verification
+    set:
+      mercury.enabled: true
+      mercury.bundleSignatureVerification.enabled: false
+    asserts:
+      - equal:
+          path: data.DISABLE_BUNDLE_SIGNATURE_VERIFICATION
+          value: "true"
+      - isNull:
+          path: data.MODULE_BUNDLE_REQUIRE_SIGNATURE
+      - isNull:
+          path: data.MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64
+
 ---
 suite: test mercury service
 templates:
@@ -402,6 +429,49 @@ tests:
                 name: composio-composio-secrets
                 key: OPENAI_API_KEY
                 optional: true
+
+  - it: should enable strict module bundle signature verification for knative
+    set:
+      mercury.enabled: true
+      mercury.useKnative: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISABLE_BUNDLE_SIGNATURE_VERIFICATION
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MODULE_BUNDLE_REQUIRE_SIGNATURE
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64
+            value: "/avANrHX/zfDqUOu3U2URZsWy7mJrkbidGs4Wvh8rFA="
+
+  - it: should allow disabling module bundle signature verification for knative
+    set:
+      mercury.enabled: true
+      mercury.useKnative: true
+      mercury.bundleSignatureVerification.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISABLE_BUNDLE_SIGNATURE_VERIFICATION
+            value: "true"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MODULE_BUNDLE_REQUIRE_SIGNATURE
+            value: "true"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MODULE_BUNDLE_VERIFICATION_PUBLIC_KEY_BASE64
+            value: "/avANrHX/zfDqUOu3U2URZsWy7mJrkbidGs4Wvh8rFA="
 
   - it: should render additional mercury init containers for knative
     set:

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -1103,6 +1103,12 @@ mercury:
   secretsDir: "/etc/secrets/mercury"
   # -- Mercury file storage backend. Valid values are "s3" or "base64". Renders FILE_BACKEND.
   fileStorage: "s3"
+  # Mercury module bundle signature verification configuration.
+  bundleSignatureVerification:
+    # -- Enable strict runtime verification of signed module bundles.
+    enabled: true
+    # -- Base64-encoded public verification key for module bundle signatures. This is not a signing key.
+    publicKeyBase64: "/avANrHX/zfDqUOu3U2URZsWy7mJrkbidGs4Wvh8rFA="
   # -- Additional init containers for Mercury. Mount `mercury-secrets` to populate `.Values.mercury.secretsDir`.
   additionalInitContainers: []
   serviceAccount:


### PR DESCRIPTION
## Summary
- enable strict Mercury module bundle signature verification by default for deployment and Knative modes
- add values.yaml escape hatch via mercury.bundleSignatureVerification.enabled=false
- document that only the public verification key is configured

## Tests
- cd composio && ./run-tests.sh mercury
- helm lint composio/
- git diff --check