### PR TITLE
Require toolkit registry for Thermos

### DIFF
--- a/composio/templates/thermos/thermos-db-init-job.yaml
+++ b/composio/templates/thermos/thermos-db-init-job.yaml
@@ -80,22 +80,8 @@ spec:
                   optional: true
             - name: ADMIN_EMAIL
               value: {{ .Values.dbInit.adminEmail | default "hello@composio.dev" | quote }}
-            # When toolkit-registry sidecar is enabled (default), the
-            # thermos-db-init job runs Atlas migrations only — toolkit data is
-            # served by the standalone thermos-toolkit-registry Postgres. When
-            # disabled, the db-init container also restores the SQL dump baked
-            # into the image into DATABASE_URL.
-            #
-            # Defaults to "true" when the toolkitRegistry stanza is absent.
-            # Note: `default true X` doesn't help here because Helm's default
-            # treats `false` as the zero value, so `false` would round-trip to
-            # `true`. Use explicit hasKey instead.
-            {{- $registryEnabled := true -}}
-            {{- if and .Values.toolkitRegistry (hasKey .Values.toolkitRegistry "enabled") -}}
-              {{- $registryEnabled = .Values.toolkitRegistry.enabled -}}
-            {{- end }}
             - name: TOOLKIT_REGISTRY_ENABLED
-              value: {{ $registryEnabled | quote }}
+              value: "true"
             {{- if .Values.thermos.dbInit.extraAtlasFlags }}
             - name: EXTRA_ATLAS_FLAGS
               value: {{ .Values.thermos.dbInit.extraAtlasFlags | quote }}

--- a/composio/templates/thermos/thermos-misc-workers.yaml
+++ b/composio/templates/thermos/thermos-misc-workers.yaml
@@ -51,12 +51,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or (eq (include "composio.temporalEnabled" .) "true") .Values.toolkitRegistry.enabled .Values.thermosMiscWorkers.additionalInitContainers }}
       initContainers:
         {{- if eq (include "composio.temporalEnabled" .) "true" }}
 {{ include "composio.temporalNamespaceWaitInitContainer" . | nindent 8 }}
         {{- end }}
-        {{- if .Values.toolkitRegistry.enabled }}
         - name: wait-for-toolkit-registry
           image: {{ include "composio.imageReference" (dict "image" .Values.toolkitRegistry.image "context" .) | quote }}
           imagePullPolicy: {{ .Values.toolkitRegistry.image.pullPolicy }}
@@ -76,11 +74,9 @@ spec:
                 sleep 2
               done
               echo "toolkit registry is ready after $i attempt(s)"
-        {{- end }}
         {{- with .Values.thermosMiscWorkers.additionalInitContainers }}
 {{ tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
-      {{- end }}
       containers:
         - name: thermos-misc-workers
           image: {{ include "composio.imageReference" (dict "image" .Values.thermosMiscWorkers.image "context" .) | quote }}
@@ -156,10 +152,8 @@ spec:
                   name: {{ $coreSecret }}
                   key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
                   optional: true
-            {{- if .Values.toolkitRegistry.enabled }}
             - name: TOOLKIT_REGISTRY_DB_URL
               value: {{ include "composio.toolkitRegistryDbUrl" . | quote }}
-            {{- end }}
             {{- if .Values.thermosMiscWorkers.env }}
             {{- toYaml .Values.thermosMiscWorkers.env | nindent 12 }}
             {{- end }}

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -50,12 +50,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or (eq (include "composio.temporalEnabled" .) "true") .Values.toolkitRegistry.enabled .Values.thermos.additionalInitContainers }}
       initContainers:
         {{- if eq (include "composio.temporalEnabled" .) "true" }}
 {{ include "composio.temporalNamespaceWaitInitContainer" . | nindent 8 }}
         {{- end }}
-        {{- if .Values.toolkitRegistry.enabled }}
         - name: wait-for-toolkit-registry
           image: {{ include "composio.imageReference" (dict "image" .Values.toolkitRegistry.image "context" .) | quote }}
           imagePullPolicy: {{ .Values.toolkitRegistry.image.pullPolicy }}
@@ -75,11 +73,9 @@ spec:
                 sleep 2
               done
               echo "toolkit registry is ready after $i attempt(s)"
-        {{- end }}
         {{- with .Values.thermos.additionalInitContainers }}
 {{ tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
-      {{- end }}
       containers:
         - name: thermos
           image: {{ include "composio.imageReference" (dict "image" .Values.thermos.image "context" .) | quote }}
@@ -151,10 +147,8 @@ spec:
                   name: {{ $coreSecret }}
                   key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
                   optional: true
-            {{- if .Values.toolkitRegistry.enabled }}
             - name: TOOLKIT_REGISTRY_DB_URL
               value: {{ include "composio.toolkitRegistryDbUrl" . | quote }}
-            {{- end }}
             {{- if .Values.thermos.env }}
             {{- toYaml .Values.thermos.env | nindent 12 }}
             {{- end }}

--- a/composio/templates/thermos/toolkit-registry.yaml
+++ b/composio/templates/thermos/toolkit-registry.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.toolkitRegistry.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -107,4 +106,3 @@ spec:
   selector:
     app: toolkit-registry
     release: {{ .Release.Name }}
-{{- end }}

--- a/composio/tests/db_init_test.yaml
+++ b/composio/tests/db_init_test.yaml
@@ -418,28 +418,6 @@ tests:
             name: TOOLKIT_REGISTRY_ENABLED
             value: "true"
 
-  - it: should set TOOLKIT_REGISTRY_ENABLED=false when toolkitRegistry is disabled
-    set:
-      thermos.dbInit.enabled: true
-      toolkitRegistry.enabled: false
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_ENABLED
-            value: "false"
-
-  - it: should default TOOLKIT_REGISTRY_ENABLED=true when toolkitRegistry stanza is omitted
-    set:
-      thermos.dbInit.enabled: true
-      toolkitRegistry: null
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_ENABLED
-            value: "true"
-
 ---
 suite: test postgres init job
 templates:

--- a/composio/tests/thermos_test.yaml
+++ b/composio/tests/thermos_test.yaml
@@ -291,20 +291,6 @@ tests:
           path: spec.template.spec.initContainers[1].name
           value: custom-init
 
-  - it: should skip toolkit registry wiring when explicitly disabled
-    documentSelector:
-      path: kind
-      value: Deployment
-    set:
-      toolkitRegistry.enabled: false
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: TOOLKIT_REGISTRY_DB_URL
-      - isNull:
-          path: spec.template.spec.initContainers
-
 ---
 suite: test thermos service
 templates:
@@ -414,13 +400,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[0].value
           value: toolkit-registry
-
-  - it: should not render toolkit registry when disabled
-    set:
-      toolkitRegistry.enabled: false
-    asserts:
-      - hasDocuments:
-          count: 0
 
   - it: should apply nodeSelector, affinity, and tolerations to toolkit registry pod
     documentIndex: 0

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -472,9 +472,6 @@ thermos:
     scaleUpPods: 4
 # Toolkit registry configuration (read-only Postgres with toolkit/tool/trigger data)
 toolkitRegistry:
-  # -- Enable the standalone toolkit registry Postgres deployment used by Thermos for toolkit/tool/trigger reads.
-  # Enabled by default for on-prem installs; disable only if you explicitly want Thermos to fall back to the primary registry DB.
-  enabled: true
   # -- Number of toolkit registry pod replicas
   replicaCount: 2
   image:


### PR DESCRIPTION
## Summary

- remove the unsupported `toolkitRegistry.enabled` Helm value entirely
- render the toolkit registry Deployment/Service unconditionally
- always wire Thermos and Thermos misc workers to the toolkit registry DB URL and wait init container
- keep Thermos db-init on the registry path by hardcoding `TOOLKIT_REGISTRY_ENABLED=true`
- delete the unit tests that covered the old non-registry fallback

## Why

The on-prem chart should only run in registry-backed mode. There is no supported non-registry install path anymore, so the chart should not expose a boolean that suggests the toolkit registry can be disabled. Passing `toolkitRegistry.enabled=false` is now just an unused value; it does not affect rendering.

## Verification

- `./run-tests.sh thermos`
  - `27` passed
- `./run-tests.sh db`
  - `43` passed
- `helm template composio . --set toolkitRegistry.enabled=false --show-only templates/thermos/toolkit-registry.yaml --show-only templates/thermos/thermos.yaml --show-only templates/thermos/thermos-db-init-job.yaml`
  - still rendered the toolkit registry Service/Deployment, Thermos `wait-for-toolkit-registry` init container, `TOOLKIT_REGISTRY_DB_URL`, and db-init `TOOLKIT_REGISTRY_ENABLED=true`
- `./run-tests.sh`
  - `333` passed
