### PR TITLE
Make Grype CVE scans reusable

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -38,20 +38,24 @@ runs:
           --arg color    "$COLOR" \
           --arg title    "$INPUT_TITLE" \
           --arg summary  "$INPUT_SUMMARY" \
-          '{
-            text: ($title + "\n" + $summary),
+          '
+          def chunks($text; $size):
+            [range(0; ($text | length); $size) as $start | $text[$start:($start + $size)]]
+            | map(select(length > 0));
+
+          {
+            text: ($title + "\n" + $summary[0:3000]),
             attachments: [{
               color: $color,
-              blocks: [
+              blocks: ([
                 {
                   type: "section",
                   text: { type: "mrkdwn", text: ("*" + $title + "*") }
-                },
-                {
-                  type: "section",
-                  text: { type: "mrkdwn", text: $summary }
                 }
-              ]
+              ] + (chunks($summary; 2900) | .[:49] | map({
+                  type: "section",
+                  text: { type: "mrkdwn", text: . }
+                })))
             }],
             unfurl_links: false,
             unfurl_media: false

--- a/.github/scripts/cve/build-cve-report.mjs
+++ b/.github/scripts/cve/build-cve-report.mjs
@@ -99,8 +99,13 @@ export async function buildCveReport({
   releaseVersion = "",
   scanStartedAt = new Date().toISOString(),
   baselineFindingsFile = "",
+  ignoredScanTargetsFile = "",
 }) {
   const targets = await readJson(scanTargetsFile, []);
+  const ignoredTargets = await readJson(
+    ignoredScanTargetsFile || path.join(outputDir, "ignored-scan-targets.json"),
+    [],
+  );
   const baseline = baselineFindingsFile
     ? normalizeBaseline(await readJson(baselineFindingsFile, []))
     : new Map();
@@ -190,6 +195,12 @@ export async function buildCveReport({
 
   const totalHigh = imageStats.reduce((sum, item) => sum + item.high, 0);
   const totalCritical = imageStats.reduce((sum, item) => sum + item.critical, 0);
+  const ignoredImageStats = ignoredTargets.map((target) => ({
+    image: target.image,
+    scan_image: target.scan_image || target.image,
+    source: target.source || "rendered",
+    reason: target.reason || "excluded from CVE gate",
+  }));
   const fixedNow = findings.filter((finding) => finding.fix_available_now).length;
   const fixedAtReleaseScan = findings.filter(
     (finding) => finding.fix_available_at_release_scan === true,
@@ -222,6 +233,7 @@ export async function buildCveReport({
     `- Fix available at release scan: ${fixedAtReleaseScan}`,
     `- New since release scan: ${newlyDetected}`,
     `- Grype scan errors: ${scanErrors.length}`,
+    `- Ignored images: ${ignoredImageStats.length}`,
     ...imageStats.map((item) => (
       `- \`${item.image}\`: ${item.high} HIGH / ${item.critical} CRITICAL` +
       (item.image !== item.scan_image ? ` (scanned \`${item.scan_image}\`)` : "")
@@ -236,6 +248,7 @@ export async function buildCveReport({
     `- Scan started at: \`${scanStartedAt}\``,
     `- Grype DB built at: \`${grypeDbBuiltAt || "unknown"}\``,
     "- Policy: fail on any HIGH or CRITICAL finding",
+    "- Exclusions: images introduced only by the Temporal dependency chart are ignored",
     "",
     "### Image Findings",
     "",
@@ -254,6 +267,18 @@ export async function buildCveReport({
     `- New since release scan: ${newlyDetected}`,
     `- Grype scan errors: ${scanErrors.length}`,
     "",
+    "### Ignored Images",
+    "",
+    ignoredImageStats.length === 0
+      ? "No images were ignored.\n"
+      : [
+          "| Rendered image | Scanned image | Source | Reason |",
+          "| --- | --- | --- | --- |",
+          ...ignoredImageStats.map((item) => (
+            `| \`${item.image}\` | \`${item.scan_image}\` | ${item.source} | ${item.reason} |`
+          )),
+        ].join("\n") + "\n",
+    "",
     "### HIGH/CRITICAL Details",
     "",
     renderTable(findings),
@@ -261,6 +286,7 @@ export async function buildCveReport({
 
   await writeFile(path.join(outputDir, "image-stats.tsv"), imageStatsTsv);
   await writeFile(path.join(outputDir, "image-stats.json"), `${JSON.stringify(imageStats, null, 2)}\n`);
+  await writeFile(path.join(outputDir, "ignored-image-stats.json"), `${JSON.stringify(ignoredImageStats, null, 2)}\n`);
   await writeFile(path.join(outputDir, "finding-details.json"), `${JSON.stringify(findings, null, 2)}\n`);
   await writeFile(path.join(outputDir, "slack-stats.md"), slackStats);
   await writeFile(path.join(outputDir, "summary.md"), summary);
@@ -274,6 +300,7 @@ export async function buildCveReport({
     newlyDetected,
     findings,
     imageStats,
+    ignoredImageStats,
     grypeDbBuiltAt,
   };
 }
@@ -288,6 +315,7 @@ async function main() {
     releaseVersion: args.release_version || "",
     scanStartedAt: args.scan_started_at || new Date().toISOString(),
     baselineFindingsFile: args.baseline_findings || "",
+    ignoredScanTargetsFile: args.ignored_scan_targets || "",
   });
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }

--- a/.github/scripts/cve/build-cve-report.mjs
+++ b/.github/scripts/cve/build-cve-report.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HIGH_CRITICAL = new Set(["high", "critical"]);
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+    const key = arg.slice(2).replaceAll("-", "_");
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+    args[key] = value;
+    index += 1;
+  }
+  return args;
+}
+
+async function readJson(file, fallback = undefined) {
+  try {
+    return JSON.parse(await readFile(file, "utf8"));
+  } catch (error) {
+    if (fallback !== undefined && error.code === "ENOENT") {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+function findingKey({ image, id, packageName, installedVersion }) {
+  return `${image}|${id}|${packageName}|${installedVersion}`;
+}
+
+function fixAvailable(fix) {
+  if (!fix) return false;
+  if (Array.isArray(fix.versions) && fix.versions.length > 0) return true;
+  return String(fix.state || "").toLowerCase() === "fixed";
+}
+
+function vulnerabilityDate(vulnerability) {
+  return (
+    vulnerability.publishedDate ||
+    vulnerability.published_at ||
+    vulnerability.disclosureDate ||
+    vulnerability.disclosed_at ||
+    null
+  );
+}
+
+function normalizeBaseline(baseline) {
+  const map = new Map();
+  for (const item of Array.isArray(baseline) ? baseline : []) {
+    if (item?.key) {
+      map.set(item.key, item);
+    }
+  }
+  return map;
+}
+
+function reportNameForTarget(target) {
+  if (target.report) return target.report;
+  return `${target.scan_image.replaceAll(/[^A-Za-z0-9_.-]/g, "_")}.json`;
+}
+
+function renderTable(rows) {
+  if (rows.length === 0) return "No HIGH or CRITICAL findings.\n";
+  return [
+    "| Severity | CVE | Image | Package | Installed | Fix now | First detected | Fix at release scan |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ...rows.map((finding) => [
+      `| ${finding.severity}`,
+      finding.id,
+      `\`${finding.image}\``,
+      `\`${finding.package}\``,
+      `\`${finding.installed_version}\``,
+      finding.fix_available_now ? "yes" : "no",
+      finding.first_detected_at || "unknown",
+      finding.fix_available_at_release_scan === null
+        ? "unknown"
+        : finding.fix_available_at_release_scan
+          ? "yes"
+          : "no",
+    ].join(" | ") + " |"),
+  ].join("\n") + "\n";
+}
+
+export async function buildCveReport({
+  reportsDir,
+  scanTargetsFile,
+  outputDir,
+  releaseTag,
+  releaseVersion = "",
+  scanStartedAt = new Date().toISOString(),
+  baselineFindingsFile = "",
+}) {
+  const targets = await readJson(scanTargetsFile, []);
+  const baseline = baselineFindingsFile
+    ? normalizeBaseline(await readJson(baselineFindingsFile, []))
+    : new Map();
+
+  const imageStats = [];
+  const findings = [];
+  let grypeDbBuiltAt = "";
+
+  for (const target of targets) {
+    const reportName = reportNameForTarget(target);
+    const report = await readJson(path.join(reportsDir, reportName), {
+      descriptor: {},
+      matches: [],
+    });
+    grypeDbBuiltAt ||= report?.descriptor?.db?.status?.built || "";
+
+    let high = 0;
+    let critical = 0;
+
+    for (const match of report.matches || []) {
+      const vulnerability = match.vulnerability || {};
+      const severity = String(vulnerability.severity || "").toLowerCase();
+      if (!HIGH_CRITICAL.has(severity)) continue;
+      if (severity === "high") high += 1;
+      if (severity === "critical") critical += 1;
+
+      const packageName = match.artifact?.name || "unknown";
+      const installedVersion = match.artifact?.version || "unknown";
+      const id = vulnerability.id || "unknown";
+      const key = findingKey({
+        image: target.image,
+        id,
+        packageName,
+        installedVersion,
+      });
+      const prior = baseline.get(key);
+      const fixNow = fixAvailable(vulnerability.fix);
+
+      findings.push({
+        key,
+        id,
+        severity: severity === "critical" ? "Critical" : "High",
+        image: target.image,
+        scan_image: target.scan_image,
+        source: target.source || "rendered",
+        package: packageName,
+        installed_version: installedVersion,
+        package_type: match.artifact?.type || "",
+        data_source: vulnerability.dataSource || "",
+        cve_published_at: vulnerabilityDate(vulnerability),
+        seen_at_release_scan: Boolean(prior),
+        first_detected_at: prior?.first_detected_at || scanStartedAt,
+        detected_at_scan: scanStartedAt,
+        fix_state_now: vulnerability.fix?.state || "unknown",
+        fix_versions_now: vulnerability.fix?.versions || [],
+        fix_available_now: fixNow,
+        fix_available_at_release_scan:
+          typeof prior?.fix_available_at_release_scan === "boolean"
+            ? prior.fix_available_at_release_scan
+            : fixNow,
+        fix_available_at_release_scan_source:
+          typeof prior?.fix_available_at_release_scan === "boolean"
+            ? "baseline"
+            : "current_scan",
+      });
+    }
+
+    imageStats.push({
+      image: target.image,
+      scan_image: target.scan_image,
+      source: target.source || "rendered",
+      high,
+      critical,
+      grype_exit: Number(target.grype_exit || (high > 0 || critical > 0 ? 2 : 0)),
+      report: reportName,
+    });
+  }
+
+  findings.sort((left, right) => {
+    const severityOrder = { Critical: 0, High: 1 };
+    return (
+      severityOrder[left.severity] - severityOrder[right.severity] ||
+      left.id.localeCompare(right.id) ||
+      left.package.localeCompare(right.package)
+    );
+  });
+
+  const totalHigh = imageStats.reduce((sum, item) => sum + item.high, 0);
+  const totalCritical = imageStats.reduce((sum, item) => sum + item.critical, 0);
+  const fixedNow = findings.filter((finding) => finding.fix_available_now).length;
+  const fixedAtReleaseScan = findings.filter(
+    (finding) => finding.fix_available_at_release_scan === true,
+  ).length;
+  const newlyDetected = findings.filter((finding) => !finding.seen_at_release_scan).length;
+  const scanErrors = imageStats.filter(
+    (item) => item.grype_exit !== 0 && item.grype_exit !== 2,
+  );
+  const scanResult =
+    totalHigh > 0 || totalCritical > 0 || scanErrors.length > 0
+      ? "failed"
+      : "success";
+
+  const imageStatsTsv = [
+    "image\tscan_image\tsource\thigh\tcritical\tgrype_exit\treport",
+    ...imageStats.map((item) => [
+      item.image,
+      item.scan_image,
+      item.source,
+      item.high,
+      item.critical,
+      item.grype_exit,
+      item.report,
+    ].join("\t")),
+  ].join("\n") + "\n";
+
+  const slackStats = [
+    `- Total: ${totalHigh} HIGH / ${totalCritical} CRITICAL`,
+    `- Fix available now: ${fixedNow}`,
+    `- Fix available at release scan: ${fixedAtReleaseScan}`,
+    `- New since release scan: ${newlyDetected}`,
+    `- Grype scan errors: ${scanErrors.length}`,
+    ...imageStats.map((item) => (
+      `- \`${item.image}\`: ${item.high} HIGH / ${item.critical} CRITICAL` +
+      (item.image !== item.scan_image ? ` (scanned \`${item.scan_image}\`)` : "")
+    )),
+  ].join("\n") + "\n";
+
+  const summary = [
+    "## Grype CVE Scan",
+    "",
+    `- Image release tag: \`${releaseTag || "unknown"}\``,
+    `- Replicated/Helm release: \`${releaseVersion || "unknown"}\``,
+    `- Scan started at: \`${scanStartedAt}\``,
+    `- Grype DB built at: \`${grypeDbBuiltAt || "unknown"}\``,
+    "- Policy: fail on any HIGH or CRITICAL finding",
+    "",
+    "### Image Findings",
+    "",
+    "| Rendered image | Scanned image | Source | HIGH | CRITICAL | Grype exit | Report |",
+    "| --- | --- | --- | ---: | ---: | ---: | --- |",
+    ...imageStats.map((item) => (
+      `| \`${item.image}\` | \`${item.scan_image}\` | ${item.source} | ${item.high} | ${item.critical} | ${item.grype_exit} | \`${item.report}\` |`
+    )),
+    "",
+    "### Totals",
+    "",
+    `- HIGH: ${totalHigh}`,
+    `- CRITICAL: ${totalCritical}`,
+    `- Fix available now: ${fixedNow}`,
+    `- Fix available at release scan: ${fixedAtReleaseScan}`,
+    `- New since release scan: ${newlyDetected}`,
+    `- Grype scan errors: ${scanErrors.length}`,
+    "",
+    "### HIGH/CRITICAL Details",
+    "",
+    renderTable(findings),
+  ].join("\n");
+
+  await writeFile(path.join(outputDir, "image-stats.tsv"), imageStatsTsv);
+  await writeFile(path.join(outputDir, "image-stats.json"), `${JSON.stringify(imageStats, null, 2)}\n`);
+  await writeFile(path.join(outputDir, "finding-details.json"), `${JSON.stringify(findings, null, 2)}\n`);
+  await writeFile(path.join(outputDir, "slack-stats.md"), slackStats);
+  await writeFile(path.join(outputDir, "summary.md"), summary);
+
+  return {
+    scanResult,
+    totalHigh,
+    totalCritical,
+    fixedNow,
+    fixedAtReleaseScan,
+    newlyDetected,
+    findings,
+    imageStats,
+    grypeDbBuiltAt,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await buildCveReport({
+    reportsDir: args.reports_dir,
+    scanTargetsFile: args.scan_targets,
+    outputDir: args.output_dir || args.reports_dir,
+    releaseTag: args.release_tag,
+    releaseVersion: args.release_version || "",
+    scanStartedAt: args.scan_started_at || new Date().toISOString(),
+    baselineFindingsFile: args.baseline_findings || "",
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/cve/build-cve-report.mjs
+++ b/.github/scripts/cve/build-cve-report.mjs
@@ -44,6 +44,22 @@ function fixAvailable(fix) {
   return String(fix.state || "").toLowerCase() === "fixed";
 }
 
+function normalizeFixAvailableDates(fix) {
+  return (fix?.available || [])
+    .filter((item) => item && item.date)
+    .map((item) => ({
+      version: item.version || "",
+      date: item.date,
+      kind: item.kind || "",
+    }))
+    .sort((left, right) => left.date.localeCompare(right.date));
+}
+
+function earliestDate(values) {
+  const dates = values.filter(Boolean).sort();
+  return dates[0] || "";
+}
+
 function vulnerabilityDate(vulnerability) {
   return (
     vulnerability.publishedDate ||
@@ -72,8 +88,8 @@ function reportNameForTarget(target) {
 function renderTable(rows) {
   if (rows.length === 0) return "No HIGH or CRITICAL findings.\n";
   return [
-    "| Severity | CVE | Image | Package | Installed | Fix now | First detected | Fix at release scan |",
-    "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    "| Severity | CVE | Image | Package | Installed | Fix now | Earliest fix date | First detected | Fix at release scan |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
     ...rows.map((finding) => [
       `| ${finding.severity}`,
       finding.id,
@@ -81,6 +97,7 @@ function renderTable(rows) {
       `\`${finding.package}\``,
       `\`${finding.installed_version}\``,
       finding.fix_available_now ? "yes" : "no",
+      finding.earliest_fix_available_at || "none",
       finding.first_detected_at || "unknown",
       finding.fix_available_at_release_scan === null
         ? "unknown"
@@ -89,6 +106,86 @@ function renderTable(rows) {
           : "no",
     ].join(" | ") + " |"),
   ].join("\n") + "\n";
+}
+
+function emptySeverityBreakdown() {
+  return {
+    Critical: { cves: 0, fix_available: 0, no_fix_available: 0 },
+    High: { cves: 0, fix_available: 0, no_fix_available: 0 },
+  };
+}
+
+function buildImageCveBreakdown(imageStats, findings) {
+  const byImage = new Map();
+  for (const image of imageStats) {
+    byImage.set(image.image, {
+      image: image.image,
+      scan_image: image.scan_image,
+      source: image.source,
+      cve_count: 0,
+      finding_occurrences: 0,
+      fix_available_cves: 0,
+      no_fix_available_cves: 0,
+      fix_available_occurrences: 0,
+      no_fix_available_occurrences: 0,
+      earliest_fix_available_at: "",
+      severity: emptySeverityBreakdown(),
+      high: image.high,
+      critical: image.critical,
+      grype_exit: image.grype_exit,
+      report: image.report,
+    });
+  }
+
+  const cvesByImage = new Map();
+  for (const finding of findings) {
+    const image = byImage.get(finding.image);
+    if (!image) continue;
+    image.finding_occurrences += 1;
+    if (finding.fix_available_now) {
+      image.fix_available_occurrences += 1;
+    } else {
+      image.no_fix_available_occurrences += 1;
+    }
+
+    const key = `${finding.id}|${finding.severity}`;
+    const imageCves = cvesByImage.get(finding.image) || new Map();
+    const cve = imageCves.get(key) || {
+      id: finding.id,
+      severity: finding.severity,
+      fix_available: false,
+      earliest_fix_available_at: "",
+    };
+    cve.fix_available ||= finding.fix_available_now;
+    cve.earliest_fix_available_at = earliestDate([
+      cve.earliest_fix_available_at,
+      finding.earliest_fix_available_at,
+    ]);
+    imageCves.set(key, cve);
+    cvesByImage.set(finding.image, imageCves);
+  }
+
+  for (const [imageName, cves] of cvesByImage.entries()) {
+    const image = byImage.get(imageName);
+    if (!image) continue;
+    for (const cve of cves.values()) {
+      image.cve_count += 1;
+      image.severity[cve.severity].cves += 1;
+      if (cve.fix_available) {
+        image.fix_available_cves += 1;
+        image.severity[cve.severity].fix_available += 1;
+      } else {
+        image.no_fix_available_cves += 1;
+        image.severity[cve.severity].no_fix_available += 1;
+      }
+      image.earliest_fix_available_at = earliestDate([
+        image.earliest_fix_available_at,
+        cve.earliest_fix_available_at,
+      ]);
+    }
+  }
+
+  return [...byImage.values()];
 }
 
 export async function buildCveReport({
@@ -143,6 +240,7 @@ export async function buildCveReport({
       });
       const prior = baseline.get(key);
       const fixNow = fixAvailable(vulnerability.fix);
+      const fixAvailableDatesNow = normalizeFixAvailableDates(vulnerability.fix);
 
       findings.push({
         key,
@@ -161,6 +259,8 @@ export async function buildCveReport({
         detected_at_scan: scanStartedAt,
         fix_state_now: vulnerability.fix?.state || "unknown",
         fix_versions_now: vulnerability.fix?.versions || [],
+        fix_available_dates_now: fixAvailableDatesNow,
+        earliest_fix_available_at: fixAvailableDatesNow[0]?.date || "",
         fix_available_now: fixNow,
         fix_available_at_release_scan:
           typeof prior?.fix_available_at_release_scan === "boolean"
@@ -195,6 +295,7 @@ export async function buildCveReport({
 
   const totalHigh = imageStats.reduce((sum, item) => sum + item.high, 0);
   const totalCritical = imageStats.reduce((sum, item) => sum + item.critical, 0);
+  const imageCveBreakdown = buildImageCveBreakdown(imageStats, findings);
   const ignoredImageStats = ignoredTargets.map((target) => ({
     image: target.image,
     scan_image: target.scan_image || target.image,
@@ -205,6 +306,19 @@ export async function buildCveReport({
   const fixedAtReleaseScan = findings.filter(
     (finding) => finding.fix_available_at_release_scan === true,
   ).length;
+  const globalCveFixStatus = new Map();
+  for (const finding of findings) {
+    globalCveFixStatus.set(
+      finding.id,
+      (globalCveFixStatus.get(finding.id) || false) || finding.fix_available_now,
+    );
+  }
+  const uniqueCveCount = globalCveFixStatus.size;
+  const fixAvailableCves = [...globalCveFixStatus.values()].filter(Boolean).length;
+  const noFixAvailableCves = uniqueCveCount - fixAvailableCves;
+  const earliestFixAvailableAt = earliestDate(
+    findings.map((finding) => finding.earliest_fix_available_at),
+  );
   const newlyDetected = findings.filter((finding) => !finding.seen_at_release_scan).length;
   const scanErrors = imageStats.filter(
     (item) => item.grype_exit !== 0 && item.grype_exit !== 2,
@@ -227,15 +341,44 @@ export async function buildCveReport({
     ].join("\t")),
   ].join("\n") + "\n";
 
+  const imageCveBreakdownTsv = [
+    "image\tscan_image\tsource\tcve_count\tfinding_occurrences\tfix_available_cves\tno_fix_available_cves\tfix_available_occurrences\tno_fix_available_occurrences\tcritical_cves\tcritical_fix_available\tcritical_no_fix_available\thigh_cves\thigh_fix_available\thigh_no_fix_available\tearliest_fix_available_at",
+    ...imageCveBreakdown.map((item) => [
+      item.image,
+      item.scan_image,
+      item.source,
+      item.cve_count,
+      item.finding_occurrences,
+      item.fix_available_cves,
+      item.no_fix_available_cves,
+      item.fix_available_occurrences,
+      item.no_fix_available_occurrences,
+      item.severity.Critical.cves,
+      item.severity.Critical.fix_available,
+      item.severity.Critical.no_fix_available,
+      item.severity.High.cves,
+      item.severity.High.fix_available,
+      item.severity.High.no_fix_available,
+      item.earliest_fix_available_at,
+    ].join("\t")),
+  ].join("\n") + "\n";
+
   const slackStats = [
     `- Total: ${totalHigh} HIGH / ${totalCritical} CRITICAL`,
+    `- Unique CVE/advisory IDs: ${uniqueCveCount}`,
+    `- Unique CVE/advisory IDs with fixes: ${fixAvailableCves}`,
+    `- Unique CVE/advisory IDs without fixes: ${noFixAvailableCves}`,
     `- Fix available now: ${fixedNow}`,
     `- Fix available at release scan: ${fixedAtReleaseScan}`,
+    `- Earliest fix date detected: ${earliestFixAvailableAt || "none"}`,
     `- New since release scan: ${newlyDetected}`,
     `- Grype scan errors: ${scanErrors.length}`,
     `- Ignored images: ${ignoredImageStats.length}`,
-    ...imageStats.map((item) => (
-      `- \`${item.image}\`: ${item.high} HIGH / ${item.critical} CRITICAL` +
+    ...imageCveBreakdown.map((item) => (
+      `- \`${item.image}\`: ${item.high} HIGH / ${item.critical} CRITICAL, ` +
+      `${item.cve_count} unique CVE/advisory IDs, ` +
+      `${item.fix_available_cves} fixable / ${item.no_fix_available_cves} no fix, ` +
+      `earliest fix ${item.earliest_fix_available_at || "none"}` +
       (item.image !== item.scan_image ? ` (scanned \`${item.scan_image}\`)` : "")
     )),
   ].join("\n") + "\n";
@@ -262,10 +405,22 @@ export async function buildCveReport({
     "",
     `- HIGH: ${totalHigh}`,
     `- CRITICAL: ${totalCritical}`,
+    `- Unique CVE/advisory IDs: ${uniqueCveCount}`,
+    `- Unique CVE/advisory IDs with fixes: ${fixAvailableCves}`,
+    `- Unique CVE/advisory IDs without fixes: ${noFixAvailableCves}`,
+    `- Earliest fix date detected: ${earliestFixAvailableAt || "none"}`,
     `- Fix available now: ${fixedNow}`,
     `- Fix available at release scan: ${fixedAtReleaseScan}`,
     `- New since release scan: ${newlyDetected}`,
     `- Grype scan errors: ${scanErrors.length}`,
+    "",
+    "### Image CVE Breakdown",
+    "",
+    "| Rendered image | Scanned image | Unique CVE/advisory IDs | Package occurrences | Fixable CVEs | No-fix CVEs | CRITICAL fix/no fix | HIGH fix/no fix | Earliest fix date detected |",
+    "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ...imageCveBreakdown.map((item) => (
+      `| \`${item.image}\` | \`${item.scan_image}\` | ${item.cve_count} | ${item.finding_occurrences} | ${item.fix_available_cves} | ${item.no_fix_available_cves} | ${item.severity.Critical.fix_available} / ${item.severity.Critical.no_fix_available} | ${item.severity.High.fix_available} / ${item.severity.High.no_fix_available} | ${item.earliest_fix_available_at || "none"} |`
+    )),
     "",
     "### Ignored Images",
     "",
@@ -286,6 +441,8 @@ export async function buildCveReport({
 
   await writeFile(path.join(outputDir, "image-stats.tsv"), imageStatsTsv);
   await writeFile(path.join(outputDir, "image-stats.json"), `${JSON.stringify(imageStats, null, 2)}\n`);
+  await writeFile(path.join(outputDir, "image-cve-breakdown.tsv"), imageCveBreakdownTsv);
+  await writeFile(path.join(outputDir, "image-cve-breakdown.json"), `${JSON.stringify(imageCveBreakdown, null, 2)}\n`);
   await writeFile(path.join(outputDir, "ignored-image-stats.json"), `${JSON.stringify(ignoredImageStats, null, 2)}\n`);
   await writeFile(path.join(outputDir, "finding-details.json"), `${JSON.stringify(findings, null, 2)}\n`);
   await writeFile(path.join(outputDir, "slack-stats.md"), slackStats);
@@ -295,11 +452,16 @@ export async function buildCveReport({
     scanResult,
     totalHigh,
     totalCritical,
+    uniqueCveCount,
+    fixAvailableCves,
+    noFixAvailableCves,
+    earliestFixAvailableAt,
     fixedNow,
     fixedAtReleaseScan,
     newlyDetected,
     findings,
     imageStats,
+    imageCveBreakdown,
     ignoredImageStats,
     grypeDbBuiltAt,
   };

--- a/.github/scripts/cve/build-cve-report.mjs
+++ b/.github/scripts/cve/build-cve-report.mjs
@@ -14,7 +14,7 @@ function parseArgs(argv) {
     }
     const key = arg.slice(2).replaceAll("-", "_");
     const value = argv[index + 1];
-    if (!value || value.startsWith("--")) {
+    if (index + 1 >= argv.length || value.startsWith("--")) {
       throw new Error(`Missing value for ${arg}`);
     }
     args[key] = value;

--- a/.github/scripts/cve/build-cve-report.mjs
+++ b/.github/scripts/cve/build-cve-report.mjs
@@ -300,7 +300,7 @@ export async function buildCveReport({
     image: target.image,
     scan_image: target.scan_image || target.image,
     source: target.source || "rendered",
-    reason: target.reason || "excluded from CVE gate",
+    reason: target.reason || "excluded from CVE scan",
   }));
   const fixedNow = findings.filter((finding) => finding.fix_available_now).length;
   const fixedAtReleaseScan = findings.filter(

--- a/.github/scripts/cve/build-cve-report.test.mjs
+++ b/.github/scripts/cve/build-cve-report.test.mjs
@@ -34,9 +34,47 @@ test("buildCveReport aggregates image stats and enriched high/critical findings"
             id: "CVE-1",
             severity: "Critical",
             dataSource: "https://example.test/CVE-1",
-            fix: { state: "fixed", versions: ["1.2.4"] },
+            fix: {
+              state: "fixed",
+              versions: ["1.2.4"],
+              available: [{ version: "1.2.4", date: "2026-06-20", kind: "first-observed" }],
+            },
           },
           artifact: { name: "openssl", version: "1.2.3", type: "deb" },
+        },
+        {
+          vulnerability: {
+            id: "CVE-3",
+            severity: "High",
+            dataSource: "https://example.test/CVE-3",
+            fix: { state: "not-fixed", versions: [] },
+          },
+          artifact: { name: "glibc", version: "2.36", type: "deb" },
+        },
+        {
+          vulnerability: {
+            id: "CVE-3",
+            severity: "High",
+            dataSource: "https://example.test/CVE-3",
+            fix: { state: "not-fixed", versions: [] },
+          },
+          artifact: { name: "libc-bin", version: "2.36", type: "deb" },
+        },
+        {
+          vulnerability: {
+            id: "GHSA-4",
+            severity: "High",
+            dataSource: "https://example.test/GHSA-4",
+            fix: {
+              state: "fixed",
+              versions: ["4.0.1"],
+              available: [
+                { version: "4.0.0", date: "2026-06-25", kind: "first-observed" },
+                { version: "4.0.1", date: "2026-06-15", kind: "first-observed" },
+              ],
+            },
+          },
+          artifact: { name: "pillow", version: "4.0.0", type: "python" },
         },
         {
           vulnerability: {
@@ -86,28 +124,50 @@ test("buildCveReport aggregates image stats and enriched high/critical findings"
     });
 
     assert.equal(result.scanResult, "failed");
-    assert.equal(result.totalHigh, 0);
+    assert.equal(result.totalHigh, 3);
     assert.equal(result.totalCritical, 1);
-    assert.equal(result.newlyDetected, 0);
-    assert.equal(result.findings.length, 1);
+    assert.equal(result.newlyDetected, 3);
+    assert.equal(result.findings.length, 4);
     assert.equal(result.findings[0].fix_available_now, true);
     assert.equal(result.findings[0].seen_at_release_scan, true);
     assert.equal(result.findings[0].fix_available_at_release_scan, false);
     assert.equal(result.findings[0].first_detected_at, "2026-07-01T00:00:00Z");
+    assert.equal(result.findings[0].earliest_fix_available_at, "2026-06-20");
+    assert.deepEqual(result.findings[0].fix_available_dates_now, [
+      { version: "1.2.4", date: "2026-06-20", kind: "first-observed" },
+    ]);
+    assert.equal(result.imageCveBreakdown.length, 1);
+    assert.equal(result.imageCveBreakdown[0].cve_count, 3);
+    assert.equal(result.imageCveBreakdown[0].finding_occurrences, 4);
+    assert.equal(result.imageCveBreakdown[0].fix_available_cves, 2);
+    assert.equal(result.imageCveBreakdown[0].no_fix_available_cves, 1);
+    assert.equal(result.imageCveBreakdown[0].earliest_fix_available_at, "2026-06-15");
+    assert.deepEqual(result.imageCveBreakdown[0].severity, {
+      Critical: { cves: 1, fix_available: 1, no_fix_available: 0 },
+      High: { cves: 2, fix_available: 1, no_fix_available: 1 },
+    });
     assert.equal(result.ignoredImageStats.length, 1);
     assert.equal(result.ignoredImageStats[0].image, "temporalio/admin-tools:1.28.0");
 
     const summary = await readFile(path.join(dir, "summary.md"), "utf8");
     assert.match(summary, /Replicated\/Helm release: `0\.2\.99`/);
     assert.match(summary, /CVE-1/);
+    assert.match(summary, /Image CVE Breakdown/);
+    assert.match(summary, /Earliest fix date detected/);
+    assert.match(summary, /Unique CVE\/advisory IDs: 3/);
     assert.match(summary, /Fix available now/);
     assert.match(summary, /Temporal dependency chart/);
     assert.match(summary, /Ignored Images/);
     assert.match(summary, /temporalio\/admin-tools:1\.28\.0/);
 
+    const imageBreakdown = JSON.parse(await readFile(path.join(dir, "image-cve-breakdown.json"), "utf8"));
+    assert.equal(imageBreakdown[0].earliest_fix_available_at, "2026-06-15");
+
     const slack = await readFile(path.join(dir, "slack-stats.md"), "utf8");
-    assert.match(slack, /1 CRITICAL/);
-    assert.match(slack, /Fix available now: 1/);
+    assert.match(slack, /3 HIGH \/ 1 CRITICAL/);
+    assert.match(slack, /Fix available now: 2/);
+    assert.match(slack, /Unique CVE\/advisory IDs: 3/);
+    assert.match(slack, /Earliest fix date detected: 2026-06-15/);
     assert.match(slack, /Ignored images: 1/);
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/.github/scripts/cve/build-cve-report.test.mjs
+++ b/.github/scripts/cve/build-cve-report.test.mjs
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import test from "node:test";
 
 import { buildCveReport } from "./build-cve-report.mjs";
+
+const execFileAsync = promisify(execFile);
 
 async function writeJson(file, value) {
   await writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
@@ -16,7 +20,7 @@ test("buildCveReport aggregates image stats and enriched high/critical findings"
     const reportsDir = path.join(dir, "reports");
     await writeFile(path.join(dir, "placeholder"), "");
     await rm(path.join(dir, "placeholder"));
-    await import("node:fs/promises").then(({ mkdir }) => mkdir(reportsDir));
+    await mkdir(reportsDir);
 
     const reportName = "apollo.json";
     await writeJson(path.join(reportsDir, reportName), {
@@ -91,6 +95,36 @@ test("buildCveReport aggregates image stats and enriched high/critical findings"
     const slack = await readFile(path.join(dir, "slack-stats.md"), "utf8");
     assert.match(slack, /1 CRITICAL/);
     assert.match(slack, /Fix available now: 1/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI accepts an empty optional release version", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "cve-report-cli-test-"));
+  try {
+    const reportsDir = path.join(dir, "reports");
+    await mkdir(reportsDir);
+    await writeJson(path.join(dir, "scan-targets.json"), []);
+
+    await execFileAsync(process.execPath, [
+      path.join(import.meta.dirname, "build-cve-report.mjs"),
+      "--reports-dir",
+      reportsDir,
+      "--scan-targets",
+      path.join(dir, "scan-targets.json"),
+      "--output-dir",
+      dir,
+      "--release-tag",
+      "r1",
+      "--release-version",
+      "",
+      "--scan-started-at",
+      "2026-07-02T12:00:00Z",
+    ]);
+
+    const summary = await readFile(path.join(dir, "summary.md"), "utf8");
+    assert.match(summary, /Replicated\/Helm release: `unknown`/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/.github/scripts/cve/build-cve-report.test.mjs
+++ b/.github/scripts/cve/build-cve-report.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildCveReport } from "./build-cve-report.mjs";
+
+async function writeJson(file, value) {
+  await writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+test("buildCveReport aggregates image stats and enriched high/critical findings", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "cve-report-test-"));
+  try {
+    const reportsDir = path.join(dir, "reports");
+    await writeFile(path.join(dir, "placeholder"), "");
+    await rm(path.join(dir, "placeholder"));
+    await import("node:fs/promises").then(({ mkdir }) => mkdir(reportsDir));
+
+    const reportName = "apollo.json";
+    await writeJson(path.join(reportsDir, reportName), {
+      descriptor: {
+        db: { status: { built: "2026-07-02T10:00:00Z" } },
+        version: "0.115.0",
+      },
+      matches: [
+        {
+          vulnerability: {
+            id: "CVE-1",
+            severity: "Critical",
+            dataSource: "https://example.test/CVE-1",
+            fix: { state: "fixed", versions: ["1.2.4"] },
+          },
+          artifact: { name: "openssl", version: "1.2.3", type: "deb" },
+        },
+        {
+          vulnerability: {
+            id: "CVE-2",
+            severity: "Medium",
+            fix: { state: "fixed", versions: ["9.9.9"] },
+          },
+          artifact: { name: "ignored", version: "9.9.8", type: "deb" },
+        },
+      ],
+    });
+
+    await writeJson(path.join(dir, "scan-targets.json"), [
+      {
+        image: "artifacts.composio.io/proxy/app/ecr/apollo:r1",
+        scan_image: "008971668139.dkr.ecr.us-east-1.amazonaws.com/composio-self-host/apollo:r1",
+        source: "replicated-proxy",
+        report: reportName,
+        grype_exit: 2,
+      },
+    ]);
+
+    await writeJson(path.join(dir, "baseline.json"), [
+      {
+        key: "artifacts.composio.io/proxy/app/ecr/apollo:r1|CVE-1|openssl|1.2.3",
+        first_detected_at: "2026-07-01T00:00:00Z",
+        fix_available_at_release_scan: false,
+      },
+    ]);
+
+    const result = await buildCveReport({
+      reportsDir,
+      scanTargetsFile: path.join(dir, "scan-targets.json"),
+      outputDir: dir,
+      releaseTag: "r1",
+      releaseVersion: "0.2.99",
+      scanStartedAt: "2026-07-02T12:00:00Z",
+      baselineFindingsFile: path.join(dir, "baseline.json"),
+    });
+
+    assert.equal(result.scanResult, "failed");
+    assert.equal(result.totalHigh, 0);
+    assert.equal(result.totalCritical, 1);
+    assert.equal(result.newlyDetected, 0);
+    assert.equal(result.findings.length, 1);
+    assert.equal(result.findings[0].fix_available_now, true);
+    assert.equal(result.findings[0].seen_at_release_scan, true);
+    assert.equal(result.findings[0].fix_available_at_release_scan, false);
+    assert.equal(result.findings[0].first_detected_at, "2026-07-01T00:00:00Z");
+
+    const summary = await readFile(path.join(dir, "summary.md"), "utf8");
+    assert.match(summary, /Replicated\/Helm release: `0\.2\.99`/);
+    assert.match(summary, /CVE-1/);
+    assert.match(summary, /Fix available now/);
+
+    const slack = await readFile(path.join(dir, "slack-stats.md"), "utf8");
+    assert.match(slack, /1 CRITICAL/);
+    assert.match(slack, /Fix available now: 1/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/cve/build-cve-report.test.mjs
+++ b/.github/scripts/cve/build-cve-report.test.mjs
@@ -58,6 +58,14 @@ test("buildCveReport aggregates image stats and enriched high/critical findings"
         grype_exit: 2,
       },
     ]);
+    await writeJson(path.join(dir, "ignored-scan-targets.json"), [
+      {
+        image: "temporalio/admin-tools:1.28.0",
+        scan_image: "temporalio/admin-tools:1.28.0",
+        source: "rendered",
+        reason: "Temporal dependency chart image; excluded from Composio-managed CVE gate",
+      },
+    ]);
 
     await writeJson(path.join(dir, "baseline.json"), [
       {
@@ -86,15 +94,21 @@ test("buildCveReport aggregates image stats and enriched high/critical findings"
     assert.equal(result.findings[0].seen_at_release_scan, true);
     assert.equal(result.findings[0].fix_available_at_release_scan, false);
     assert.equal(result.findings[0].first_detected_at, "2026-07-01T00:00:00Z");
+    assert.equal(result.ignoredImageStats.length, 1);
+    assert.equal(result.ignoredImageStats[0].image, "temporalio/admin-tools:1.28.0");
 
     const summary = await readFile(path.join(dir, "summary.md"), "utf8");
     assert.match(summary, /Replicated\/Helm release: `0\.2\.99`/);
     assert.match(summary, /CVE-1/);
     assert.match(summary, /Fix available now/);
+    assert.match(summary, /Temporal dependency chart/);
+    assert.match(summary, /Ignored Images/);
+    assert.match(summary, /temporalio\/admin-tools:1\.28\.0/);
 
     const slack = await readFile(path.join(dir, "slack-stats.md"), "utf8");
     assert.match(slack, /1 CRITICAL/);
     assert.match(slack, /Fix available now: 1/);
+    assert.match(slack, /Ignored images: 1/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/.github/scripts/cve/build-cve-report.test.mjs
+++ b/.github/scripts/cve/build-cve-report.test.mjs
@@ -101,7 +101,7 @@ test("buildCveReport aggregates image stats and enriched high/critical findings"
         image: "temporalio/admin-tools:1.28.0",
         scan_image: "temporalio/admin-tools:1.28.0",
         source: "rendered",
-        reason: "Temporal dependency chart image; excluded from Composio-managed CVE gate",
+        reason: "Temporal dependency chart image; excluded from Composio-managed CVE scan",
       },
     ]);
 

--- a/.github/scripts/cve/build-released-cve-audit-alert.mjs
+++ b/.github/scripts/cve/build-released-cve-audit-alert.mjs
@@ -1,0 +1,142 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+async function readTextIfPresent(file) {
+  if (!file) return "";
+  try {
+    return await readFile(file, "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") return "";
+    throw error;
+  }
+}
+
+async function readJsonIfPresent(file) {
+  const text = await readTextIfPresent(file);
+  if (!text.trim()) return {};
+  return JSON.parse(text);
+}
+
+function trim(value) {
+  return String(value ?? "").trim();
+}
+
+function withFailureMention(summary, slackUsergroupId) {
+  const body = trim(summary);
+  if (!slackUsergroupId || body.includes(`<!subteam^${slackUsergroupId}|@implementations>`)) {
+    return `${body}\n`;
+  }
+  return `<!subteam^${slackUsergroupId}|@implementations>\n${body}\n`;
+}
+
+export function buildReleasedCveAuditAlert({
+  auditStatus = "",
+  auditTitle = "",
+  auditSummary = "",
+  slackUsergroupId = "",
+  channel = "Stable",
+  releaseCount = "3",
+  releaseSequences = "",
+  releasesOutcome = "unknown",
+  auditOutcome = "unknown",
+  runUrl = "",
+  artifactName = "",
+  artifactDownloadCommand = "",
+}) {
+  const status = trim(auditStatus);
+  const summary = trim(auditSummary);
+
+  if (summary) {
+    const resolvedStatus = status || "FAILURE";
+    return {
+      status: resolvedStatus,
+      title:
+        trim(auditTitle) ||
+        (resolvedStatus === "SUCCESS"
+          ? ":white_check_mark: Released CVE audit: clean"
+          : ":rotating_light: Released CVE audit: ATTENTION NEEDED"),
+      summary:
+        resolvedStatus === "SUCCESS"
+          ? `${summary}\n`
+          : withFailureMention(summary, trim(slackUsergroupId)),
+    };
+  }
+
+  const scope =
+    trim(releaseSequences) === ""
+      ? `channel \`${channel}\`, latest ${releaseCount} release(s)`
+      : `explicit Replicated release sequence(s): \`${releaseSequences}\``;
+  const lines = [];
+  if (slackUsergroupId) {
+    lines.push(`<!subteam^${slackUsergroupId}|@implementations>`);
+  }
+  lines.push(
+    "*Good to go:* NO - released CVE audit did not complete",
+    "*Scope:* Already released channel versions only; independent of the nightly release gate.",
+    `*Requested audit:* ${scope}`,
+    "*Findings:* UNKNOWN - the audit failed before producing the CVE summary.",
+    "*Stages:*",
+    `- Release resolution: \`${releasesOutcome || "unknown"}\``,
+    `- Audit scan/report: \`${auditOutcome || "unknown"}\``,
+  );
+  if (artifactName) {
+    lines.push(`*Artifact:* \`${artifactName}\``);
+  }
+  if (artifactDownloadCommand) {
+    lines.push("*Download partial reports, if any were uploaded:*", "```", artifactDownloadCommand, "```");
+  }
+  if (runUrl) {
+    lines.push(`*Workflow:* <${runUrl}|released CVE audit run>`);
+  }
+
+  return {
+    status: "FAILURE",
+    title: ":rotating_light: Released CVE audit: WORKFLOW FAILED",
+    summary: `${lines.join("\n")}\n`,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (index + 1 >= argv.length || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    args[key.slice(2).replaceAll("-", "_")] = value;
+    index += 1;
+  }
+  return args;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArgs(process.argv.slice(2));
+  const outputDir = args.output_dir || "audit-reports";
+  const resultFile = args.result_file || path.join(outputDir, "released-cve-audit-result.json");
+  const summaryFile = args.summary_file || path.join(outputDir, "slack-summary.md");
+  const result = await readJsonIfPresent(resultFile);
+  const summary = await readTextIfPresent(summaryFile);
+  const alert = buildReleasedCveAuditAlert({
+    auditStatus: result.status,
+    auditTitle: result.slackTitle,
+    auditSummary: summary,
+    slackUsergroupId: args.slack_usergroup_id || "",
+    channel: args.channel || "Stable",
+    releaseCount: args.release_count || "3",
+    releaseSequences: args.release_sequences || "",
+    releasesOutcome: args.releases_outcome || "unknown",
+    auditOutcome: args.audit_outcome || "unknown",
+    runUrl: args.run_url || "",
+    artifactName: args.artifact_name || "",
+    artifactDownloadCommand: args.artifact_download_command || "",
+  });
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(path.join(outputDir, "released-cve-audit-alert.json"), `${JSON.stringify(alert, null, 2)}\n`);
+  await writeFile(path.join(outputDir, "released-cve-audit-alert-summary.md"), alert.summary);
+  process.stdout.write(`${JSON.stringify(alert, null, 2)}\n`);
+}

--- a/.github/scripts/cve/build-released-cve-audit-alert.mjs
+++ b/.github/scripts/cve/build-released-cve-audit-alert.mjs
@@ -72,7 +72,8 @@ export function buildReleasedCveAuditAlert({
   }
   lines.push(
     "*Good to go:* NO - released CVE audit did not complete",
-    "*Scope:* Already released channel versions only; independent of the nightly release gate.",
+    "*Scope:* Already released channel versions only; independent of the nightly release workflow.",
+    "*Release blocking:* NO - this audit is alert-only.",
     `*Requested audit:* ${scope}`,
     "*Findings:* UNKNOWN - the audit failed before producing the CVE summary.",
     "*Stages:*",

--- a/.github/scripts/cve/build-released-cve-audit-alert.test.mjs
+++ b/.github/scripts/cve/build-released-cve-audit-alert.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildReleasedCveAuditAlert } from "./build-released-cve-audit-alert.mjs";
+
+test("uses the completed released audit summary when one exists", () => {
+  const alert = buildReleasedCveAuditAlert({
+    auditStatus: "FAILURE",
+    auditTitle: ":rotating_light: Released CVE audit: ATTENTION NEEDED",
+    auditSummary: "<!subteam^S123|@implementations>\n*Good to go:* NO - Released images contain 2 HIGH and 1 CRITICAL findings\n",
+    slackUsergroupId: "S123",
+    channel: "Stable",
+    releaseCount: "3",
+    releaseSequences: "",
+    auditOutcome: "success",
+    releasesOutcome: "success",
+    runUrl: "https://github.com/ComposioHQ/helm-charts/actions/runs/1",
+    artifactName: "released-grype-cve-audit-1-1",
+    artifactDownloadCommand:
+      "gh run download 1 --repo ComposioHQ/helm-charts --name released-grype-cve-audit-1-1 --dir ./released-cve-audit",
+  });
+
+  assert.equal(alert.status, "FAILURE");
+  assert.equal(alert.title, ":rotating_light: Released CVE audit: ATTENTION NEEDED");
+  assert.match(alert.summary, /^<!subteam\^S123\|@implementations>/);
+  assert.match(alert.summary, /Released images contain 2 HIGH and 1 CRITICAL findings/);
+  assert.doesNotMatch(alert.summary, /Nightly release gate/);
+});
+
+test("builds a tagged fallback alert when the released audit fails before summary generation", () => {
+  const alert = buildReleasedCveAuditAlert({
+    auditStatus: "",
+    auditTitle: "",
+    auditSummary: "",
+    slackUsergroupId: "S123",
+    channel: "Stable",
+    releaseCount: "3",
+    releaseSequences: "",
+    auditOutcome: "failure",
+    releasesOutcome: "success",
+    runUrl: "https://github.com/ComposioHQ/helm-charts/actions/runs/2",
+    artifactName: "released-grype-cve-audit-2-1",
+    artifactDownloadCommand:
+      "gh run download 2 --repo ComposioHQ/helm-charts --name released-grype-cve-audit-2-1 --dir ./released-cve-audit",
+  });
+
+  assert.equal(alert.status, "FAILURE");
+  assert.equal(alert.title, ":rotating_light: Released CVE audit: WORKFLOW FAILED");
+  assert.match(alert.summary, /^<!subteam\^S123\|@implementations>/);
+  assert.match(alert.summary, /\*Good to go:\* NO - released CVE audit did not complete/);
+  assert.match(alert.summary, /\*Scope:\* Already released channel versions only; independent of the nightly release gate\./);
+  assert.match(alert.summary, /\*Findings:\* UNKNOWN - the audit failed before producing the CVE summary\./);
+  assert.match(alert.summary, /Release resolution: `success`/);
+  assert.match(alert.summary, /Audit scan\/report: `failure`/);
+  assert.match(alert.summary, /released-grype-cve-audit-2-1/);
+  assert.match(alert.summary, /https:\/\/github\.com\/ComposioHQ\/helm-charts\/actions\/runs\/2/);
+});

--- a/.github/scripts/cve/build-released-cve-audit-alert.test.mjs
+++ b/.github/scripts/cve/build-released-cve-audit-alert.test.mjs
@@ -48,7 +48,8 @@ test("builds a tagged fallback alert when the released audit fails before summar
   assert.equal(alert.title, ":rotating_light: Released CVE audit: WORKFLOW FAILED");
   assert.match(alert.summary, /^<!subteam\^S123\|@implementations>/);
   assert.match(alert.summary, /\*Good to go:\* NO - released CVE audit did not complete/);
-  assert.match(alert.summary, /\*Scope:\* Already released channel versions only; independent of the nightly release gate\./);
+  assert.match(alert.summary, /\*Scope:\* Already released channel versions only; independent of the nightly release workflow\./);
+  assert.match(alert.summary, /\*Release blocking:\* NO - this audit is alert-only\./);
   assert.match(alert.summary, /\*Findings:\* UNKNOWN - the audit failed before producing the CVE summary\./);
   assert.match(alert.summary, /Release resolution: `success`/);
   assert.match(alert.summary, /Audit scan\/report: `failure`/);

--- a/.github/scripts/cve/build-released-cve-audit.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.mjs
@@ -151,6 +151,10 @@ function markdownTableCell(value) {
   return String(value ?? "").replaceAll("\n", " ").replaceAll("|", "\\|");
 }
 
+function markdownRow(cells) {
+  return `| ${cells.map(markdownTableCell).join(" | ")} |`;
+}
+
 function buildMarkdownSummary(report) {
   const lines = [
     "## Released CVE Audit",
@@ -194,13 +198,12 @@ function buildMarkdownSummary(report) {
 
   for (const release of report.releases) {
     lines.push(
-      [
-        "|",
+      markdownRow([
         release.sequence,
-        markdownTableCell(release.created_at || "unknown"),
-        markdownTableCell(release.chart_version || "unknown"),
-        `\`${markdownTableCell(release.detected_release_tag || "unknown")}\``,
-        markdownTableCell(release.baseline_source || "missing"),
+        release.created_at || "unknown",
+        release.chart_version || "unknown",
+        `\`${release.detected_release_tag || "unknown"}\``,
+        release.baseline_source || "missing",
         release.totalHigh,
         release.totalCritical,
         release.publishTiming.publishedAfterRelease,
@@ -208,9 +211,8 @@ function buildMarkdownSummary(report) {
         release.reasonCounts["missing-release-baseline"] || 0,
         release.reasonCounts["new-since-release-scan"] || 0,
         release.fixedNow,
-        markdownTableCell(release.scan_result),
-        "|",
-      ].join(" "),
+        release.scan_result,
+      ]),
     );
   }
 
@@ -224,15 +226,14 @@ function buildMarkdownSummary(report) {
 
   for (const finding of report.findingContext) {
     lines.push(
-      [
-        "|",
+      markdownRow([
         finding.release_sequence,
-        markdownTableCell(finding.severity || "unknown"),
-        markdownTableCell(finding.id || "unknown"),
-        markdownTableCell(finding.cve_published_at || "unknown"),
-        markdownTableCell(finding.release_context_reason_label || "unknown"),
-        `\`${markdownTableCell(finding.image || "unknown")}\``,
-        `\`${markdownTableCell(finding.package || "unknown")}\``,
+        finding.severity || "unknown",
+        finding.id || "unknown",
+        finding.cve_published_at || "unknown",
+        finding.release_context_reason_label || "unknown",
+        `\`${finding.image || "unknown"}\``,
+        `\`${finding.package || "unknown"}\``,
         finding.fix_available_now ? "yes" : "no",
         finding.fix_available_at_release_scan === null ||
         typeof finding.fix_available_at_release_scan === "undefined"
@@ -240,8 +241,7 @@ function buildMarkdownSummary(report) {
           : finding.fix_available_at_release_scan
             ? "yes"
             : "no",
-        "|",
-      ].join(" "),
+      ]),
     );
   }
 

--- a/.github/scripts/cve/build-released-cve-audit.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.mjs
@@ -1,0 +1,396 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const REASON_LABELS = {
+  "published-after-release": "published after release",
+  "no-fix-at-release-scan": "no fix at release scan",
+  "missing-release-baseline": "missing release baseline",
+  "new-since-release-scan": "new since release scan",
+  "known-fix-available-at-release-scan": "known with fix available at release scan",
+  "unknown-release-context": "unknown release context",
+};
+
+const REASON_ORDER = [
+  "published-after-release",
+  "no-fix-at-release-scan",
+  "missing-release-baseline",
+  "new-since-release-scan",
+  "known-fix-available-at-release-scan",
+  "unknown-release-context",
+];
+
+function parseDate(value) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+}
+
+function increment(object, key, amount = 1) {
+  object[key] = (object[key] || 0) + amount;
+}
+
+function number(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function baselineMissing(release) {
+  const source = String(release.baseline_source || "").trim();
+  return source === "" || source === "missing";
+}
+
+function publicationBucket(finding, release) {
+  const publishedAt = parseDate(finding.cve_published_at);
+  if (!publishedAt) return "unknownPublishDate";
+
+  const releaseCreatedAt = parseDate(release.release_created_at);
+  if (releaseCreatedAt && publishedAt > releaseCreatedAt) {
+    return "publishedAfterRelease";
+  }
+
+  return "publishedOnOrBeforeRelease";
+}
+
+export function classifyFindingReleaseContext(finding, release) {
+  if (publicationBucket(finding, release) === "publishedAfterRelease") {
+    return "published-after-release";
+  }
+
+  if (baselineMissing(release)) {
+    return "missing-release-baseline";
+  }
+
+  if (finding.seen_at_release_scan === false) {
+    return "new-since-release-scan";
+  }
+
+  if (finding.fix_available_at_release_scan === false) {
+    return "no-fix-at-release-scan";
+  }
+
+  if (finding.fix_available_at_release_scan === true) {
+    return "known-fix-available-at-release-scan";
+  }
+
+  return "unknown-release-context";
+}
+
+async function readJson(file, fallback = null) {
+  try {
+    return JSON.parse(await readFile(file, "utf8"));
+  } catch (error) {
+    if (fallback !== null && error.code === "ENOENT") return fallback;
+    throw error;
+  }
+}
+
+function releaseSummary(release, findings) {
+  const reasonCounts = {};
+  const publishTiming = {
+    publishedAfterRelease: 0,
+    publishedOnOrBeforeRelease: 0,
+    unknownPublishDate: 0,
+  };
+
+  for (const finding of findings) {
+    increment(reasonCounts, finding.release_context_reason);
+    increment(publishTiming, finding.release_publish_timing);
+  }
+
+  return {
+    sequence: release.release_sequence,
+    created_at: release.release_created_at || "",
+    chart_version: release.release_chart_version || "",
+    detected_release_tag: release.detected_release_tag || "",
+    baseline_source: release.baseline_source || "missing",
+    scan_result: release.scanResult || "unknown",
+    totalHigh: number(release.totalHigh),
+    totalCritical: number(release.totalCritical),
+    fixedNow: number(release.fixedNow),
+    fixedAtReleaseScan: number(release.fixedAtReleaseScan),
+    newlyDetected: number(release.newlyDetected),
+    releaseError: release.error || "",
+    grypeScanErrors: (release.imageStats || []).filter(
+      (item) => number(item.grype_exit) !== 0 && number(item.grype_exit) !== 2,
+    ).length,
+    publishTiming,
+    reasonCounts,
+  };
+}
+
+function buildFindingContext(releases) {
+  const findings = [];
+
+  for (const release of releases) {
+    for (const finding of release.findings || []) {
+      const releasePublishTiming = publicationBucket(finding, release);
+      const releaseContextReason = classifyFindingReleaseContext(finding, release);
+      findings.push({
+        ...finding,
+        release_sequence: release.release_sequence,
+        release_created_at: release.release_created_at || "",
+        release_chart_version: release.release_chart_version || "",
+        detected_release_tag: release.detected_release_tag || "",
+        baseline_source: release.baseline_source || "missing",
+        release_publish_timing: releasePublishTiming,
+        release_context_reason: releaseContextReason,
+        release_context_reason_label: REASON_LABELS[releaseContextReason],
+      });
+    }
+  }
+
+  return findings;
+}
+
+function reasonLines(reasonCounts) {
+  return REASON_ORDER.map((reason) => `- ${REASON_LABELS[reason]}: ${reasonCounts[reason] || 0}`);
+}
+
+function markdownTableCell(value) {
+  return String(value ?? "").replaceAll("\n", " ").replaceAll("|", "\\|");
+}
+
+function buildMarkdownSummary(report) {
+  const lines = [
+    "## Released CVE Audit",
+    "",
+    `- Channel: \`${report.channel}\``,
+    `- Releases scanned: ${report.releaseCount}`,
+    `- Scan started at: \`${report.scanStartedAt}\``,
+    `- Artifact: \`${report.artifactName}\``,
+    "",
+    "Download full reports:",
+    "",
+    "```bash",
+    report.artifactDownloadCommand,
+    "```",
+    "",
+    "### Totals",
+    "",
+    `- HIGH: ${report.totalHigh}`,
+    `- CRITICAL: ${report.totalCritical}`,
+    `- New since release scan: ${report.newlyDetected}`,
+    `- Fix available now: ${report.fixedNow}`,
+    `- Fix available at release scan: ${report.fixedAtReleaseScan}`,
+    `- Grype scan errors: ${report.scanErrors}`,
+    `- Release scan errors: ${report.releaseErrors}`,
+    "",
+    "### CVE Publication Timing",
+    "",
+    `- Published after release: ${report.publishTiming.publishedAfterRelease}`,
+    `- Published before/on release: ${report.publishTiming.publishedOnOrBeforeRelease}`,
+    `- Unknown publish date: ${report.publishTiming.unknownPublishDate}`,
+    "",
+    "### Why Findings Are Present",
+    "",
+    ...reasonLines(report.reasonCounts),
+    "",
+    "### Releases",
+    "",
+    "| Sequence | Created | Chart | Image tag | Baseline | HIGH | CRITICAL | Published after release | No fix at release scan | Missing baseline | New since release scan | Fix now | Result |",
+    "| ---: | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+  ];
+
+  for (const release of report.releases) {
+    lines.push(
+      [
+        "|",
+        release.sequence,
+        markdownTableCell(release.created_at || "unknown"),
+        markdownTableCell(release.chart_version || "unknown"),
+        `\`${markdownTableCell(release.detected_release_tag || "unknown")}\``,
+        markdownTableCell(release.baseline_source || "missing"),
+        release.totalHigh,
+        release.totalCritical,
+        release.publishTiming.publishedAfterRelease,
+        release.reasonCounts["no-fix-at-release-scan"] || 0,
+        release.reasonCounts["missing-release-baseline"] || 0,
+        release.reasonCounts["new-since-release-scan"] || 0,
+        release.fixedNow,
+        markdownTableCell(release.scan_result),
+        "|",
+      ].join(" "),
+    );
+  }
+
+  lines.push(
+    "",
+    "### HIGH/CRITICAL Finding Context",
+    "",
+    "| Release | Severity | CVE | Published | Reason | Image | Package | Fix now | Fix at release scan |",
+    "| ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
+  );
+
+  for (const finding of report.findingContext) {
+    lines.push(
+      [
+        "|",
+        finding.release_sequence,
+        markdownTableCell(finding.severity || "unknown"),
+        markdownTableCell(finding.id || "unknown"),
+        markdownTableCell(finding.cve_published_at || "unknown"),
+        markdownTableCell(finding.release_context_reason_label || "unknown"),
+        `\`${markdownTableCell(finding.image || "unknown")}\``,
+        `\`${markdownTableCell(finding.package || "unknown")}\``,
+        finding.fix_available_now ? "yes" : "no",
+        finding.fix_available_at_release_scan === null ||
+        typeof finding.fix_available_at_release_scan === "undefined"
+          ? "unknown"
+          : finding.fix_available_at_release_scan
+            ? "yes"
+            : "no",
+        "|",
+      ].join(" "),
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function buildSlackSummary(report) {
+  const lines = [];
+  if (report.status !== "SUCCESS" && report.slackUsergroupId) {
+    lines.push(`<!subteam^${report.slackUsergroupId}|@implementations>`);
+  }
+  lines.push(
+    report.status === "SUCCESS"
+      ? "*Good to go:* YES"
+      : `*Good to go:* NO - Released images contain ${report.totalHigh} HIGH and ${report.totalCritical} CRITICAL findings`,
+    `*Channel:* \`${report.channel}\``,
+    `*Releases scanned:* ${report.releaseCount}`,
+    `*Findings:* ${report.totalHigh} HIGH / ${report.totalCritical} CRITICAL`,
+    `*New since release scan:* ${report.newlyDetected}`,
+    `*Fix available now:* ${report.fixedNow}`,
+    `*Scan errors:* Grype ${report.scanErrors}, release inspection ${report.releaseErrors}`,
+    `*CVE publication timing:* after release ${report.publishTiming.publishedAfterRelease}, before/on release ${report.publishTiming.publishedOnOrBeforeRelease}, unknown ${report.publishTiming.unknownPublishDate}`,
+    "*Why present:*",
+    ...reasonLines(report.reasonCounts),
+    "*Per-release summary:*",
+  );
+
+  for (const release of report.releases) {
+    lines.push(
+      `- sequence ${release.sequence} chart \`${release.chart_version || "unknown"}\` tag \`${release.detected_release_tag || "unknown"}\`: ` +
+        `${release.totalHigh} HIGH / ${release.totalCritical} CRITICAL, ` +
+        `published-after-release ${release.publishTiming.publishedAfterRelease}, ` +
+        `no-fix-at-release ${release.reasonCounts["no-fix-at-release-scan"] || 0}, ` +
+        `baseline ${release.baseline_source || "missing"}`,
+    );
+  }
+
+  lines.push(
+    `*Artifact:* \`${report.artifactName}\``,
+    "*Download reports:*",
+    "```",
+    report.artifactDownloadCommand,
+    "```",
+  );
+
+  return `${lines.join("\n")}\n`;
+}
+
+export async function buildReleasedCveAudit({
+  releaseResultsFile,
+  outputDir,
+  channel,
+  scanStartedAt,
+  artifactName,
+  artifactDownloadCommand,
+  slackUsergroupId = "",
+}) {
+  const releaseResults = await readJson(releaseResultsFile, []);
+  const findingContext = buildFindingContext(releaseResults);
+  const releases = releaseResults.map((release) =>
+    releaseSummary(
+      release,
+      findingContext.filter((finding) => finding.release_sequence === release.release_sequence),
+    ),
+  );
+
+  const reasonCounts = {};
+  const publishTiming = {
+    publishedAfterRelease: 0,
+    publishedOnOrBeforeRelease: 0,
+    unknownPublishDate: 0,
+  };
+
+  for (const finding of findingContext) {
+    increment(reasonCounts, finding.release_context_reason);
+    increment(publishTiming, finding.release_publish_timing);
+  }
+
+  const totalHigh = releases.reduce((sum, release) => sum + release.totalHigh, 0);
+  const totalCritical = releases.reduce((sum, release) => sum + release.totalCritical, 0);
+  const fixedNow = releases.reduce((sum, release) => sum + release.fixedNow, 0);
+  const fixedAtReleaseScan = releases.reduce((sum, release) => sum + release.fixedAtReleaseScan, 0);
+  const newlyDetected = releases.reduce((sum, release) => sum + release.newlyDetected, 0);
+  const scanErrors = releases.reduce((sum, release) => sum + release.grypeScanErrors, 0);
+  const releaseErrors = releases.filter((release) => release.releaseError).length;
+  const status =
+    totalHigh > 0 || totalCritical > 0 || scanErrors > 0 || releaseErrors > 0
+      ? "FAILURE"
+      : "SUCCESS";
+
+  const report = {
+    status,
+    slackTitle:
+      status === "SUCCESS"
+        ? ":white_check_mark: Released CVE audit: clean"
+        : ":rotating_light: Released CVE audit: ATTENTION NEEDED",
+    channel,
+    releaseCount: releaseResults.length,
+    scanStartedAt,
+    artifactName,
+    artifactDownloadCommand,
+    totalHigh,
+    totalCritical,
+    fixedNow,
+    fixedAtReleaseScan,
+    newlyDetected,
+    scanErrors,
+    releaseErrors,
+    publishTiming,
+    reasonCounts,
+    releases,
+    findingContext,
+    slackUsergroupId,
+  };
+
+  await writeFile(path.join(outputDir, "finding-context.json"), `${JSON.stringify(findingContext, null, 2)}\n`);
+  await writeFile(path.join(outputDir, "released-cve-audit-result.json"), `${JSON.stringify(report, null, 2)}\n`);
+  await writeFile(path.join(outputDir, "summary.md"), buildMarkdownSummary(report));
+  await writeFile(path.join(outputDir, "slack-summary.md"), buildSlackSummary(report));
+
+  return report;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (index + 1 >= argv.length || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    args[key.slice(2).replaceAll("-", "_")] = value;
+    index += 1;
+  }
+  return args;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArgs(process.argv.slice(2));
+  await buildReleasedCveAudit({
+    releaseResultsFile: args.release_results,
+    outputDir: args.output_dir,
+    channel: args.channel,
+    scanStartedAt: args.scan_started_at,
+    artifactName: args.artifact_name,
+    artifactDownloadCommand: args.artifact_download_command,
+    slackUsergroupId: args.slack_usergroup_id || "",
+  });
+}

--- a/.github/scripts/cve/build-released-cve-audit.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.mjs
@@ -260,6 +260,7 @@ function buildSlackSummary(report) {
     report.status === "SUCCESS"
       ? "*Good to go:* YES"
       : `*Good to go:* NO - Released images contain ${report.totalHigh} HIGH and ${report.totalCritical} CRITICAL findings`,
+    "*Scope:* Already released channel versions only; independent of the nightly release gate.",
     `*Channel:* \`${report.channel}\``,
     `*Releases scanned:* ${report.releaseCount}`,
     `*Findings:* ${report.totalHigh} HIGH / ${report.totalCritical} CRITICAL`,

--- a/.github/scripts/cve/build-released-cve-audit.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.mjs
@@ -110,6 +110,7 @@ function releaseSummary(release, findings) {
     fixedNow: number(release.fixedNow),
     fixedAtReleaseScan: number(release.fixedAtReleaseScan),
     newlyDetected: number(release.newlyDetected),
+    ignoredImages: (release.ignoredImageStats || []).length,
     releaseError: release.error || "",
     grypeScanErrors: (release.imageStats || []).filter(
       (item) => number(item.grype_exit) !== 0 && number(item.grype_exit) !== 2,
@@ -179,6 +180,7 @@ function buildMarkdownSummary(report) {
     `- Fix available at release scan: ${report.fixedAtReleaseScan}`,
     `- Grype scan errors: ${report.scanErrors}`,
     `- Release scan errors: ${report.releaseErrors}`,
+    `- Ignored images: ${report.ignoredImages}`,
     "",
     "### CVE Publication Timing",
     "",
@@ -192,8 +194,8 @@ function buildMarkdownSummary(report) {
     "",
     "### Releases",
     "",
-    "| Sequence | Created | Chart | Image tag | Baseline | HIGH | CRITICAL | Published after release | No fix at release scan | Missing baseline | New since release scan | Fix now | Result |",
-    "| ---: | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    "| Sequence | Created | Chart | Image tag | Baseline | HIGH | CRITICAL | Ignored images | Published after release | No fix at release scan | Missing baseline | New since release scan | Fix now | Result |",
+    "| ---: | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
   ];
 
   for (const release of report.releases) {
@@ -206,6 +208,7 @@ function buildMarkdownSummary(report) {
         release.baseline_source || "missing",
         release.totalHigh,
         release.totalCritical,
+        release.ignoredImages,
         release.publishTiming.publishedAfterRelease,
         release.reasonCounts["no-fix-at-release-scan"] || 0,
         release.reasonCounts["missing-release-baseline"] || 0,
@@ -262,6 +265,7 @@ function buildSlackSummary(report) {
     `*Findings:* ${report.totalHigh} HIGH / ${report.totalCritical} CRITICAL`,
     `*New since release scan:* ${report.newlyDetected}`,
     `*Fix available now:* ${report.fixedNow}`,
+    `*Ignored images:* ${report.ignoredImages}`,
     `*Scan errors:* Grype ${report.scanErrors}, release inspection ${report.releaseErrors}`,
     `*CVE publication timing:* after release ${report.publishTiming.publishedAfterRelease}, before/on release ${report.publishTiming.publishedOnOrBeforeRelease}, unknown ${report.publishTiming.unknownPublishDate}`,
     "*Why present:*",
@@ -273,6 +277,7 @@ function buildSlackSummary(report) {
     lines.push(
       `- sequence ${release.sequence} chart \`${release.chart_version || "unknown"}\` tag \`${release.detected_release_tag || "unknown"}\`: ` +
         `${release.totalHigh} HIGH / ${release.totalCritical} CRITICAL, ` +
+        `ignored images ${release.ignoredImages}, ` +
         `published-after-release ${release.publishTiming.publishedAfterRelease}, ` +
         `no-fix-at-release ${release.reasonCounts["no-fix-at-release-scan"] || 0}, ` +
         `baseline ${release.baseline_source || "missing"}`,
@@ -325,6 +330,7 @@ export async function buildReleasedCveAudit({
   const fixedNow = releases.reduce((sum, release) => sum + release.fixedNow, 0);
   const fixedAtReleaseScan = releases.reduce((sum, release) => sum + release.fixedAtReleaseScan, 0);
   const newlyDetected = releases.reduce((sum, release) => sum + release.newlyDetected, 0);
+  const ignoredImages = releases.reduce((sum, release) => sum + release.ignoredImages, 0);
   const scanErrors = releases.reduce((sum, release) => sum + release.grypeScanErrors, 0);
   const releaseErrors = releases.filter((release) => release.releaseError).length;
   const status =
@@ -348,6 +354,7 @@ export async function buildReleasedCveAudit({
     fixedNow,
     fixedAtReleaseScan,
     newlyDetected,
+    ignoredImages,
     scanErrors,
     releaseErrors,
     publishTiming,

--- a/.github/scripts/cve/build-released-cve-audit.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.mjs
@@ -324,7 +324,8 @@ function buildSlackSummary(report) {
     report.status === "SUCCESS"
       ? "*Good to go:* YES"
       : `*Good to go:* NO - Released images contain ${report.totalHigh} HIGH and ${report.totalCritical} CRITICAL findings`,
-    "*Scope:* Already released channel versions only; independent of the nightly release gate.",
+    "*Scope:* Already released channel versions only; independent of the nightly release workflow.",
+    "*Release blocking:* NO - this audit is alert-only.",
     `*Channel:* \`${report.channel}\``,
     `*Releases scanned:* ${report.releaseCount}`,
     `*Findings:* ${report.totalHigh} HIGH / ${report.totalCritical} CRITICAL`,

--- a/.github/scripts/cve/build-released-cve-audit.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.mjs
@@ -30,6 +30,11 @@ function increment(object, key, amount = 1) {
   object[key] = (object[key] || 0) + amount;
 }
 
+function earliestDate(values) {
+  const dates = values.filter(Boolean).sort();
+  return dates[0] || "";
+}
+
 function number(value) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
@@ -85,6 +90,38 @@ async function readJson(file, fallback = null) {
   }
 }
 
+function severityBreakdown(value = {}) {
+  return {
+    cves: number(value.cves),
+    fix_available: number(value.fix_available),
+    no_fix_available: number(value.no_fix_available),
+  };
+}
+
+function imageCveBreakdownForRelease(release) {
+  const sourceRows = Array.isArray(release.imageCveBreakdown) ? release.imageCveBreakdown : [];
+  return sourceRows.map((item) => ({
+    release_sequence: release.release_sequence,
+    release_created_at: release.release_created_at || "",
+    release_chart_version: release.release_chart_version || "",
+    detected_release_tag: release.detected_release_tag || "",
+    image: item.image || "",
+    scan_image: item.scan_image || item.image || "",
+    source: item.source || "rendered",
+    cve_count: number(item.cve_count),
+    finding_occurrences: number(item.finding_occurrences),
+    fix_available_cves: number(item.fix_available_cves),
+    no_fix_available_cves: number(item.no_fix_available_cves),
+    fix_available_occurrences: number(item.fix_available_occurrences),
+    no_fix_available_occurrences: number(item.no_fix_available_occurrences),
+    earliest_fix_available_at: item.earliest_fix_available_at || "",
+    severity: {
+      Critical: severityBreakdown(item.severity?.Critical),
+      High: severityBreakdown(item.severity?.High),
+    },
+  }));
+}
+
 function releaseSummary(release, findings) {
   const reasonCounts = {};
   const publishTiming = {
@@ -117,6 +154,7 @@ function releaseSummary(release, findings) {
     ).length,
     publishTiming,
     reasonCounts,
+    imageCveBreakdown: imageCveBreakdownForRelease(release),
   };
 }
 
@@ -178,6 +216,7 @@ function buildMarkdownSummary(report) {
     `- New since release scan: ${report.newlyDetected}`,
     `- Fix available now: ${report.fixedNow}`,
     `- Fix available at release scan: ${report.fixedAtReleaseScan}`,
+    `- Earliest fix date detected: ${report.earliestFixAvailableAt || "none"}`,
     `- Grype scan errors: ${report.scanErrors}`,
     `- Release scan errors: ${report.releaseErrors}`,
     `- Ignored images: ${report.ignoredImages}`,
@@ -227,6 +266,31 @@ function buildMarkdownSummary(report) {
     "| ---: | --- | --- | --- | --- | --- | --- | --- | --- |",
   );
 
+  lines.splice(
+    lines.findIndex((line) => line === "### HIGH/CRITICAL Finding Context"),
+    0,
+    "",
+    "### Image CVE Breakdown",
+    "",
+    "| Release | Image tag | Image | Unique CVE/advisory IDs | Package occurrences | Fixable CVEs | No-fix CVEs | CRITICAL fix/no fix | HIGH fix/no fix | Earliest fix date detected |",
+    "| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ...report.imageCveBreakdown.map((item) =>
+      markdownRow([
+        item.release_sequence,
+        `\`${item.detected_release_tag || "unknown"}\``,
+        `\`${item.image || "unknown"}\``,
+        item.cve_count,
+        item.finding_occurrences,
+        item.fix_available_cves,
+        item.no_fix_available_cves,
+        `${item.severity.Critical.fix_available} / ${item.severity.Critical.no_fix_available}`,
+        `${item.severity.High.fix_available} / ${item.severity.High.no_fix_available}`,
+        item.earliest_fix_available_at || "none",
+      ]),
+    ),
+    "",
+  );
+
   for (const finding of report.findingContext) {
     lines.push(
       markdownRow([
@@ -264,6 +328,7 @@ function buildSlackSummary(report) {
     `*Channel:* \`${report.channel}\``,
     `*Releases scanned:* ${report.releaseCount}`,
     `*Findings:* ${report.totalHigh} HIGH / ${report.totalCritical} CRITICAL`,
+    `*Earliest fix date detected:* ${report.earliestFixAvailableAt || "none"}`,
     `*New since release scan:* ${report.newlyDetected}`,
     `*Fix available now:* ${report.fixedNow}`,
     `*Ignored images:* ${report.ignoredImages}`,
@@ -271,6 +336,8 @@ function buildSlackSummary(report) {
     `*CVE publication timing:* after release ${report.publishTiming.publishedAfterRelease}, before/on release ${report.publishTiming.publishedOnOrBeforeRelease}, unknown ${report.publishTiming.unknownPublishDate}`,
     "*Why present:*",
     ...reasonLines(report.reasonCounts),
+    "*Top image CVE breakdown:*",
+    ...topImageBreakdownLines(report.imageCveBreakdown),
     "*Per-release summary:*",
   );
 
@@ -294,6 +361,30 @@ function buildSlackSummary(report) {
   );
 
   return `${lines.join("\n")}\n`;
+}
+
+function topImageBreakdownLines(imageCveBreakdown) {
+  const top = [...imageCveBreakdown]
+    .filter((item) => item.cve_count > 0)
+    .sort((left, right) =>
+      right.cve_count - left.cve_count ||
+      right.finding_occurrences - left.finding_occurrences ||
+      String(left.image).localeCompare(String(right.image)),
+    )
+    .slice(0, 5);
+
+  if (top.length === 0) {
+    return ["- No image-level HIGH/CRITICAL CVE rows."];
+  }
+
+  return top.map(
+    (item) =>
+      `- release ${item.release_sequence} \`${item.image}\`: ` +
+      `${item.cve_count} unique CVE/advisory IDs, ` +
+      `${item.fix_available_cves} fixable / ${item.no_fix_available_cves} no fix, ` +
+      `${item.severity.Critical.cves} Critical / ${item.severity.High.cves} High, ` +
+      `earliest fix ${item.earliest_fix_available_at || "none"}`,
+  );
 }
 
 export async function buildReleasedCveAudit({
@@ -332,6 +423,10 @@ export async function buildReleasedCveAudit({
   const fixedAtReleaseScan = releases.reduce((sum, release) => sum + release.fixedAtReleaseScan, 0);
   const newlyDetected = releases.reduce((sum, release) => sum + release.newlyDetected, 0);
   const ignoredImages = releases.reduce((sum, release) => sum + release.ignoredImages, 0);
+  const imageCveBreakdown = releases.flatMap((release) => release.imageCveBreakdown);
+  const earliestFixAvailableAt = earliestDate(
+    imageCveBreakdown.map((item) => item.earliest_fix_available_at),
+  );
   const scanErrors = releases.reduce((sum, release) => sum + release.grypeScanErrors, 0);
   const releaseErrors = releases.filter((release) => release.releaseError).length;
   const status =
@@ -354,6 +449,7 @@ export async function buildReleasedCveAudit({
     totalCritical,
     fixedNow,
     fixedAtReleaseScan,
+    earliestFixAvailableAt,
     newlyDetected,
     ignoredImages,
     scanErrors,
@@ -361,6 +457,7 @@ export async function buildReleasedCveAudit({
     publishTiming,
     reasonCounts,
     releases,
+    imageCveBreakdown,
     findingContext,
     slackUsergroupId,
   };

--- a/.github/scripts/cve/build-released-cve-audit.test.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.test.mjs
@@ -54,7 +54,7 @@ test("buildReleasedCveAudit explains why findings are present in released versio
         ignoredImageStats: [
           {
             image: "temporalio/admin-tools:1.28.0",
-            reason: "Temporal dependency chart image; excluded from Composio-managed CVE gate",
+            reason: "Temporal dependency chart image; excluded from Composio-managed CVE scan",
           },
         ],
         findings: [
@@ -181,7 +181,8 @@ test("buildReleasedCveAudit explains why findings are present in released versio
 
     const slack = await readFile(path.join(dir, "slack-summary.md"), "utf8");
     assert.match(slack, /^<!subteam\^S123\|@implementations>/);
-    assert.match(slack, /Already released channel versions only; independent of the nightly release gate/);
+    assert.match(slack, /Already released channel versions only; independent of the nightly release workflow/);
+    assert.match(slack, /Release blocking:\* NO - this audit is alert-only/);
     assert.match(slack, /CVE publication timing/);
     assert.match(slack, /Earliest fix date detected:\* 2026-07-02/);
     assert.match(slack, /Top image CVE breakdown/);

--- a/.github/scripts/cve/build-released-cve-audit.test.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.test.mjs
@@ -94,6 +94,7 @@ test("buildReleasedCveAudit explains why findings are present in released versio
       artifactName: "released-grype-cve-audit-1-1",
       artifactDownloadCommand:
         "gh run download 1 --repo ComposioHQ/helm-charts --name released-grype-cve-audit-1-1 --dir ./released-cve-audit",
+      slackUsergroupId: "S123",
     });
 
     assert.equal(result.status, "FAILURE");
@@ -121,6 +122,8 @@ test("buildReleasedCveAudit explains why findings are present in released versio
     assert.match(summary, /\| 10 \| Critical \| CVE-after \| 2026-07-02T00:00:00Z \| published after release \|/);
 
     const slack = await readFile(path.join(dir, "slack-summary.md"), "utf8");
+    assert.match(slack, /^<!subteam\^S123\|@implementations>/);
+    assert.match(slack, /Already released channel versions only; independent of the nightly release gate/);
     assert.match(slack, /CVE publication timing/);
     assert.match(slack, /Ignored images:\* 1/);
     assert.match(slack, /after release 1/);

--- a/.github/scripts/cve/build-released-cve-audit.test.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildReleasedCveAudit } from "./build-released-cve-audit.mjs";
+
+async function writeJson(file, value) {
+  await writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+test("buildReleasedCveAudit explains why findings are present in released versions", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "released-cve-audit-test-"));
+  try {
+    const releaseResultsFile = path.join(dir, "release-results.json");
+    await writeJson(releaseResultsFile, [
+      {
+        scanResult: "failed",
+        release_sequence: 10,
+        release_created_at: "2026-07-01T10:00:00Z",
+        release_chart_version: "0.2.10",
+        detected_release_tag: "r20260701_01",
+        baseline_source: "r20260701_01",
+        totalHigh: 1,
+        totalCritical: 1,
+        fixedNow: 1,
+        newlyDetected: 1,
+        imageStats: [],
+        findings: [
+          {
+            id: "CVE-after",
+            severity: "Critical",
+            image: "image-a",
+            package: "openssl",
+            cve_published_at: "2026-07-02T00:00:00Z",
+            seen_at_release_scan: false,
+            first_detected_at: "2026-07-04T00:00:00Z",
+            fix_available_now: true,
+            fix_available_at_release_scan: false,
+          },
+          {
+            id: "CVE-no-fix",
+            severity: "High",
+            image: "image-a",
+            package: "glibc",
+            cve_published_at: "2026-06-30T00:00:00Z",
+            seen_at_release_scan: true,
+            first_detected_at: "2026-07-01T10:05:00Z",
+            fix_available_now: false,
+            fix_available_at_release_scan: false,
+          },
+        ],
+      },
+      {
+        scanResult: "failed",
+        release_sequence: 9,
+        release_created_at: "2026-06-29T10:00:00Z",
+        release_chart_version: "0.2.9",
+        detected_release_tag: "r20260629_01",
+        baseline_source: "missing",
+        totalHigh: 1,
+        totalCritical: 0,
+        fixedNow: 0,
+        newlyDetected: 1,
+        imageStats: [],
+        findings: [
+          {
+            id: "CVE-unknown",
+            severity: "High",
+            image: "image-b",
+            package: "zlib",
+            cve_published_at: null,
+            seen_at_release_scan: false,
+            first_detected_at: "2026-07-04T00:00:00Z",
+            fix_available_now: false,
+            fix_available_at_release_scan: null,
+          },
+        ],
+      },
+    ]);
+
+    const result = await buildReleasedCveAudit({
+      releaseResultsFile,
+      outputDir: dir,
+      channel: "Stable",
+      scanStartedAt: "2026-07-04T01:00:00Z",
+      artifactName: "released-grype-cve-audit-1-1",
+      artifactDownloadCommand:
+        "gh run download 1 --repo ComposioHQ/helm-charts --name released-grype-cve-audit-1-1 --dir ./released-cve-audit",
+    });
+
+    assert.equal(result.status, "FAILURE");
+    assert.equal(result.totalHigh, 2);
+    assert.equal(result.totalCritical, 1);
+    assert.equal(result.publishTiming.publishedAfterRelease, 1);
+    assert.equal(result.publishTiming.publishedOnOrBeforeRelease, 1);
+    assert.equal(result.publishTiming.unknownPublishDate, 1);
+    assert.equal(result.reasonCounts["published-after-release"], 1);
+    assert.equal(result.reasonCounts["no-fix-at-release-scan"], 1);
+    assert.equal(result.reasonCounts["missing-release-baseline"], 1);
+
+    const findingContext = JSON.parse(await readFile(path.join(dir, "finding-context.json"), "utf8"));
+    assert.equal(findingContext[0].release_context_reason, "published-after-release");
+    assert.equal(findingContext[1].release_context_reason, "no-fix-at-release-scan");
+    assert.equal(findingContext[2].release_context_reason, "missing-release-baseline");
+
+    const summary = await readFile(path.join(dir, "summary.md"), "utf8");
+    assert.match(summary, /Released CVE Audit/);
+    assert.match(summary, /Published after release/);
+    assert.match(summary, /No fix at release scan/);
+
+    const slack = await readFile(path.join(dir, "slack-summary.md"), "utf8");
+    assert.match(slack, /CVE publication timing/);
+    assert.match(slack, /after release 1/);
+    assert.match(slack, /before\/on release 1/);
+    assert.match(slack, /unknown 1/);
+    assert.match(slack, /published after release: 1/);
+    assert.match(slack, /no fix at release scan: 1/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/cve/build-released-cve-audit.test.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.test.mjs
@@ -26,7 +26,31 @@ test("buildReleasedCveAudit explains why findings are present in released versio
         totalCritical: 1,
         fixedNow: 1,
         newlyDetected: 1,
-        imageStats: [],
+        imageStats: [
+          {
+            image: "image-a",
+            scan_image: "image-a",
+            high: 1,
+            critical: 1,
+            grype_exit: 2,
+          },
+        ],
+        imageCveBreakdown: [
+          {
+            image: "image-a",
+            scan_image: "image-a",
+            source: "rendered",
+            cve_count: 2,
+            finding_occurrences: 2,
+            fix_available_cves: 1,
+            no_fix_available_cves: 1,
+            earliest_fix_available_at: "2026-07-02",
+            severity: {
+              Critical: { cves: 1, fix_available: 1, no_fix_available: 0 },
+              High: { cves: 1, fix_available: 0, no_fix_available: 1 },
+            },
+          },
+        ],
         ignoredImageStats: [
           {
             image: "temporalio/admin-tools:1.28.0",
@@ -69,7 +93,31 @@ test("buildReleasedCveAudit explains why findings are present in released versio
         totalCritical: 0,
         fixedNow: 0,
         newlyDetected: 1,
-        imageStats: [],
+        imageStats: [
+          {
+            image: "image-b",
+            scan_image: "image-b",
+            high: 1,
+            critical: 0,
+            grype_exit: 2,
+          },
+        ],
+        imageCveBreakdown: [
+          {
+            image: "image-b",
+            scan_image: "image-b",
+            source: "rendered",
+            cve_count: 1,
+            finding_occurrences: 1,
+            fix_available_cves: 0,
+            no_fix_available_cves: 1,
+            earliest_fix_available_at: "",
+            severity: {
+              Critical: { cves: 0, fix_available: 0, no_fix_available: 0 },
+              High: { cves: 1, fix_available: 0, no_fix_available: 1 },
+            },
+          },
+        ],
         findings: [
           {
             id: "CVE-unknown",
@@ -101,6 +149,12 @@ test("buildReleasedCveAudit explains why findings are present in released versio
     assert.equal(result.totalHigh, 2);
     assert.equal(result.totalCritical, 1);
     assert.equal(result.ignoredImages, 1);
+    assert.equal(result.imageCveBreakdown.length, 2);
+    assert.equal(result.imageCveBreakdown[0].release_sequence, 10);
+    assert.equal(result.imageCveBreakdown[0].cve_count, 2);
+    assert.equal(result.imageCveBreakdown[0].fix_available_cves, 1);
+    assert.equal(result.imageCveBreakdown[0].no_fix_available_cves, 1);
+    assert.equal(result.earliestFixAvailableAt, "2026-07-02");
     assert.equal(result.publishTiming.publishedAfterRelease, 1);
     assert.equal(result.publishTiming.publishedOnOrBeforeRelease, 1);
     assert.equal(result.publishTiming.unknownPublishDate, 1);
@@ -116,6 +170,10 @@ test("buildReleasedCveAudit explains why findings are present in released versio
     const summary = await readFile(path.join(dir, "summary.md"), "utf8");
     assert.match(summary, /Released CVE Audit/);
     assert.match(summary, /Ignored images: 1/);
+    assert.match(summary, /Image CVE Breakdown/);
+    assert.match(summary, /Earliest fix date detected/);
+    assert.match(summary, /Earliest fix date detected: 2026-07-02/);
+    assert.match(summary, /\| 10 \| `r20260701_01` \| `image-a` \| 2 \| 2 \| 1 \| 1 \| 1 \/ 0 \| 0 \/ 1 \| 2026-07-02 \|/);
     assert.match(summary, /Published after release/);
     assert.match(summary, /No fix at release scan/);
     assert.match(summary, /\| 10 \| 2026-07-01T10:00:00Z \| 0\.2\.10 \| `r20260701_01` \|/);
@@ -125,6 +183,9 @@ test("buildReleasedCveAudit explains why findings are present in released versio
     assert.match(slack, /^<!subteam\^S123\|@implementations>/);
     assert.match(slack, /Already released channel versions only; independent of the nightly release gate/);
     assert.match(slack, /CVE publication timing/);
+    assert.match(slack, /Earliest fix date detected:\* 2026-07-02/);
+    assert.match(slack, /Top image CVE breakdown/);
+    assert.match(slack, /image-a.*2 unique CVE\/advisory IDs.*1 fixable \/ 1 no fix/);
     assert.match(slack, /Ignored images:\* 1/);
     assert.match(slack, /after release 1/);
     assert.match(slack, /before\/on release 1/);

--- a/.github/scripts/cve/build-released-cve-audit.test.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.test.mjs
@@ -109,6 +109,8 @@ test("buildReleasedCveAudit explains why findings are present in released versio
     assert.match(summary, /Released CVE Audit/);
     assert.match(summary, /Published after release/);
     assert.match(summary, /No fix at release scan/);
+    assert.match(summary, /\| 10 \| 2026-07-01T10:00:00Z \| 0\.2\.10 \| `r20260701_01` \|/);
+    assert.match(summary, /\| 10 \| Critical \| CVE-after \| 2026-07-02T00:00:00Z \| published after release \|/);
 
     const slack = await readFile(path.join(dir, "slack-summary.md"), "utf8");
     assert.match(slack, /CVE publication timing/);

--- a/.github/scripts/cve/build-released-cve-audit.test.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.test.mjs
@@ -27,6 +27,12 @@ test("buildReleasedCveAudit explains why findings are present in released versio
         fixedNow: 1,
         newlyDetected: 1,
         imageStats: [],
+        ignoredImageStats: [
+          {
+            image: "temporalio/admin-tools:1.28.0",
+            reason: "Temporal dependency chart image; excluded from Composio-managed CVE gate",
+          },
+        ],
         findings: [
           {
             id: "CVE-after",
@@ -93,6 +99,7 @@ test("buildReleasedCveAudit explains why findings are present in released versio
     assert.equal(result.status, "FAILURE");
     assert.equal(result.totalHigh, 2);
     assert.equal(result.totalCritical, 1);
+    assert.equal(result.ignoredImages, 1);
     assert.equal(result.publishTiming.publishedAfterRelease, 1);
     assert.equal(result.publishTiming.publishedOnOrBeforeRelease, 1);
     assert.equal(result.publishTiming.unknownPublishDate, 1);
@@ -107,6 +114,7 @@ test("buildReleasedCveAudit explains why findings are present in released versio
 
     const summary = await readFile(path.join(dir, "summary.md"), "utf8");
     assert.match(summary, /Released CVE Audit/);
+    assert.match(summary, /Ignored images: 1/);
     assert.match(summary, /Published after release/);
     assert.match(summary, /No fix at release scan/);
     assert.match(summary, /\| 10 \| 2026-07-01T10:00:00Z \| 0\.2\.10 \| `r20260701_01` \|/);
@@ -114,6 +122,7 @@ test("buildReleasedCveAudit explains why findings are present in released versio
 
     const slack = await readFile(path.join(dir, "slack-summary.md"), "utf8");
     assert.match(slack, /CVE publication timing/);
+    assert.match(slack, /Ignored images:\* 1/);
     assert.match(slack, /after release 1/);
     assert.match(slack, /before\/on release 1/);
     assert.match(slack, /unknown 1/);

--- a/.github/scripts/cve/classify-grype-scan-result.mjs
+++ b/.github/scripts/cve/classify-grype-scan-result.mjs
@@ -1,0 +1,113 @@
+import { appendFileSync } from "node:fs";
+
+function normalize(value) {
+  return String(value || "").trim();
+}
+
+function nonSuccess(outcome) {
+  return normalize(outcome) !== "success";
+}
+
+export function classifyGrypeWorkflowResult({
+  renderOutcome = "",
+  scanOutcome = "",
+  reportOutcome = "",
+  publishOutcome = "",
+  scanResult = "",
+} = {}) {
+  if (nonSuccess(renderOutcome)) {
+    return {
+      failureReason: "render-failed",
+      failureSummary: "Rendering Helm scan targets failed; Grype did not run.",
+    };
+  }
+
+  if (nonSuccess(scanOutcome)) {
+    return {
+      failureReason: "scan-execution-failed",
+      failureSummary:
+        "Running Grype scans failed; Grype scan findings may be incomplete or unavailable.",
+    };
+  }
+
+  if (nonSuccess(reportOutcome)) {
+    return {
+      failureReason: "report-build-failed",
+      failureSummary:
+        "Build Grype report failed; Grype may or may not have found HIGH/CRITICAL vulnerabilities.",
+    };
+  }
+
+  if (nonSuccess(publishOutcome)) {
+    return {
+      failureReason: "report-publish-failed",
+      failureSummary:
+        "Publishing Grype report outputs failed; Grype scan findings may be incomplete or unavailable.",
+    };
+  }
+
+  if (normalize(scanResult) === "success") {
+    return {
+      failureReason: "success",
+      failureSummary: "",
+    };
+  }
+
+  if (normalize(scanResult) === "failed") {
+    return {
+      failureReason: "high-critical-findings",
+      failureSummary: "Grype found HIGH or CRITICAL vulnerabilities",
+    };
+  }
+
+  return {
+    failureReason: "missing-scan-result",
+    failureSummary:
+      "Grype report completed but did not publish a scan result; scan findings may be incomplete or unavailable.",
+  };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${key}`);
+    }
+    const value = argv[index + 1];
+    if (index + 1 >= argv.length || value.startsWith("--")) {
+      throw new Error(`Missing value for ${key}`);
+    }
+    args[key.slice(2).replaceAll("-", "_")] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function githubOutput(result) {
+  return [
+    `failure_reason=${result.failureReason}`,
+    "failure_summary<<__CVE_FAILURE_SUMMARY__",
+    result.failureSummary,
+    "__CVE_FAILURE_SUMMARY__",
+    "",
+  ].join("\n");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArgs(process.argv.slice(2));
+  const result = classifyGrypeWorkflowResult({
+    renderOutcome: args.render_outcome,
+    scanOutcome: args.scan_outcome,
+    reportOutcome: args.report_outcome,
+    publishOutcome: args.publish_outcome,
+    scanResult: args.scan_result,
+  });
+  const output = githubOutput(result);
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, output);
+  } else {
+    process.stdout.write(output);
+  }
+}

--- a/.github/scripts/cve/classify-grype-scan-result.test.mjs
+++ b/.github/scripts/cve/classify-grype-scan-result.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { classifyGrypeWorkflowResult } from "./classify-grype-scan-result.mjs";
+
+test("classifies report build failures without claiming vulnerabilities were found", () => {
+  const result = classifyGrypeWorkflowResult({
+    renderOutcome: "success",
+    scanOutcome: "success",
+    reportOutcome: "failure",
+    publishOutcome: "skipped",
+    scanResult: "",
+  });
+
+  assert.equal(result.failureReason, "report-build-failed");
+  assert.match(result.failureSummary, /Build Grype report failed/);
+  assert.match(result.failureSummary, /may or may not have found HIGH\/CRITICAL vulnerabilities/);
+  assert.doesNotMatch(result.failureSummary, /^Grype found HIGH or CRITICAL vulnerabilities/);
+});
+
+test("classifies completed failed reports as blocking HIGH or CRITICAL findings", () => {
+  const result = classifyGrypeWorkflowResult({
+    renderOutcome: "success",
+    scanOutcome: "success",
+    reportOutcome: "success",
+    publishOutcome: "success",
+    scanResult: "failed",
+  });
+
+  assert.equal(result.failureReason, "high-critical-findings");
+  assert.equal(result.failureSummary, "Grype found HIGH or CRITICAL vulnerabilities");
+});

--- a/.github/scripts/cve/classify-grype-scan-result.test.mjs
+++ b/.github/scripts/cve/classify-grype-scan-result.test.mjs
@@ -18,7 +18,7 @@ test("classifies report build failures without claiming vulnerabilities were fou
   assert.doesNotMatch(result.failureSummary, /^Grype found HIGH or CRITICAL vulnerabilities/);
 });
 
-test("classifies completed failed reports as blocking HIGH or CRITICAL findings", () => {
+test("classifies completed failed reports as reported HIGH or CRITICAL findings", () => {
   const result = classifyGrypeWorkflowResult({
     renderOutcome: "success",
     scanOutcome: "success",

--- a/.github/scripts/cve/render-scan-targets.sh
+++ b/.github/scripts/cve/render-scan-targets.sh
@@ -134,7 +134,7 @@ if [[ -s "${ignored_images_file}" ]]; then
   while IFS= read -r rendered_image; do
     row="$(target_for_image \
       "${rendered_image}" \
-      "Temporal dependency chart image; excluded from Composio-managed CVE gate")"
+      "Temporal dependency chart image; excluded from Composio-managed CVE scan")"
     append_json_row "${ignored_scan_targets_file}" "${row}"
   done < "${ignored_images_file}"
 fi

--- a/.github/scripts/cve/render-scan-targets.sh
+++ b/.github/scripts/cve/render-scan-targets.sh
@@ -27,6 +27,8 @@ fi
 mkdir -p "${OUTPUT_DIR}"
 rendered_images_file="${OUTPUT_DIR}/rendered-images.txt"
 scan_targets_file="${OUTPUT_DIR}/scan-targets.json"
+ignored_images_file="${OUTPUT_DIR}/ignored-images.txt"
+ignored_scan_targets_file="${OUTPUT_DIR}/ignored-scan-targets.json"
 
 work_dir="$(mktemp -d)"
 trap 'rm -rf "${work_dir}"' EXIT
@@ -54,17 +56,30 @@ collect_rendered_images() {
 }
 
 if [[ "${RENDER_TEMPORAL}" == "1" ]]; then
-  {
-    collect_rendered_images
-    collect_rendered_images --set features.temporal=true
-  } | sort -u > "${rendered_images_file}"
+  base_images_file="${work_dir}/base-images.txt"
+  temporal_enabled_images_file="${work_dir}/temporal-enabled-images.txt"
+  all_images_file="${work_dir}/all-images.txt"
+
+  collect_rendered_images | sort -u > "${base_images_file}"
+  collect_rendered_images --set features.temporal=true | sort -u > "${temporal_enabled_images_file}"
+
+  comm -13 "${base_images_file}" "${temporal_enabled_images_file}" > "${ignored_images_file}"
+  cat "${base_images_file}" "${temporal_enabled_images_file}" | sort -u > "${all_images_file}"
+
+  if [[ -s "${ignored_images_file}" ]]; then
+    grep -Fvx -f "${ignored_images_file}" "${all_images_file}" > "${rendered_images_file}" || true
+  else
+    cp "${all_images_file}" "${rendered_images_file}"
+  fi
 else
   collect_rendered_images | sort -u > "${rendered_images_file}"
+  : > "${ignored_images_file}"
 fi
 
 if [[ ! -s "${rendered_images_file}" ]]; then
   echo "No images were found in rendered Helm manifests." >&2
   echo '[]' > "${scan_targets_file}"
+  echo '[]' > "${ignored_scan_targets_file}"
   exit 0
 fi
 
@@ -72,8 +87,12 @@ replicated_registry="$(yq -r '.replicated.registry' "${work_chart_dir}/values.ya
 replicated_app="$(yq -r '.replicated.app' "${work_chart_dir}/values.yaml")"
 replicated_proxy_prefix="${replicated_registry}/proxy/${replicated_app}/${ECR_REGISTRY}"
 
-echo '[]' > "${scan_targets_file}"
-while IFS= read -r rendered_image; do
+target_for_image() {
+  local rendered_image="$1"
+  local reason="${2:-}"
+  local scan_image
+  local source
+
   scan_image="${rendered_image}"
   source="rendered"
   if [[ "${rendered_image}" == "${replicated_proxy_prefix}/"* ]]; then
@@ -81,14 +100,46 @@ while IFS= read -r rendered_image; do
     source="replicated-proxy"
   fi
 
-  row="$(jq -n \
-    --arg image "${rendered_image}" \
-    --arg scan_image "${scan_image}" \
-    --arg source "${source}" \
-    '{image: $image, scan_image: $scan_image, source: $source}')"
-  jq -c --argjson row "${row}" '. + [$row]' "${scan_targets_file}" > "${scan_targets_file}.tmp"
-  mv "${scan_targets_file}.tmp" "${scan_targets_file}"
+  if [[ -n "${reason}" ]]; then
+    jq -n \
+      --arg image "${rendered_image}" \
+      --arg scan_image "${scan_image}" \
+      --arg source "${source}" \
+      --arg reason "${reason}" \
+      '{image: $image, scan_image: $scan_image, source: $source, reason: $reason}'
+  else
+    jq -n \
+      --arg image "${rendered_image}" \
+      --arg scan_image "${scan_image}" \
+      --arg source "${source}" \
+      '{image: $image, scan_image: $scan_image, source: $source}'
+  fi
+}
+
+append_json_row() {
+  local file="$1"
+  local row="$2"
+  jq -c --argjson row "${row}" '. + [$row]' "${file}" > "${file}.tmp"
+  mv "${file}.tmp" "${file}"
+}
+
+echo '[]' > "${scan_targets_file}"
+while IFS= read -r rendered_image; do
+  row="$(target_for_image "${rendered_image}")"
+  append_json_row "${scan_targets_file}" "${row}"
 done < "${rendered_images_file}"
 
+echo '[]' > "${ignored_scan_targets_file}"
+if [[ -s "${ignored_images_file}" ]]; then
+  while IFS= read -r rendered_image; do
+    row="$(target_for_image \
+      "${rendered_image}" \
+      "Temporal dependency chart image; excluded from Composio-managed CVE gate")"
+    append_json_row "${ignored_scan_targets_file}" "${row}"
+  done < "${ignored_images_file}"
+fi
+
 echo "Rendered image list: ${rendered_images_file}"
+echo "Ignored image list: ${ignored_images_file}"
+echo "Ignored scan targets: ${ignored_scan_targets_file}"
 echo "Scan targets: ${scan_targets_file}"

--- a/.github/scripts/cve/render-scan-targets.sh
+++ b/.github/scripts/cve/render-scan-targets.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHART_DIR="${CHART_DIR:-./composio}"
+OUTPUT_DIR="${OUTPUT_DIR:-cve-reports}"
+RENDER_TEMPORAL="${RENDER_TEMPORAL:-1}"
+OVERRIDE_IMAGE_TAGS="${OVERRIDE_IMAGE_TAGS:-}"
+
+if [[ -z "${OVERRIDE_IMAGE_TAGS}" ]]; then
+  if [[ -n "${RELEASE_TAG:-}" ]]; then
+    OVERRIDE_IMAGE_TAGS="1"
+  else
+    OVERRIDE_IMAGE_TAGS="0"
+  fi
+fi
+
+if [[ "${OVERRIDE_IMAGE_TAGS}" == "1" && -z "${RELEASE_TAG:-}" ]]; then
+  echo "RELEASE_TAG is required when OVERRIDE_IMAGE_TAGS=1" >&2
+  exit 1
+fi
+
+if [[ -z "${ECR_REGISTRY:-}" ]]; then
+  echo "ECR_REGISTRY is required" >&2
+  exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+rendered_images_file="${OUTPUT_DIR}/rendered-images.txt"
+scan_targets_file="${OUTPUT_DIR}/scan-targets.json"
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+work_chart_dir="${work_dir}/chart"
+cp -R "${CHART_DIR}" "${work_chart_dir}"
+
+cd "${work_chart_dir}"
+if [[ "${OVERRIDE_IMAGE_TAGS}" == "1" ]]; then
+  yq eval -i '.apollo.image.tag = strenv(RELEASE_TAG)' ./values.yaml
+  yq eval -i '.apollo.dbInit.image.tag = strenv(RELEASE_TAG)' ./values.yaml
+  yq eval -i '.thermos.image.tag = strenv(RELEASE_TAG)' ./values.yaml
+  yq eval -i '.thermos.dbInit.image.tag = strenv(RELEASE_TAG)' ./values.yaml
+  yq eval -i '.thermosMiscWorkers.image.tag = strenv(RELEASE_TAG)' ./values.yaml
+  yq eval -i '.mercury.image.tag = strenv(RELEASE_TAG)' ./values.yaml
+  yq eval -i '.frontend.image.tag = strenv(RELEASE_TAG)' ./values.yaml
+  yq eval -i '.weaviate.image.tag = strenv(RELEASE_TAG)' ./values.yaml
+  yq eval -i '.toolkitRegistry.image.tag = strenv(RELEASE_TAG)' ./values.yaml
+fi
+cd - >/dev/null
+
+collect_rendered_images() {
+  helm template composio "${work_chart_dir}" "$@" \
+    | yq -r '.. | select(tag == "!!map" and has("image")) | .image' \
+    | grep -Ev '^(---|null)?$'
+}
+
+if [[ "${RENDER_TEMPORAL}" == "1" ]]; then
+  {
+    collect_rendered_images
+    collect_rendered_images --set features.temporal=true
+  } | sort -u > "${rendered_images_file}"
+else
+  collect_rendered_images | sort -u > "${rendered_images_file}"
+fi
+
+if [[ ! -s "${rendered_images_file}" ]]; then
+  echo "No images were found in rendered Helm manifests." >&2
+  echo '[]' > "${scan_targets_file}"
+  exit 0
+fi
+
+replicated_registry="$(yq -r '.replicated.registry' "${work_chart_dir}/values.yaml")"
+replicated_app="$(yq -r '.replicated.app' "${work_chart_dir}/values.yaml")"
+replicated_proxy_prefix="${replicated_registry}/proxy/${replicated_app}/${ECR_REGISTRY}"
+
+echo '[]' > "${scan_targets_file}"
+while IFS= read -r rendered_image; do
+  scan_image="${rendered_image}"
+  source="rendered"
+  if [[ "${rendered_image}" == "${replicated_proxy_prefix}/"* ]]; then
+    scan_image="${ECR_REGISTRY}/${rendered_image#"${replicated_proxy_prefix}/"}"
+    source="replicated-proxy"
+  fi
+
+  row="$(jq -n \
+    --arg image "${rendered_image}" \
+    --arg scan_image "${scan_image}" \
+    --arg source "${source}" \
+    '{image: $image, scan_image: $scan_image, source: $source}')"
+  jq -c --argjson row "${row}" '. + [$row]' "${scan_targets_file}" > "${scan_targets_file}.tmp"
+  mv "${scan_targets_file}.tmp" "${scan_targets_file}"
+done < "${rendered_images_file}"
+
+echo "Rendered image list: ${rendered_images_file}"
+echo "Scan targets: ${scan_targets_file}"

--- a/.github/scripts/cve/render-scan-targets.test.mjs
+++ b/.github/scripts/cve/render-scan-targets.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, "utf8"));
+}
+
+test("render-scan-targets excludes images introduced by the Temporal dependency chart", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "render-scan-targets-test-"));
+  try {
+    await execFileAsync("bash", [
+      path.join(repoRoot, ".github/scripts/cve/render-scan-targets.sh"),
+    ], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        CHART_DIR: path.join(repoRoot, "composio"),
+        OUTPUT_DIR: dir,
+        ECR_REGISTRY: "008971668139.dkr.ecr.us-east-1.amazonaws.com",
+        RELEASE_TAG: "rtest",
+        RENDER_TEMPORAL: "1",
+      },
+    });
+
+    const scanTargets = await readJson(path.join(dir, "scan-targets.json"));
+    const ignoredTargets = await readJson(path.join(dir, "ignored-scan-targets.json"));
+
+    assert.ok(
+      scanTargets.some((target) => target.image.includes("composio-self-host/apollo:rtest")),
+      "non-Temporal Composio images should remain scan targets",
+    );
+    assert.equal(
+      scanTargets.some((target) => target.image.includes("temporalio/")),
+      false,
+      "Temporal dependency images should not be scanned or counted in the CVE gate",
+    );
+    assert.ok(
+      ignoredTargets.some((target) => target.image.includes("temporalio/admin-tools")),
+      "Temporal dependency images should be recorded as ignored report metadata",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/cve/render-scan-targets.test.mjs
+++ b/.github/scripts/cve/render-scan-targets.test.mjs
@@ -40,7 +40,7 @@ test("render-scan-targets excludes images introduced by the Temporal dependency 
     assert.equal(
       scanTargets.some((target) => target.image.includes("temporalio/")),
       false,
-      "Temporal dependency images should not be scanned or counted in the CVE gate",
+      "Temporal dependency images should not be scanned or counted in the CVE scan",
     );
     assert.ok(
       ignoredTargets.some((target) => target.image.includes("temporalio/admin-tools")),

--- a/.github/scripts/cve/run-grype-scan.sh
+++ b/.github/scripts/cve/run-grype-scan.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR="${OUTPUT_DIR:-cve-reports}"
+SCAN_TARGETS_FILE="${SCAN_TARGETS_FILE:-${OUTPUT_DIR}/scan-targets.json}"
+GRYPE_BIN="${GRYPE_BIN:-grype}"
+
+if [[ ! -f "${SCAN_TARGETS_FILE}" ]]; then
+  echo "Scan targets file not found: ${SCAN_TARGETS_FILE}" >&2
+  exit 1
+fi
+
+mapfile -t targets < <(jq -c '.[]' "${SCAN_TARGETS_FILE}")
+echo '[]' > "${SCAN_TARGETS_FILE}.updated"
+
+for target in "${targets[@]}"; do
+  scan_image="$(jq -r '.scan_image' <<<"${target}")"
+  safe_name="$(printf '%s' "${scan_image}" | tr -c 'A-Za-z0-9_.-' '_')"
+  report_name="${safe_name}.json"
+  report_json="${OUTPUT_DIR}/${report_name}"
+
+  echo "Scanning ${scan_image}"
+  set +e
+  "${GRYPE_BIN}" "registry:${scan_image}" \
+    --fail-on high \
+    --output json \
+    --file "${report_json}"
+  grype_rc=$?
+  set -e
+
+  updated="$(jq -c \
+    --arg report "${report_name}" \
+    --argjson grype_exit "${grype_rc}" \
+    '. + {report: $report, grype_exit: $grype_exit}' <<<"${target}")"
+  jq -c --argjson row "${updated}" '. + [$row]' "${SCAN_TARGETS_FILE}.updated" > "${SCAN_TARGETS_FILE}.tmp"
+  mv "${SCAN_TARGETS_FILE}.tmp" "${SCAN_TARGETS_FILE}.updated"
+done
+
+mv "${SCAN_TARGETS_FILE}.updated" "${SCAN_TARGETS_FILE}"

--- a/.github/workflows/grype-cve-scan.yml
+++ b/.github/workflows/grype-cve-scan.yml
@@ -28,15 +28,10 @@ on:
         type: string
         default: grype-cve-reports
       fail_on_high_critical:
-        description: "Fail the workflow when Grype reports HIGH or CRITICAL findings"
+        description: "Optionally fail the workflow when Grype reports HIGH or CRITICAL findings"
         required: false
         type: boolean
-        default: true
-      allow_high_critical_ack:
-        description: "Exact acknowledgement string that permits release flow despite HIGH/CRITICAL findings"
-        required: false
-        type: string
-        default: ""
+        default: false
       render_temporal:
         description: "Also render the Temporal-enabled image set"
         required: false
@@ -227,16 +222,9 @@ jobs:
           if-no-files-found: warn
           path: cve-reports
 
-      - name: Reject invalid CVE override acknowledgement
-        if: ${{ inputs.allow_high_critical_ack != '' && inputs.allow_high_critical_ack != 'DANGEROUSLY ACKNOWLEDGE' }}
-        shell: bash
-        run: |
-          echo "The CVE gate can only be bypassed by typing DANGEROUSLY ACKNOWLEDGE exactly." >&2
-          exit 1
-
       - name: Fail on HIGH or CRITICAL CVEs
-        if: ${{ inputs.fail_on_high_critical && steps.classify.outputs.failure_reason == 'high-critical-findings' && inputs.allow_high_critical_ack != 'DANGEROUSLY ACKNOWLEDGE' }}
+        if: ${{ inputs.fail_on_high_critical && steps.classify.outputs.failure_reason == 'high-critical-findings' }}
         shell: bash
         run: |
-          echo "Grype reported HIGH or CRITICAL vulnerabilities. Blocking release." >&2
+          echo "Grype reported HIGH or CRITICAL vulnerabilities." >&2
           exit 1

--- a/.github/workflows/grype-cve-scan.yml
+++ b/.github/workflows/grype-cve-scan.yml
@@ -63,6 +63,12 @@ on:
       artifact_download_command:
         description: "gh command for downloading the uploaded artifact"
         value: ${{ jobs.scan.outputs.artifact_download_command }}
+      failure_reason:
+        description: "Machine-readable reason for a failed CVE workflow"
+        value: ${{ jobs.scan.outputs.failure_reason }}
+      failure_summary:
+        description: "Human-readable reason for a failed CVE workflow"
+        value: ${{ jobs.scan.outputs.failure_summary }}
 
 env:
   AWS_REGION: us-east-1
@@ -81,6 +87,8 @@ jobs:
       stats: ${{ steps.publish.outputs.stats }}
       artifact_name: ${{ steps.publish.outputs.artifact_name }}
       artifact_download_command: ${{ steps.publish.outputs.artifact_download_command }}
+      failure_reason: ${{ steps.classify.outputs.failure_reason }}
+      failure_summary: ${{ steps.classify.outputs.failure_summary }}
     steps:
       - name: Checkout CVE scan scripts
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -126,6 +134,7 @@ jobs:
           grype version
 
       - name: Render scan targets
+        id: render
         shell: bash
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
@@ -135,6 +144,7 @@ jobs:
         run: .github/scripts/cve/render-scan-targets.sh
 
       - name: Run Grype scans
+        id: scan_grype
         shell: bash
         env:
           OUTPUT_DIR: cve-reports
@@ -197,6 +207,18 @@ jobs:
             echo "__CVE_SUMMARY__"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Classify Grype workflow result
+        id: classify
+        if: always()
+        shell: bash
+        run: |
+          node .github/scripts/cve/classify-grype-scan-result.mjs \
+            --render-outcome "${{ steps.render.outcome }}" \
+            --scan-outcome "${{ steps.scan_grype.outcome }}" \
+            --report-outcome "${{ steps.report.outcome }}" \
+            --publish-outcome "${{ steps.publish.outcome }}" \
+            --scan-result "${{ steps.publish.outputs.scan_result }}"
+
       - name: Upload Grype reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -213,7 +235,7 @@ jobs:
           exit 1
 
       - name: Fail on HIGH or CRITICAL CVEs
-        if: ${{ inputs.fail_on_high_critical && steps.publish.outputs.scan_result != 'success' && inputs.allow_high_critical_ack != 'DANGEROUSLY ACKNOWLEDGE' }}
+        if: ${{ inputs.fail_on_high_critical && steps.classify.outputs.failure_reason == 'high-critical-findings' && inputs.allow_high_critical_ack != 'DANGEROUSLY ACKNOWLEDGE' }}
         shell: bash
         run: |
           echo "Grype reported HIGH or CRITICAL vulnerabilities. Blocking release." >&2

--- a/.github/workflows/grype-cve-scan.yml
+++ b/.github/workflows/grype-cve-scan.yml
@@ -1,0 +1,220 @@
+name: Grype CVE Scan
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Image release tag to render and scan"
+        required: true
+        type: string
+      chart_ref:
+        description: "Git ref containing the Helm chart to render"
+        required: false
+        type: string
+        default: release-stable
+      release_version:
+        description: "Replicated/Helm release version for report labeling"
+        required: false
+        type: string
+        default: ""
+      scan_name:
+        description: "Short scan label for artifact naming"
+        required: false
+        type: string
+        default: nightly
+      artifact_prefix:
+        description: "Artifact name prefix"
+        required: false
+        type: string
+        default: grype-cve-reports
+      fail_on_high_critical:
+        description: "Fail the workflow when Grype reports HIGH or CRITICAL findings"
+        required: false
+        type: boolean
+        default: true
+      allow_high_critical_ack:
+        description: "Exact acknowledgement string that permits release flow despite HIGH/CRITICAL findings"
+        required: false
+        type: string
+        default: ""
+      render_temporal:
+        description: "Also render the Temporal-enabled image set"
+        required: false
+        type: boolean
+        default: true
+      aws_role_arn:
+        description: "AWS role used for ECR image metadata/pulls"
+        required: false
+        type: string
+        default: arn:aws:iam::008971668139:role/github-actions-helm-charts-ecr
+    outputs:
+      scan_result:
+        description: "success or failed"
+        value: ${{ jobs.scan.outputs.scan_result }}
+      summary:
+        description: "Markdown Grype summary"
+        value: ${{ jobs.scan.outputs.summary }}
+      stats:
+        description: "Slack-ready Grype stats"
+        value: ${{ jobs.scan.outputs.stats }}
+      artifact_name:
+        description: "Uploaded artifact name"
+        value: ${{ jobs.scan.outputs.artifact_name }}
+      artifact_download_command:
+        description: "gh command for downloading the uploaded artifact"
+        value: ${{ jobs.scan.outputs.artifact_download_command }}
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REGISTRY: 008971668139.dkr.ecr.us-east-1.amazonaws.com
+  GRYPE_VERSION: v0.115.0
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      scan_result: ${{ steps.publish.outputs.scan_result }}
+      summary: ${{ steps.publish.outputs.summary }}
+      stats: ${{ steps.publish.outputs.stats }}
+      artifact_name: ${{ steps.publish.outputs.artifact_name }}
+      artifact_download_command: ${{ steps.publish.outputs.artifact_download_command }}
+    steps:
+      - name: Checkout CVE scan scripts
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout chart ref
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.chart_ref }}
+          path: chart-src
+          persist-credentials: false
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
+        with:
+          version: 'latest'
+
+      - name: Install yq
+        uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
+        with:
+          role-to-assume: ${{ inputs.aws_role_arn }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR for Grype registry scans
+        shell: bash
+        run: |
+          set -euo pipefail
+          aws ecr get-login-password --region "${AWS_REGION}" \
+            | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+
+      - name: Install Grype
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sSfL https://get.anchore.io/grype -o /tmp/install-grype.sh
+          sudo sh /tmp/install-grype.sh -b /usr/local/bin "${GRYPE_VERSION}"
+          grype version
+
+      - name: Render scan targets
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          CHART_DIR: ./chart-src/composio
+          OUTPUT_DIR: cve-reports
+          RENDER_TEMPORAL: ${{ inputs.render_temporal && '1' || '0' }}
+        run: .github/scripts/cve/render-scan-targets.sh
+
+      - name: Run Grype scans
+        shell: bash
+        env:
+          OUTPUT_DIR: cve-reports
+        run: .github/scripts/cve/run-grype-scan.sh
+
+      - name: Build Grype report
+        id: report
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          scan_started_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          node .github/scripts/cve/build-cve-report.mjs \
+            --reports-dir cve-reports \
+            --scan-targets cve-reports/scan-targets.json \
+            --output-dir cve-reports \
+            --release-tag "${RELEASE_TAG}" \
+            --release-version "${RELEASE_VERSION}" \
+            --scan-started-at "${scan_started_at}" \
+            > cve-reports/report-result.json
+
+      - name: Publish report outputs
+        id: publish
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          ARTIFACT_PREFIX: ${{ inputs.artifact_prefix }}
+          SCAN_NAME: ${{ inputs.scan_name }}
+        run: |
+          set -euo pipefail
+          artifact_name="${ARTIFACT_PREFIX}-${SCAN_NAME}-${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_download_command="gh run download ${GITHUB_RUN_ID} --repo ${GITHUB_REPOSITORY} --name ${artifact_name} --dir ./grype-cve-reports"
+
+          {
+            echo
+            echo "### Artifact"
+            echo
+            echo "- Artifact: \`${artifact_name}\`"
+            echo
+            echo "Download full reports:"
+            echo
+            echo "\`\`\`bash"
+            echo "${artifact_download_command}"
+            echo "\`\`\`"
+          } >> cve-reports/summary.md
+
+          cat cve-reports/summary.md >> "${GITHUB_STEP_SUMMARY}"
+
+          {
+            echo "scan_result=$(jq -r '.scanResult' cve-reports/report-result.json)"
+            echo "artifact_name=${artifact_name}"
+            echo "artifact_download_command=${artifact_download_command}"
+            echo "stats<<__CVE_STATS__"
+            cat cve-reports/slack-stats.md
+            echo "__CVE_STATS__"
+            echo "summary<<__CVE_SUMMARY__"
+            cat cve-reports/summary.md
+            echo "__CVE_SUMMARY__"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Upload Grype reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ${{ steps.publish.outputs.artifact_name || format('{0}-{1}-{2}-{3}-{4}', inputs.artifact_prefix, inputs.scan_name, inputs.release_tag, github.run_id, github.run_attempt) }}
+          if-no-files-found: warn
+          path: cve-reports
+
+      - name: Reject invalid CVE override acknowledgement
+        if: ${{ inputs.allow_high_critical_ack != '' && inputs.allow_high_critical_ack != 'DANGEROUSLY ACKNOWLEDGE' }}
+        shell: bash
+        run: |
+          echo "The CVE gate can only be bypassed by typing DANGEROUSLY ACKNOWLEDGE exactly." >&2
+          exit 1
+
+      - name: Fail on HIGH or CRITICAL CVEs
+        if: ${{ inputs.fail_on_high_critical && steps.publish.outputs.scan_result != 'success' && inputs.allow_high_critical_ack != 'DANGEROUSLY ACKNOWLEDGE' }}
+        shell: bash
+        run: |
+          echo "Grype reported HIGH or CRITICAL vulnerabilities. Blocking release." >&2
+          exit 1

--- a/.github/workflows/nighty-release.yml
+++ b/.github/workflows/nighty-release.yml
@@ -332,312 +332,20 @@ jobs:
           echo "retagged_images: ${{ steps.retag.outputs.retagged_images }}"
 
   cve-scan:
-    runs-on: ubuntu-latest
     needs:
       - retag-latest-images
     permissions:
       id-token: write
       contents: read
-    outputs:
-      scan_result: ${{ steps.scan.outputs.scan_result }}
-      summary: ${{ steps.scan.outputs.summary }}
-      stats: ${{ steps.scan.outputs.stats }}
-      artifact_name: ${{ steps.scan.outputs.artifact_name }}
-      artifact_download_command: ${{ steps.scan.outputs.artifact_download_command }}
-    steps:
-      - name: Reject invalid CVE override acknowledgement
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_cve_acknowledgement != '' && inputs.skip_cve_acknowledgement != 'DANGEROUSLY ACKNOWLEDGE' }}
-        shell: bash
-        run: |
-          echo "The CVE gate can only be skipped by typing DANGEROUSLY ACKNOWLEDGE exactly." >&2
-          exit 1
-
-      - name: Checkout release chart
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          fetch-depth: 0
-          ref: release-stable
-          persist-credentials: false
-
-      - name: Install Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
-        with:
-          version: 'latest'
-
-      - name: Install yq
-        uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d
-
-      - name: Determine AWS Assume Role ARN
-        id: env
-        shell: bash
-        run: |
-          echo "AWS_ROLE_ARN=arn:aws:iam::008971668139:role/github-actions-helm-charts-ecr" >> "$GITHUB_OUTPUT"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
-        with:
-          role-to-assume: ${{ steps.env.outputs.AWS_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Login to ECR for Grype registry scans
-        shell: bash
-        run: |
-          set -euo pipefail
-          aws ecr get-login-password --region "${AWS_REGION}" \
-            | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
-
-      - name: Install Grype
-        shell: bash
-        run: |
-          set -euo pipefail
-          curl -sSfL https://get.anchore.io/grype -o /tmp/install-grype.sh
-          sudo sh /tmp/install-grype.sh -b /usr/local/bin "${GRYPE_VERSION}"
-          grype version
-
-      - name: Scan retagged images with Grype
-        id: scan
-        shell: bash
-        env:
-          RETAGGED_IMAGES_JSON: ${{ needs.retag-latest-images.outputs.retagged_images }}
-          RELEASE_TAG: ${{ needs.retag-latest-images.outputs.release_tag }}
-        run: |
-          set -euo pipefail
-          mkdir -p cve-reports
-          summary_file="cve-reports/summary.md"
-          stats_tsv_file="cve-reports/image-stats.tsv"
-          stats_json_file="cve-reports/image-stats.json"
-          slack_stats_file="cve-reports/slack-stats.md"
-          rendered_images_file="cve-reports/rendered-images.txt"
-          scan_targets_file="cve-reports/scan-targets.json"
-          artifact_name="nightly-grype-cve-reports-${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          artifact_download_command="gh run download ${GITHUB_RUN_ID} --repo ${GITHUB_REPOSITORY} --name ${artifact_name} --dir ./nightly-grype-reports"
-
-          printf 'image\tscan_image\tsource\thigh\tcritical\tgrype_exit\treport\n' > "${stats_tsv_file}"
-          echo '[]' > "${stats_json_file}"
-          echo '[]' > "${scan_targets_file}"
-          : > "${slack_stats_file}"
-
-          {
-            echo "## Grype CVE Scan"
-            echo
-            echo "- Release tag: \`${RELEASE_TAG}\`"
-            echo "- Policy: fail on any HIGH or CRITICAL finding"
-            echo "- Source: rendered Helm images, including Replicated/subchart images"
-            echo "- Artifact: \`${artifact_name}\`"
-            echo
-            echo "Download full reports:"
-            echo
-            echo "\`\`\`bash"
-            echo "${artifact_download_command}"
-            echo "\`\`\`"
-            echo
-          } > "${summary_file}"
-
-          if [[ -z "${RETAGGED_IMAGES_JSON}" || "${RETAGGED_IMAGES_JSON}" == "[]" ]]; then
-            echo "No retagged images were provided to the CVE scan." >> "${summary_file}"
-            echo "No image-level Grype stats were produced." > "${slack_stats_file}"
-            {
-              echo "scan_result=failed"
-              echo "artifact_name=${artifact_name}"
-              echo "artifact_download_command=${artifact_download_command}"
-              echo "stats<<__CVE_STATS__"
-              cat "${slack_stats_file}"
-              echo "__CVE_STATS__"
-              echo "summary<<__CVE_SUMMARY__"
-              cat "${summary_file}"
-              echo "__CVE_SUMMARY__"
-            } >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          cd ./composio
-          yq eval -i '.apollo.image.tag = strenv(RELEASE_TAG)' ./values.yaml
-          yq eval -i '.apollo.dbInit.image.tag = strenv(RELEASE_TAG)' ./values.yaml
-          yq eval -i '.thermos.image.tag = strenv(RELEASE_TAG)' ./values.yaml
-          yq eval -i '.thermos.dbInit.image.tag = strenv(RELEASE_TAG)' ./values.yaml
-          yq eval -i '.thermosMiscWorkers.image.tag = strenv(RELEASE_TAG)' ./values.yaml
-          yq eval -i '.mercury.image.tag = strenv(RELEASE_TAG)' ./values.yaml
-          yq eval -i '.frontend.image.tag = strenv(RELEASE_TAG)' ./values.yaml
-          yq eval -i '.weaviate.image.tag = strenv(RELEASE_TAG)' ./values.yaml
-          yq eval -i '.toolkitRegistry.image.tag = strenv(RELEASE_TAG)' ./values.yaml
-          cd -
-
-          collect_rendered_images() {
-            helm template composio ./composio "$@" \
-              | yq -r '.. | select(tag == "!!map" and has("image")) | .image' \
-              | grep -Ev '^(---|null)?$'
-          }
-
-          {
-            collect_rendered_images
-            collect_rendered_images --set features.temporal=true
-          } | sort -u > "${rendered_images_file}"
-
-          if [[ ! -s "${rendered_images_file}" ]]; then
-            echo "No images were found in the rendered Helm manifests." >> "${summary_file}"
-            echo "No image-level Grype stats were produced." > "${slack_stats_file}"
-            {
-              echo "scan_result=failed"
-              echo "artifact_name=${artifact_name}"
-              echo "artifact_download_command=${artifact_download_command}"
-              echo "stats<<__CVE_STATS__"
-              cat "${slack_stats_file}"
-              echo "__CVE_STATS__"
-              echo "summary<<__CVE_SUMMARY__"
-              cat "${summary_file}"
-              echo "__CVE_SUMMARY__"
-            } >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          replicated_registry="$(yq -r '.replicated.registry' ./composio/values.yaml)"
-          replicated_app="$(yq -r '.replicated.app' ./composio/values.yaml)"
-          replicated_proxy_prefix="${replicated_registry}/proxy/${replicated_app}/${ECR_REGISTRY}"
-          while IFS= read -r rendered_image; do
-            scan_image="${rendered_image}"
-            source="rendered"
-            if [[ "${rendered_image}" == "${replicated_proxy_prefix}/"* ]]; then
-              scan_image="${ECR_REGISTRY}/${rendered_image#"${replicated_proxy_prefix}/"}"
-              source="replicated-proxy"
-            fi
-
-            target_row="$(jq -n \
-              --arg image "${rendered_image}" \
-              --arg scan_image "${scan_image}" \
-              --arg source "${source}" \
-              '{image: $image, scan_image: $scan_image, source: $source}')"
-            jq -c --argjson row "${target_row}" '. + [$row]' "${scan_targets_file}" > "${scan_targets_file}.tmp"
-            mv "${scan_targets_file}.tmp" "${scan_targets_file}"
-          done < "${rendered_images_file}"
-
-          scan_result="success"
-          total_high=0
-          total_critical=0
-          scan_error_summary=""
-          mapfile -t image_rows < <(jq -c '.[]' "${scan_targets_file}")
-
-          {
-            echo "### Rendered images"
-            echo
-            sed 's/^/- `/' "${rendered_images_file}" | sed 's/$/`/'
-            echo
-            echo "### Image findings"
-            echo
-            echo "| Rendered image | Scanned image | Source | HIGH | CRITICAL | Grype exit | Report |"
-            echo "| --- | --- | --- | ---: | ---: | ---: | --- |"
-          } >> "${summary_file}"
-
-          for row in "${image_rows[@]}"; do
-            image="$(jq -r '.image' <<<"${row}")"
-            scan_image="$(jq -r '.scan_image' <<<"${row}")"
-            source="$(jq -r '.source' <<<"${row}")"
-            safe_name="$(printf '%s' "${scan_image}" | tr -c 'A-Za-z0-9_.-' '_')"
-            report_json="cve-reports/${safe_name}.json"
-
-            echo "Scanning ${scan_image} (rendered as ${image})"
-            set +e
-            grype "registry:${scan_image}" \
-              --fail-on high \
-              --output json \
-              --file "${report_json}"
-            grype_rc=$?
-            set -e
-
-            high_count="0"
-            critical_count="0"
-            if [[ -s "${report_json}" ]]; then
-              high_count="$(
-                jq '[.matches[]? | select(((.vulnerability.severity // "") | ascii_downcase) == "high")] | length' "${report_json}"
-              )"
-              critical_count="$(
-                jq '[.matches[]? | select(((.vulnerability.severity // "") | ascii_downcase) == "critical")] | length' "${report_json}"
-              )"
-            fi
-
-            total_high="$((total_high + high_count))"
-            total_critical="$((total_critical + critical_count))"
-            report_name="${safe_name}.json"
-            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "${image}" "${scan_image}" "${source}" "${high_count}" "${critical_count}" "${grype_rc}" "${report_name}" >> "${stats_tsv_file}"
-            stats_row="$(jq -n \
-              --arg image "${image}" \
-              --arg scan_image "${scan_image}" \
-              --arg source "${source}" \
-              --arg report "${report_name}" \
-              --argjson high "${high_count}" \
-              --argjson critical "${critical_count}" \
-              --argjson grype_exit "${grype_rc}" \
-              '{image: $image, scan_image: $scan_image, source: $source, high: $high, critical: $critical, grype_exit: $grype_exit, report: $report}')"
-            jq -c --argjson row "${stats_row}" '. + [$row]' "${stats_json_file}" > "${stats_json_file}.tmp"
-            mv "${stats_json_file}.tmp" "${stats_json_file}"
-
-            {
-              echo "| \`${image}\` | \`${scan_image}\` | ${source} | ${high_count} | ${critical_count} | ${grype_rc} | \`${report_name}\` |"
-            } >> "${summary_file}"
-
-            if (( grype_rc == 2 || high_count > 0 || critical_count > 0 )); then
-              scan_result="failed"
-            fi
-
-            if (( grype_rc != 0 && grype_rc != 2 && high_count == 0 && critical_count == 0 )); then
-              scan_result="failed"
-              if [[ -z "${scan_error_summary}" ]]; then
-                scan_error_summary="Grype failed while scanning ${scan_image} with exit code ${grype_rc}"
-              fi
-            fi
-          done
-
-          jq -r '.[] | "- `" + .image + "`: " + (.high | tostring) + " HIGH / " + (.critical | tostring) + " CRITICAL" + (if .image != .scan_image then " (scanned `" + .scan_image + "`)" else "" end)' "${stats_json_file}" > "${slack_stats_file}"
-
-          {
-            echo
-            echo "### Totals"
-            echo
-            echo "- HIGH: ${total_high}"
-            echo "- CRITICAL: ${total_critical}"
-          } >> "${summary_file}"
-
-          if (( total_high > 0 || total_critical > 0 )); then
-            {
-              echo "### Failure"
-              echo
-              echo "Grype found ${total_high} HIGH and ${total_critical} CRITICAL findings across scanned images."
-            } >> "${summary_file}"
-          elif [[ -n "${scan_error_summary}" ]]; then
-            {
-              echo "### Failure"
-              echo
-              echo "${scan_error_summary}"
-            } >> "${summary_file}"
-          fi
-
-          cat "${summary_file}" >> "${GITHUB_STEP_SUMMARY}"
-
-          {
-            echo "scan_result=${scan_result}"
-            echo "artifact_name=${artifact_name}"
-            echo "artifact_download_command=${artifact_download_command}"
-            echo "stats<<__CVE_STATS__"
-            cat "${slack_stats_file}"
-            echo "__CVE_STATS__"
-            echo "summary<<__CVE_SUMMARY__"
-            cat "${summary_file}"
-            echo "__CVE_SUMMARY__"
-          } >> "${GITHUB_OUTPUT}"
-
-      - name: Upload Grype reports
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: ${{ steps.scan.outputs.artifact_name || format('nightly-grype-cve-reports-{0}-{1}-{2}', needs.retag-latest-images.outputs.release_tag, github.run_id, github.run_attempt) }}
-          if-no-files-found: warn
-          path: cve-reports
-
-      - name: Fail on HIGH or CRITICAL CVEs
-        if: ${{ steps.scan.outputs.scan_result != 'success' && !(github.event_name == 'workflow_dispatch' && inputs.skip_cve_acknowledgement == 'DANGEROUSLY ACKNOWLEDGE') }}
-        shell: bash
-        run: |
-          echo "Grype reported HIGH or CRITICAL vulnerabilities. Blocking nightly release." >&2
-          exit 1
+    uses: ./.github/workflows/grype-cve-scan.yml
+    with:
+      release_tag: ${{ needs.retag-latest-images.outputs.release_tag }}
+      chart_ref: release-stable
+      scan_name: nightly
+      artifact_prefix: nightly-grype-cve-reports
+      fail_on_high_critical: true
+      allow_high_critical_ack: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_cve_acknowledgement || '' }}
+      render_temporal: true
 
   replicated-release:
     runs-on: ubuntu-latest
@@ -977,6 +685,7 @@ jobs:
                 prerelease: true,
               });
               core.info(`Updated GitHub release for tag ${tag_name}.`);
+              core.setOutput("release_id", String(existingRelease.id));
               core.setOutput("release_url", existingRelease.html_url);
             } catch (e) {
               const status = e.status ?? e.response?.status;
@@ -995,8 +704,56 @@ jobs:
                 prerelease: true,
               });
               core.info(`Created GitHub release ${tag_name} at ${target_commitish}`);
+              core.setOutput("release_id", String(release.id));
               core.setOutput("release_url", release.html_url);
             }
+
+      - name: Download Grype finding baseline
+        if: ${{ needs.cve-scan.outputs.artifact_name != '' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: ${{ needs.cve-scan.outputs.artifact_name }}
+          path: downloaded-cve-reports
+
+      - name: Attach CVE baseline to GitHub release
+        if: ${{ steps.github_release.outputs.release_id != '' && hashFiles('downloaded-cve-reports/finding-details.json') != '' }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}
+          script: |
+            const fs = require("fs");
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const release_id = Number("${{ steps.github_release.outputs.release_id }}");
+            const name = "release-cve-baseline.json";
+            const data = fs.readFileSync("downloaded-cve-reports/finding-details.json");
+
+            const assets = await github.paginate(github.rest.repos.listReleaseAssets, {
+              owner,
+              repo,
+              release_id,
+              per_page: 100,
+            });
+
+            for (const asset of assets.filter((item) => item.name === name)) {
+              await github.rest.repos.deleteReleaseAsset({
+                owner,
+                repo,
+                asset_id: asset.id,
+              });
+            }
+
+            await github.rest.repos.uploadReleaseAsset({
+              owner,
+              repo,
+              release_id,
+              name,
+              data,
+              headers: {
+                "content-type": "application/json",
+                "content-length": data.length,
+              },
+            });
 
   onprem-testbed:
     if: ${{ needs.replicated-release.result == 'success' }}

--- a/.github/workflows/nighty-release.yml
+++ b/.github/workflows/nighty-release.yml
@@ -381,13 +381,15 @@ jobs:
 
       - name: Install Replicated CLI
         run: |
-          version=$(curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
-            | grep -m1 -Po '"tag_name":\s*"v\K[^"]+')
+          set -euo pipefail
+          curl -fsSL https://api.github.com/repos/replicatedhq/replicated/releases/latest \
+            -o replicated-release.json
+          version="$(jq -r '.tag_name | sub("^v"; "")' replicated-release.json)"
           echo "Downloading Replicated CLI..."
-          curl -Ls \
+          curl -fsSL \
             "https://github.com/replicatedhq/replicated/releases/download/v${version}/replicated_${version}_linux_amd64.tar.gz" \
             -o replicated.tar.gz
-          echo "Extracting Replciated CLI..."
+          echo "Extracting Replicated CLI..."
           tar xf replicated.tar.gz replicated && rm replicated.tar.gz
           echo "Installing Replicated CLI in /usr/local/bin/"
           sudo install replicated /usr/local/bin/replicated

--- a/.github/workflows/nighty-release.yml
+++ b/.github/workflows/nighty-release.yml
@@ -46,12 +46,6 @@ on:
         required: false
         type: string
         default: "latest"
-      skip_cve_acknowledgement:
-        description: "Leave blank. To allow release despite Grype HIGH/CRITICAL findings, type DANGEROUSLY ACKNOWLEDGE exactly. The scan still runs and reports."
-        required: false
-        type: string
-        default: ""
-
 permissions:
   contents: write
   pull-requests: write
@@ -343,13 +337,12 @@ jobs:
       chart_ref: release-stable
       scan_name: nightly
       artifact_prefix: nightly-grype-cve-reports
-      fail_on_high_critical: true
-      allow_high_critical_ack: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_cve_acknowledgement || '' }}
+      fail_on_high_critical: false
       render_temporal: true
 
   replicated-release:
     runs-on: ubuntu-latest
-    if: ${{ needs.retag-latest-images.result == 'success' && needs.cve-scan.result == 'success' }}
+    if: ${{ always() && needs.retag-latest-images.result == 'success' }}
     needs:
       - retag-latest-images
       - cve-scan
@@ -527,7 +520,7 @@ jobs:
           git push --force-with-lease origin "${{ steps.branch.outputs.branch_name }}"
 
   create-nightly-release-pr:
-    if: ${{ needs.replicated-release.result == 'success' && needs.cve-scan.result == 'success' }}
+    if: ${{ always() && needs.replicated-release.result == 'success' }}
     runs-on: ubuntu-latest
     needs:
       - cve-scan
@@ -594,11 +587,13 @@ jobs:
             const head = "${{ needs.replicated-release.outputs.branch_name }}";
             const releaseTag = "${{ needs.retag-latest-images.outputs.release_tag }}";
             const version = "${{ needs.replicated-release.outputs.version }}";
-            const cveScanResult = "${{ needs.cve-scan.outputs.scan_result }}";
-            const cveOverrideAcknowledged = "${{ github.event_name == 'workflow_dispatch' && inputs.skip_cve_acknowledgement == 'DANGEROUSLY ACKNOWLEDGE' && 'true' || 'false' }}" === "true";
-            const cveLine = cveOverrideAcknowledged
-              ? `Grype CVE scan result was \`${cveScanResult}\`; release was manually allowed with \`DANGEROUSLY ACKNOWLEDGE\``
-              : "Grype CVE gate passed before release creation";
+            const cveScanResult = ${{ toJSON(needs.cve-scan.outputs.scan_result) }};
+            const cveFailureSummary = ${{ toJSON(needs.cve-scan.outputs.failure_summary) }};
+            const cveLine = cveScanResult === "success"
+              ? "Grype CVE scan completed cleanly"
+              : cveScanResult
+                ? `Grype CVE scan result was \`${cveScanResult}\`; release continued with Slack alerting`
+                : `Grype CVE scan did not publish a complete result${cveFailureSummary ? ` (${cveFailureSummary})` : ""}; release continued with Slack alerting`;
             const title = `Nightly release ${releaseTag}`;
             const body = `## Summary
 
@@ -894,8 +889,6 @@ jobs:
           CVE_STATS: ${{ needs.cve-scan.outputs.stats }}
           CVE_ARTIFACT_NAME: ${{ needs.cve-scan.outputs.artifact_name }}
           CVE_ARTIFACT_DOWNLOAD_COMMAND: ${{ needs.cve-scan.outputs.artifact_download_command }}
-          CVE_OVERRIDE_ACKNOWLEDGED: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_cve_acknowledgement == 'DANGEROUSLY ACKNOWLEDGE' && '1' || '0' }}
-          CVE_OVERRIDE_INVALID: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_cve_acknowledgement != '' && inputs.skip_cve_acknowledgement != 'DANGEROUSLY ACKNOWLEDGE' && '1' || '0' }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SLACK_IMPLEMENTATIONS_USERGROUP_ID: ${{ env.SLACK_IMPLEMENTATIONS_USERGROUP_ID }}
         run: |
@@ -925,16 +918,10 @@ jobs:
           require_success "Image retag" "${RETAG_RESULT}"
 
           cve_status="${CVE_RESULT}"
-          if [[ "${CVE_OVERRIDE_ACKNOWLEDGED}" == "1" ]]; then
-            cve_status="${CVE_SCAN_RESULT:-unknown} (manual DANGEROUSLY ACKNOWLEDGE override allowed release)"
-            mark_not_good "Release proceeded with DANGEROUSLY ACKNOWLEDGE CVE override"
-          elif [[ "${CVE_OVERRIDE_INVALID}" == "1" ]]; then
-            cve_status="failure (invalid CVE override acknowledgement)"
-            mark_not_good "CVE override acknowledgement was invalid"
-          elif [[ "${CVE_RESULT}" == "failure" ]]; then
+          if [[ "${CVE_RESULT}" == "failure" ]]; then
             case "${CVE_FAILURE_REASON:-unknown}" in
               high-critical-findings)
-                cve_status="failure (HIGH/CRITICAL findings blocked release)"
+                cve_status="failure (HIGH/CRITICAL findings reported; release continued alert-only)"
                 mark_not_good "Grype found HIGH or CRITICAL vulnerabilities"
                 ;;
               report-build-failed)
@@ -946,15 +933,15 @@ jobs:
                 mark_not_good "${CVE_FAILURE_SUMMARY:-Grype CVE workflow failed; findings may be incomplete or unavailable.}"
                 ;;
               *)
-                cve_status="failure (CVE workflow failed before a definitive gate result)"
+                cve_status="failure (CVE workflow failed before a definitive scan result)"
                 mark_not_good "Grype CVE workflow failed; scan findings may be incomplete or unavailable"
                 ;;
             esac
           elif [[ "${CVE_RESULT}" != "success" ]]; then
-            mark_not_good "Grype CVE gate result was ${CVE_RESULT}"
+            mark_not_good "Grype CVE scan result was ${CVE_RESULT}"
           elif [[ "${CVE_SCAN_RESULT:-success}" != "success" ]]; then
-            cve_status="${CVE_SCAN_RESULT} (unexpected successful job result)"
-            mark_not_good "Grype CVE scan result was ${CVE_SCAN_RESULT}"
+            cve_status="${CVE_SCAN_RESULT} (HIGH/CRITICAL findings reported; release continued alert-only)"
+            mark_not_good "Grype found HIGH or CRITICAL vulnerabilities"
           else
             cve_status="success"
           fi
@@ -976,9 +963,7 @@ jobs:
               echo "<!subteam^${SLACK_IMPLEMENTATIONS_USERGROUP_ID}|@implementations>"
             fi
             echo "${verdict_line}"
-            if [[ "${CVE_OVERRIDE_ACKNOWLEDGED}" == "1" ]]; then
-              echo "*DANGEROUSLY ACKNOWLEDGE used:* YES - release was allowed even though the CVE gate did not pass normally."
-            fi
+            echo "*Release blocking:* NO - CVE findings are alert-only."
             if [[ "${REPLICATED_RESULT}" == "success" ]]; then
               echo "*Release created:* YES"
               echo "- Image release tag: \`${RELEASE_TAG:-unknown}\`"
@@ -992,7 +977,7 @@ jobs:
             echo "*Stages:*"
             echo "- Secret preflight: \`${NIGHTLY_SECRETS_RESULT}\`"
             echo "- Image retag: \`${RETAG_RESULT}\`"
-            echo "- Grype CVE gate: \`${cve_status}\`"
+            echo "- Grype CVE scan: \`${cve_status}\`"
             echo "- Replicated release: \`${REPLICATED_RESULT}\`"
             echo "- GitHub PR/release: \`${PR_RESULT}\`"
             echo "- onprem-testbed validation (fresh + upgrade + triggers): \`${ONPREM_RESULT}\`"

--- a/.github/workflows/nighty-release.yml
+++ b/.github/workflows/nighty-release.yml
@@ -878,6 +878,8 @@ jobs:
           RETAG_RESULT: ${{ needs.retag-latest-images.result }}
           CVE_RESULT: ${{ needs.cve-scan.result }}
           CVE_SCAN_RESULT: ${{ needs.cve-scan.outputs.scan_result }}
+          CVE_FAILURE_REASON: ${{ needs.cve-scan.outputs.failure_reason }}
+          CVE_FAILURE_SUMMARY: ${{ needs.cve-scan.outputs.failure_summary }}
           REPLICATED_RESULT: ${{ needs.replicated-release.result }}
           PR_RESULT: ${{ needs.create-nightly-release-pr.result }}
           ONPREM_RESULT: ${{ needs.onprem-testbed.result }}
@@ -928,8 +930,24 @@ jobs:
             cve_status="failure (invalid CVE override acknowledgement)"
             mark_not_good "CVE override acknowledgement was invalid"
           elif [[ "${CVE_RESULT}" == "failure" ]]; then
-            cve_status="failure (HIGH/CRITICAL findings blocked release)"
-            mark_not_good "Grype found HIGH or CRITICAL vulnerabilities"
+            case "${CVE_FAILURE_REASON:-unknown}" in
+              high-critical-findings)
+                cve_status="failure (HIGH/CRITICAL findings blocked release)"
+                mark_not_good "Grype found HIGH or CRITICAL vulnerabilities"
+                ;;
+              report-build-failed)
+                cve_status="failure (Build Grype report failed; findings unknown)"
+                mark_not_good "${CVE_FAILURE_SUMMARY:-Build Grype report failed; Grype may or may not have found HIGH/CRITICAL vulnerabilities.}"
+                ;;
+              render-failed|scan-execution-failed|report-publish-failed|missing-scan-result)
+                cve_status="failure (${CVE_FAILURE_SUMMARY:-Grype CVE workflow failed; findings may be incomplete or unavailable.})"
+                mark_not_good "${CVE_FAILURE_SUMMARY:-Grype CVE workflow failed; findings may be incomplete or unavailable.}"
+                ;;
+              *)
+                cve_status="failure (CVE workflow failed before a definitive gate result)"
+                mark_not_good "Grype CVE workflow failed; scan findings may be incomplete or unavailable"
+                ;;
+            esac
           elif [[ "${CVE_RESULT}" != "success" ]]; then
             mark_not_good "Grype CVE gate result was ${CVE_RESULT}"
           elif [[ "${CVE_SCAN_RESULT:-success}" != "success" ]]; then

--- a/.github/workflows/released-cve-audit.yml
+++ b/.github/workflows/released-cve-audit.yml
@@ -152,26 +152,59 @@ jobs:
               | jq -R -s 'split("\n") | map(select(. != "")) | map({sequence: (tonumber), channels: ["manual"], created_at: "", chart_version: ""})' \
               > audit-reports/releases.json
           else
-            replicated release ls \
-              --output json \
+            replicated api get /v3/apps \
               --app "${REPLICATED_APP}" \
               --token "${REPLICATED_API_TOKEN}" \
-              > audit-reports/replicated-release-list.raw.json
-            sed -n '/^\[/,$p' audit-reports/replicated-release-list.raw.json > audit-reports/replicated-release-list.json
+              > audit-reports/replicated-apps.raw.json
+            sed -n '/^{/,$p' audit-reports/replicated-apps.raw.json > audit-reports/replicated-apps.json
+
+            app_id="$(
+              jq -r \
+                --arg app "${REPLICATED_APP}" \
+                '.apps[]?
+                  | select(.slug == $app or .id == $app or .name == $app)
+                  | .id' \
+                audit-reports/replicated-apps.json \
+                | head -n1
+            )"
+            channel_id="$(
+              jq -r \
+                --arg app "${REPLICATED_APP}" \
+                --arg channel "${CHANNEL}" \
+                '.apps[]?
+                  | select(.slug == $app or .id == $app or .name == $app)
+                  | .channels[]?
+                  | select(.name == $channel or .channelSlug == ($channel | ascii_downcase) or .id == $channel)
+                  | .id' \
+                audit-reports/replicated-apps.json \
+                | head -n1
+            )"
+
+            if [[ -z "${app_id}" || -z "${channel_id}" ]]; then
+              echo "Could not resolve Replicated app/channel for app=${REPLICATED_APP} channel=${CHANNEL}" >&2
+              exit 1
+            fi
+
+            replicated api get "/v3/app/${app_id}/channel/${channel_id}/releases" \
+              --app "${REPLICATED_APP}" \
+              --token "${REPLICATED_API_TOKEN}" \
+              > audit-reports/replicated-channel-releases.raw.json
+            sed -n '/^{/,$p' audit-reports/replicated-channel-releases.raw.json > audit-reports/replicated-channel-releases.json
             jq \
               --arg channel "${CHANNEL}" \
               --argjson limit "${RELEASE_COUNT}" \
-              '[.[] | select(any(.activeChannels[]?; .name == $channel))]
-                | sort_by(.sequence)
+              '(.releases // [])
+                | sort_by(.channelSequence // 0)
                 | reverse
                 | .[:$limit]
                 | map({
                     sequence,
-                    created_at: .createdAt,
-                    channels: [.activeChannels[]?.name],
-                    chart_version: ((.charts[]? | select(.name == "composio") | .version) // .version // "")
+                    created_at: (.releasedAt // .created // .createdAt // ""),
+                    channels: [(.channelName // $channel)],
+                    chart_version: ((.chartReleases[]? | select(.name == "composio") | .version) // .semver // .version // ""),
+                    channel_sequence: (.channelSequence // null)
                   })' \
-              audit-reports/replicated-release-list.json \
+              audit-reports/replicated-channel-releases.json \
               > audit-reports/releases.json
           fi
 
@@ -183,7 +216,7 @@ jobs:
           fi
 
           echo "Resolved releases:"
-          jq -r '.[] | "- sequence \(.sequence) channels=\(.channels | join(",")) chart=\(.chart_version // "unknown")"' audit-reports/releases.json
+          jq -r '.[] | "- sequence \(.sequence) channel-sequence=\(.channel_sequence // "manual") channels=\(.channels | join(",")) chart=\(.chart_version // "unknown")"' audit-reports/releases.json
 
       - name: Scan released charts
         id: audit

--- a/.github/workflows/released-cve-audit.yml
+++ b/.github/workflows/released-cve-audit.yml
@@ -318,8 +318,10 @@ jobs:
                 > "${release_dir}/report-result.json"
             fi
 
-            result="$(jq -c '.' "${release_dir}/report-result.json")"
-            jq -c --argjson result "${result}" '. + [$result]' audit-reports/release-results.json > audit-reports/release-results.tmp.json
+            jq -c -s '.[0] + [.[1]]' \
+              audit-reports/release-results.json \
+              "${release_dir}/report-result.json" \
+              > audit-reports/release-results.tmp.json
             mv audit-reports/release-results.tmp.json audit-reports/release-results.json
           done
 

--- a/.github/workflows/released-cve-audit.yml
+++ b/.github/workflows/released-cve-audit.yml
@@ -1,0 +1,16 @@
+name: released-cve-audit
+
+on:
+  schedule:
+    - cron: "15 19 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "released-cve-audit workflow placeholder"

--- a/.github/workflows/released-cve-audit.yml
+++ b/.github/workflows/released-cve-audit.yml
@@ -85,9 +85,14 @@ jobs:
 
       - name: Install Replicated CLI
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          curl -fsSL https://api.github.com/repos/replicatedhq/replicated/releases/latest \
+          curl -fsSL \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/replicatedhq/replicated/releases/latest \
             -o replicated-release.json
           version="$(jq -r '.tag_name | sub("^v"; "")' replicated-release.json)"
           curl -fsSL \

--- a/.github/workflows/released-cve-audit.yml
+++ b/.github/workflows/released-cve-audit.yml
@@ -45,11 +45,42 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Fetch audit secrets from Doppler
+        id: doppler
+        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ env.OPRA_CI_DOPPLER_IDENTITY_ID }}
+          doppler-project: opra-ci
+          doppler-config: prd
+          inject-env-vars: true
+
+      - name: Validate audit secrets
+        shell: bash
+        env:
+          NOTIFY_SLACK: ${{ github.event_name != 'workflow_dispatch' || inputs.notify_slack }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in REPLICATED_API_TOKEN REPLICATED_APP; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("${name}")
+            fi
+          done
+
+          if [[ "${NOTIFY_SLACK}" == "true" && -z "${NIGHTLY_SLACK_WEBHOOK_URL:-}" ]]; then
+            missing+=("NIGHTLY_SLACK_WEBHOOK_URL")
+          fi
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required Doppler secret(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
       - name: Checkout CVE audit scripts
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           sparse-checkout: |
-            .github/actions/slack-notify
             .github/scripts/cve
           sparse-checkout-cone-mode: false
           persist-credentials: false
@@ -100,38 +131,6 @@ jobs:
             -o replicated.tar.gz
           tar xf replicated.tar.gz replicated
           sudo install replicated /usr/local/bin/replicated
-
-      - name: Fetch audit secrets from Doppler
-        id: doppler
-        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534
-        with:
-          auth-method: oidc
-          doppler-identity-id: ${{ env.OPRA_CI_DOPPLER_IDENTITY_ID }}
-          doppler-project: opra-ci
-          doppler-config: prd
-          inject-env-vars: true
-
-      - name: Validate audit secrets
-        shell: bash
-        env:
-          NOTIFY_SLACK: ${{ github.event_name != 'workflow_dispatch' || inputs.notify_slack }}
-        run: |
-          set -euo pipefail
-          missing=()
-          for name in REPLICATED_API_TOKEN REPLICATED_APP; do
-            if [[ -z "${!name:-}" ]]; then
-              missing+=("${name}")
-            fi
-          done
-
-          if [[ "${NOTIFY_SLACK}" == "true" && -z "${NIGHTLY_SLACK_WEBHOOK_URL:-}" ]]; then
-            missing+=("NIGHTLY_SLACK_WEBHOOK_URL")
-          fi
-
-          if (( ${#missing[@]} > 0 )); then
-            printf 'Missing required Doppler secret(s): %s\n' "${missing[*]}" >&2
-            exit 1
-          fi
 
       - name: Resolve releases to audit
         id: releases
@@ -388,25 +387,151 @@ jobs:
             echo "__AUDIT_SUMMARY__"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Build released CVE audit Slack alert
+        id: alert
+        if: always()
+        shell: bash
+        env:
+          CHANNEL: ${{ inputs.channel || 'Stable' }}
+          RELEASE_COUNT: ${{ inputs.release_count || '3' }}
+          RELEASE_SEQUENCES: ${{ inputs.release_sequences || '' }}
+          RELEASES_OUTCOME: ${{ steps.releases.outcome }}
+          AUDIT_OUTCOME: ${{ steps.audit.outcome }}
+          ARTIFACT_NAME: ${{ steps.audit.outputs.artifact_name || format('released-grype-cve-audit-{0}-{1}', github.run_id, github.run_attempt) }}
+          ARTIFACT_DOWNLOAD_COMMAND: ${{ steps.audit.outputs.artifact_download_command || format('gh run download {0} --repo {1} --name released-grype-cve-audit-{0}-{2} --dir ./released-cve-audit', github.run_id, github.repository, github.run_attempt) }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p audit-reports
+
+          if [[ -f .github/scripts/cve/build-released-cve-audit-alert.mjs ]]; then
+            node .github/scripts/cve/build-released-cve-audit-alert.mjs \
+              --output-dir audit-reports \
+              --channel "${CHANNEL}" \
+              --release-count "${RELEASE_COUNT}" \
+              --release-sequences "${RELEASE_SEQUENCES}" \
+              --releases-outcome "${RELEASES_OUTCOME}" \
+              --audit-outcome "${AUDIT_OUTCOME}" \
+              --artifact-name "${ARTIFACT_NAME}" \
+              --artifact-download-command "${ARTIFACT_DOWNLOAD_COMMAND}" \
+              --run-url "${RUN_URL}" \
+              --slack-usergroup-id "${SLACK_IMPLEMENTATIONS_USERGROUP_ID}"
+          else
+            if [[ -n "${RELEASE_SEQUENCES}" ]]; then
+              requested="explicit Replicated release sequence(s): \`${RELEASE_SEQUENCES}\`"
+            else
+              requested="channel \`${CHANNEL}\`, latest ${RELEASE_COUNT} release(s)"
+            fi
+
+            jq -n \
+              --arg usergroup "${SLACK_IMPLEMENTATIONS_USERGROUP_ID}" \
+              --arg requested "${requested}" \
+              --arg releases_outcome "${RELEASES_OUTCOME}" \
+              --arg audit_outcome "${AUDIT_OUTCOME}" \
+              --arg artifact_name "${ARTIFACT_NAME}" \
+              --arg artifact_download_command "${ARTIFACT_DOWNLOAD_COMMAND}" \
+              --arg run_url "${RUN_URL}" \
+              '{
+                status: "FAILURE",
+                title: ":rotating_light: Released CVE audit: WORKFLOW FAILED",
+                summary: (
+                  (if $usergroup == "" then "" else "<!subteam^\($usergroup)|@implementations>\n" end) +
+                  "*Good to go:* NO - released CVE audit did not complete\n" +
+                  "*Scope:* Already released channel versions only; independent of the nightly release gate.\n" +
+                  "*Requested audit:* \($requested)\n" +
+                  "*Findings:* UNKNOWN - the audit failed before producing the CVE summary.\n" +
+                  "*Stages:*\n" +
+                  "- Release resolution: `\($releases_outcome)`\n" +
+                  "- Audit scan/report: `\($audit_outcome)`\n" +
+                  "*Artifact:* `\($artifact_name)`\n" +
+                  "*Download partial reports, if any were uploaded:*\n" +
+                  "```\n\($artifact_download_command)\n```\n" +
+                  "*Workflow:* <\($run_url)|released CVE audit run>\n"
+                )
+              }' > audit-reports/released-cve-audit-alert.json
+            jq -r '.summary' audit-reports/released-cve-audit-alert.json > audit-reports/released-cve-audit-alert-summary.md
+          fi
+
+          status="$(jq -r '.status' audit-reports/released-cve-audit-alert.json)"
+          title="$(jq -r '.title' audit-reports/released-cve-audit-alert.json)"
+
+          {
+            echo "status=${status}"
+            echo "title=${title}"
+            echo "artifact_name=${ARTIFACT_NAME}"
+            echo "artifact_download_command=${ARTIFACT_DOWNLOAD_COMMAND}"
+            echo "summary<<__AUDIT_ALERT_SUMMARY__"
+            jq -r '.summary' audit-reports/released-cve-audit-alert.json
+            echo "__AUDIT_ALERT_SUMMARY__"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Upload released CVE audit reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: ${{ steps.audit.outputs.artifact_name || format('released-grype-cve-audit-{0}-{1}', github.run_id, github.run_attempt) }}
+          name: ${{ steps.alert.outputs.artifact_name || steps.audit.outputs.artifact_name || format('released-grype-cve-audit-{0}-{1}', github.run_id, github.run_attempt) }}
           if-no-files-found: warn
           path: audit-reports
 
       - name: Announce released CVE audit in Slack
-        if: ${{ always() && (github.event_name != 'workflow_dispatch' || inputs.notify_slack) && steps.audit.outputs.summary != '' }}
-        uses: ./.github/actions/slack-notify
-        with:
-          status: ${{ steps.audit.outputs.status }}
-          slack_webhook_url: ${{ steps.doppler.outputs.NIGHTLY_SLACK_WEBHOOK_URL }}
-          title: ${{ steps.audit.outputs.title }}
-          summary: ${{ steps.audit.outputs.summary }}
+        if: ${{ always() && (github.event_name != 'workflow_dispatch' || inputs.notify_slack) && steps.alert.outputs.summary != '' && steps.doppler.outputs.NIGHTLY_SLACK_WEBHOOK_URL != '' }}
+        shell: bash
+        env:
+          INPUT_STATUS: ${{ steps.alert.outputs.status }}
+          INPUT_TITLE: ${{ steps.alert.outputs.title }}
+          INPUT_SUMMARY: ${{ steps.alert.outputs.summary }}
+          SLACK_WEBHOOK_URL: ${{ steps.doppler.outputs.NIGHTLY_SLACK_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+
+          case "${INPUT_STATUS}" in
+            SUCCESS) color="#28a745" ;;
+            FAILURE) color="#cb2431" ;;
+            *)       color="#808080" ;;
+          esac
+
+          payload="$(
+            jq -n \
+              --arg color "${color}" \
+              --arg title "${INPUT_TITLE}" \
+              --arg summary "${INPUT_SUMMARY}" \
+              '
+              def chunks($text; $size):
+                [range(0; ($text | length); $size) as $start | $text[$start:($start + $size)]]
+                | map(select(length > 0));
+
+              {
+                text: ($title + "\n" + $summary[0:3000]),
+                attachments: [{
+                  color: $color,
+                  blocks: ([
+                    {
+                      type: "section",
+                      text: { type: "mrkdwn", text: ("*" + $title + "*") }
+                    }
+                  ] + (chunks($summary; 2900) | .[:49] | map({
+                    type: "section",
+                    text: { type: "mrkdwn", text: . }
+                  })))
+                }],
+                unfurl_links: false,
+                unfurl_media: false
+              }'
+          )"
+
+          response="$(
+            curl -fsS -X POST "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json" \
+              -d "${payload}"
+          )"
+
+          if [[ "${response}" != "ok" ]]; then
+            echo "::error::Slack webhook returned unexpected response: ${response}" >&2
+            exit 1
+          fi
 
       - name: Fail when released images have blocking CVEs
-        if: ${{ steps.audit.outputs.status == 'FAILURE' }}
+        if: ${{ steps.alert.outputs.status == 'FAILURE' }}
         shell: bash
         run: |
           echo "Released CVE audit found HIGH/CRITICAL vulnerabilities or scan errors." >&2

--- a/.github/workflows/released-cve-audit.yml
+++ b/.github/workflows/released-cve-audit.yml
@@ -87,9 +87,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version=$(curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
-            | grep -m1 -Po '"tag_name":\s*"v\K[^"]+')
-          curl -Ls \
+          curl -fsSL https://api.github.com/repos/replicatedhq/replicated/releases/latest \
+            -o replicated-release.json
+          version="$(jq -r '.tag_name | sub("^v"; "")' replicated-release.json)"
+          curl -fsSL \
             "https://github.com/replicatedhq/replicated/releases/download/v${version}/replicated_${version}_linux_amd64.tar.gz" \
             -o replicated.tar.gz
           tar xf replicated.tar.gz replicated

--- a/.github/workflows/released-cve-audit.yml
+++ b/.github/workflows/released-cve-audit.yml
@@ -437,7 +437,8 @@ jobs:
                 summary: (
                   (if $usergroup == "" then "" else "<!subteam^\($usergroup)|@implementations>\n" end) +
                   "*Good to go:* NO - released CVE audit did not complete\n" +
-                  "*Scope:* Already released channel versions only; independent of the nightly release gate.\n" +
+                  "*Scope:* Already released channel versions only; independent of the nightly release workflow.\n" +
+                  "*Release blocking:* NO - this audit is alert-only.\n" +
                   "*Requested audit:* \($requested)\n" +
                   "*Findings:* UNKNOWN - the audit failed before producing the CVE summary.\n" +
                   "*Stages:*\n" +
@@ -529,10 +530,3 @@ jobs:
             echo "::error::Slack webhook returned unexpected response: ${response}" >&2
             exit 1
           fi
-
-      - name: Fail when released images have blocking CVEs
-        if: ${{ steps.alert.outputs.status == 'FAILURE' }}
-        shell: bash
-        run: |
-          echo "Released CVE audit found HIGH/CRITICAL vulnerabilities or scan errors." >&2
-          exit 1

--- a/.github/workflows/released-cve-audit.yml
+++ b/.github/workflows/released-cve-audit.yml
@@ -1,0 +1,428 @@
+name: released-cve-audit
+
+on:
+  schedule:
+    # Run after the nightly release window so newly published CVEs are noticed daily.
+    - cron: "30 22 * * *"
+  workflow_dispatch:
+    inputs:
+      release_count:
+        description: "Number of latest channel releases to scan when release_sequences is blank"
+        required: false
+        type: string
+        default: "4"
+      channel:
+        description: "Replicated channel to audit"
+        required: false
+        type: string
+        default: "Stable"
+      release_sequences:
+        description: "Optional comma-separated Replicated release sequences to scan instead of resolving by channel"
+        required: false
+        type: string
+        default: ""
+      notify_slack:
+        description: "Send the final audit summary to Slack"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REGISTRY: 008971668139.dkr.ecr.us-east-1.amazonaws.com
+  GRYPE_VERSION: v0.115.0
+  OPRA_CI_DOPPLER_IDENTITY_ID: fc94b8db-1149-4b8a-8ba7-1fd4833bb870
+  SLACK_IMPLEMENTATIONS_USERGROUP_ID: S092C0T771V
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout CVE audit scripts
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          sparse-checkout: |
+            .github/actions/slack-notify
+            .github/scripts/cve
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
+        with:
+          version: 'latest'
+
+      - name: Install yq
+        uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
+        with:
+          role-to-assume: arn:aws:iam::008971668139:role/github-actions-helm-charts-ecr
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR for Grype registry scans
+        shell: bash
+        run: |
+          set -euo pipefail
+          aws ecr get-login-password --region "${AWS_REGION}" \
+            | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+
+      - name: Install Grype
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sSfL https://get.anchore.io/grype -o /tmp/install-grype.sh
+          sudo sh /tmp/install-grype.sh -b /usr/local/bin "${GRYPE_VERSION}"
+          grype version
+
+      - name: Install Replicated CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest \
+            | grep -m1 -Po '"tag_name":\s*"v\K[^"]+')
+          curl -Ls \
+            "https://github.com/replicatedhq/replicated/releases/download/v${version}/replicated_${version}_linux_amd64.tar.gz" \
+            -o replicated.tar.gz
+          tar xf replicated.tar.gz replicated
+          sudo install replicated /usr/local/bin/replicated
+
+      - name: Fetch audit secrets from Doppler
+        id: doppler
+        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ env.OPRA_CI_DOPPLER_IDENTITY_ID }}
+          doppler-project: opra-ci
+          doppler-config: prd
+          inject-env-vars: true
+
+      - name: Validate audit secrets
+        shell: bash
+        env:
+          NOTIFY_SLACK: ${{ github.event_name != 'workflow_dispatch' || inputs.notify_slack }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in REPLICATED_API_TOKEN REPLICATED_APP; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("${name}")
+            fi
+          done
+
+          if [[ "${NOTIFY_SLACK}" == "true" && -z "${NIGHTLY_SLACK_WEBHOOK_URL:-}" ]]; then
+            missing+=("NIGHTLY_SLACK_WEBHOOK_URL")
+          fi
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required Doppler secret(s): %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Resolve releases to audit
+        id: releases
+        shell: bash
+        env:
+          CHANNEL: ${{ inputs.channel || 'Stable' }}
+          RELEASE_COUNT: ${{ inputs.release_count || '4' }}
+          RELEASE_SEQUENCES: ${{ inputs.release_sequences || '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p audit-reports
+
+          if ! [[ "${RELEASE_COUNT}" =~ ^[0-9]+$ ]]; then
+            echo "release_count must be a positive integer" >&2
+            exit 1
+          fi
+
+          if [[ -n "${RELEASE_SEQUENCES//[[:space:],]/}" ]]; then
+            printf '%s\n' "${RELEASE_SEQUENCES}" \
+              | tr ',' '\n' \
+              | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+              | grep -E '^[0-9]+$' \
+              | jq -R -s 'split("\n") | map(select(. != "")) | map({sequence: (tonumber), channels: ["manual"], created_at: "", chart_version: ""})' \
+              > audit-reports/releases.json
+          else
+            replicated release ls \
+              --output json \
+              --app "${REPLICATED_APP}" \
+              --token "${REPLICATED_API_TOKEN}" \
+              > audit-reports/replicated-release-list.raw.json
+            sed -n '/^\[/,$p' audit-reports/replicated-release-list.raw.json > audit-reports/replicated-release-list.json
+            jq \
+              --arg channel "${CHANNEL}" \
+              --argjson limit "${RELEASE_COUNT}" \
+              '[.[] | select(any(.activeChannels[]?; .name == $channel))]
+                | sort_by(.sequence)
+                | reverse
+                | .[:$limit]
+                | map({
+                    sequence,
+                    created_at: .createdAt,
+                    channels: [.activeChannels[]?.name],
+                    chart_version: ((.charts[]? | select(.name == "composio") | .version) // .version // "")
+                  })' \
+              audit-reports/replicated-release-list.json \
+              > audit-reports/releases.json
+          fi
+
+          jq empty audit-reports/releases.json
+          release_total="$(jq 'length' audit-reports/releases.json)"
+          if (( release_total == 0 )); then
+            echo "No releases resolved for CVE audit." >&2
+            exit 1
+          fi
+
+          echo "Resolved releases:"
+          jq -r '.[] | "- sequence \(.sequence) channels=\(.channels | join(",")) chart=\(.chart_version // "unknown")"' audit-reports/releases.json
+
+      - name: Scan released charts
+        id: audit
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CHANNEL: ${{ inputs.channel || 'Stable' }}
+        run: |
+          set -euo pipefail
+          scan_started_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          artifact_name="released-grype-cve-audit-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_download_command="gh run download ${GITHUB_RUN_ID} --repo ${GITHUB_REPOSITORY} --name ${artifact_name} --dir ./released-cve-audit"
+          echo '[]' > audit-reports/release-results.json
+          mapfile -t releases < <(jq -c '.[]' audit-reports/releases.json)
+
+          for release in "${releases[@]}"; do
+            sequence="$(jq -r '.sequence' <<<"${release}")"
+            created_at="$(jq -r '.created_at // ""' <<<"${release}")"
+            release_dir="audit-reports/release-${sequence}"
+            mkdir -p "${release_dir}/chart" "${release_dir}/baseline"
+
+            echo "Inspecting Replicated release sequence ${sequence}"
+            replicated release inspect "${sequence}" \
+              --output json \
+              --app "${REPLICATED_APP}" \
+              --token "${REPLICATED_API_TOKEN}" \
+              > "${release_dir}/replicated-release.raw.json"
+            sed -n '/^{/,$p' "${release_dir}/replicated-release.raw.json" > "${release_dir}/replicated-release.json"
+
+            chart_version="$(
+              jq -r '(.charts[]? | select(.name == "composio") | .version) // ""' "${release_dir}/replicated-release.json"
+            )"
+            chart_content="$(
+              jq -r 'first(.config | fromjson[] | select(.name | test("^composio-[^/]+[.]tgz$")) | .content) // ""' \
+                "${release_dir}/replicated-release.json"
+            )"
+
+            if [[ -z "${chart_content}" || "${chart_content}" == "null" ]]; then
+              jq -n \
+                --arg sequence "${sequence}" \
+                --arg created_at "${created_at}" \
+                --arg chart_version "${chart_version}" \
+                --arg error "Replicated release did not include a composio chart archive" \
+                '{
+                  scanResult: "failed",
+                  totalHigh: 0,
+                  totalCritical: 0,
+                  fixedNow: 0,
+                  fixedAtReleaseScan: 0,
+                  newlyDetected: 0,
+                  findings: [],
+                  imageStats: [],
+                  release_sequence: ($sequence | tonumber),
+                  release_created_at: $created_at,
+                  release_chart_version: $chart_version,
+                  detected_release_tag: "",
+                  baseline_source: "missing",
+                  error: $error
+                }' > "${release_dir}/report-result.json"
+            else
+              printf '%s' "${chart_content}" | base64 -d > "${release_dir}/composio.tgz"
+              tar -xzf "${release_dir}/composio.tgz" -C "${release_dir}/chart"
+              chart_root="$(find "${release_dir}/chart" -mindepth 1 -maxdepth 1 -type d | head -n1)"
+
+              CHART_DIR="${chart_root}" \
+                OUTPUT_DIR="${release_dir}" \
+                OVERRIDE_IMAGE_TAGS=0 \
+                RENDER_TEMPORAL=1 \
+                .github/scripts/cve/render-scan-targets.sh
+
+              detected_release_tag="$(
+                jq -r \
+                  --arg prefix "${ECR_REGISTRY}/composio-self-host/" \
+                  '[.[]?.scan_image
+                    | select(startswith($prefix))
+                    | capture(":(?<tag>[^:@]+)$").tag]
+                    | group_by(.)
+                    | sort_by(length)
+                    | reverse
+                    | .[0][0] // ""' \
+                  "${release_dir}/scan-targets.json"
+              )"
+
+              baseline_file=""
+              baseline_source="missing"
+              for candidate in "${detected_release_tag}" "${chart_version}" "v${chart_version}"; do
+                if [[ -z "${candidate}" || "${candidate}" == "v" ]]; then
+                  continue
+                fi
+                rm -f "${release_dir}/baseline/release-cve-baseline.json"
+                if gh release download "${candidate}" \
+                  --repo "${GITHUB_REPOSITORY}" \
+                  --pattern release-cve-baseline.json \
+                  --dir "${release_dir}/baseline" \
+                  >/dev/null 2>&1; then
+                  baseline_file="${release_dir}/baseline/release-cve-baseline.json"
+                  baseline_source="${candidate}"
+                  break
+                fi
+              done
+
+              OUTPUT_DIR="${release_dir}" .github/scripts/cve/run-grype-scan.sh
+
+              baseline_args=()
+              if [[ -n "${baseline_file}" ]]; then
+                baseline_args=(--baseline-findings "${baseline_file}")
+              fi
+
+              node .github/scripts/cve/build-cve-report.mjs \
+                --reports-dir "${release_dir}" \
+                --scan-targets "${release_dir}/scan-targets.json" \
+                --output-dir "${release_dir}" \
+                --release-tag "${detected_release_tag:-replicated-${sequence}}" \
+                --release-version "${chart_version:-replicated-sequence-${sequence}}" \
+                --scan-started-at "${scan_started_at}" \
+                "${baseline_args[@]}" \
+                > "${release_dir}/report-result.raw.json"
+
+              jq \
+                --arg sequence "${sequence}" \
+                --arg created_at "${created_at}" \
+                --arg chart_version "${chart_version}" \
+                --arg detected_release_tag "${detected_release_tag}" \
+                --arg baseline_source "${baseline_source}" \
+                '. + {
+                  release_sequence: ($sequence | tonumber),
+                  release_created_at: $created_at,
+                  release_chart_version: $chart_version,
+                  detected_release_tag: $detected_release_tag,
+                  baseline_source: $baseline_source
+                }' \
+                "${release_dir}/report-result.raw.json" \
+                > "${release_dir}/report-result.json"
+            fi
+
+            result="$(jq -c '.' "${release_dir}/report-result.json")"
+            jq -c --argjson result "${result}" '. + [$result]' audit-reports/release-results.json > audit-reports/release-results.tmp.json
+            mv audit-reports/release-results.tmp.json audit-reports/release-results.json
+          done
+
+          total_high="$(jq '[.[].totalHigh] | add // 0' audit-reports/release-results.json)"
+          total_critical="$(jq '[.[].totalCritical] | add // 0' audit-reports/release-results.json)"
+          newly_detected="$(jq '[.[].newlyDetected] | add // 0' audit-reports/release-results.json)"
+          fixed_now="$(jq '[.[].fixedNow] | add // 0' audit-reports/release-results.json)"
+          release_count="$(jq 'length' audit-reports/release-results.json)"
+          scan_errors="$(jq '[.[].imageStats[]? | select(.grype_exit != 0 and .grype_exit != 2)] | length' audit-reports/release-results.json)"
+
+          {
+            echo "## Released CVE Audit"
+            echo
+            echo "- Channel: \`${CHANNEL}\`"
+            echo "- Releases scanned: ${release_count}"
+            echo "- Scan started at: \`${scan_started_at}\`"
+            echo "- Artifact: \`${artifact_name}\`"
+            echo
+            echo "Download full reports:"
+            echo
+            echo "\`\`\`bash"
+            echo "${artifact_download_command}"
+            echo "\`\`\`"
+            echo
+            echo "### Totals"
+            echo
+            echo "- HIGH: ${total_high}"
+            echo "- CRITICAL: ${total_critical}"
+            echo "- New since release scan: ${newly_detected}"
+            echo "- Fix available now: ${fixed_now}"
+            echo "- Grype scan errors: ${scan_errors}"
+            echo
+            echo "### Releases"
+            echo
+            echo "| Sequence | Chart | Image tag | Baseline | HIGH | CRITICAL | New | Fix now | Result |"
+            echo "| ---: | --- | --- | --- | ---: | ---: | ---: | ---: | --- |"
+            jq -r '.[] |
+              "| \(.release_sequence) | \(.release_chart_version // "unknown") | `\(.detected_release_tag // "unknown")` | \(.baseline_source // "missing") | \(.totalHigh) | \(.totalCritical) | \(.newlyDetected) | \(.fixedNow) | \(.scanResult) |"' \
+              audit-reports/release-results.json
+          } > audit-reports/summary.md
+
+          cat audit-reports/summary.md >> "${GITHUB_STEP_SUMMARY}"
+
+          if (( total_high > 0 || total_critical > 0 || scan_errors > 0 )); then
+            status="FAILURE"
+            title=":rotating_light: Released CVE audit: ATTENTION NEEDED"
+            blocker="Released images contain ${total_high} HIGH and ${total_critical} CRITICAL findings"
+          else
+            status="SUCCESS"
+            title=":white_check_mark: Released CVE audit: clean"
+            blocker=""
+          fi
+
+          {
+            echo "status=${status}"
+            echo "title=${title}"
+            echo "artifact_name=${artifact_name}"
+            echo "artifact_download_command=${artifact_download_command}"
+            echo "summary<<__AUDIT_SUMMARY__"
+            if [[ "${status}" != "SUCCESS" ]]; then
+              echo "<!subteam^${SLACK_IMPLEMENTATIONS_USERGROUP_ID}|@implementations>"
+              echo "*Good to go:* NO - ${blocker}"
+            else
+              echo "*Good to go:* YES"
+            fi
+            echo "*Channel:* \`${CHANNEL}\`"
+            echo "*Releases scanned:* ${release_count}"
+            echo "*Findings:* ${total_high} HIGH / ${total_critical} CRITICAL"
+            echo "*New since release scan:* ${newly_detected}"
+            echo "*Fix available now:* ${fixed_now}"
+            echo "*Grype scan errors:* ${scan_errors}"
+            echo "*Per-release summary:*"
+            jq -r '.[] |
+              "- sequence \(.release_sequence) chart `\(.release_chart_version // "unknown")` tag `\(.detected_release_tag // "unknown")`: \(.totalHigh) HIGH / \(.totalCritical) CRITICAL, new \(.newlyDetected), fix-now \(.fixedNow), baseline \(.baseline_source // "missing")"' \
+              audit-reports/release-results.json
+            echo "*Artifact:* \`${artifact_name}\`"
+            echo "*Download reports:*"
+            echo "\`\`\`"
+            echo "${artifact_download_command}"
+            echo "\`\`\`"
+            echo "__AUDIT_SUMMARY__"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Upload released CVE audit reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ${{ steps.audit.outputs.artifact_name || format('released-grype-cve-audit-{0}-{1}', github.run_id, github.run_attempt) }}
+          if-no-files-found: warn
+          path: audit-reports
+
+      - name: Announce released CVE audit in Slack
+        if: ${{ always() && (github.event_name != 'workflow_dispatch' || inputs.notify_slack) && steps.audit.outputs.summary != '' }}
+        uses: ./.github/actions/slack-notify
+        with:
+          status: ${{ steps.audit.outputs.status }}
+          slack_webhook_url: ${{ steps.doppler.outputs.NIGHTLY_SLACK_WEBHOOK_URL }}
+          title: ${{ steps.audit.outputs.title }}
+          summary: ${{ steps.audit.outputs.summary }}
+
+      - name: Fail when released images have blocking CVEs
+        if: ${{ steps.audit.outputs.status == 'FAILURE' }}
+        shell: bash
+        run: |
+          echo "Released CVE audit found HIGH/CRITICAL vulnerabilities or scan errors." >&2
+          exit 1

--- a/.github/workflows/released-cve-audit.yml
+++ b/.github/workflows/released-cve-audit.yml
@@ -3,14 +3,14 @@ name: released-cve-audit
 on:
   schedule:
     # Run after the nightly release window so newly published CVEs are noticed daily.
-    - cron: "30 22 * * *"
+    - cron: "15 19 * * *"
   workflow_dispatch:
     inputs:
       release_count:
         description: "Number of latest channel releases to scan when release_sequences is blank"
         required: false
         type: string
-        default: "4"
+        default: "3"
       channel:
         description: "Replicated channel to audit"
         required: false
@@ -132,7 +132,7 @@ jobs:
         shell: bash
         env:
           CHANNEL: ${{ inputs.channel || 'Stable' }}
-          RELEASE_COUNT: ${{ inputs.release_count || '4' }}
+          RELEASE_COUNT: ${{ inputs.release_count || '3' }}
           RELEASE_SEQUENCES: ${{ inputs.release_sequences || '' }}
         run: |
           set -euo pipefail
@@ -323,55 +323,19 @@ jobs:
             mv audit-reports/release-results.tmp.json audit-reports/release-results.json
           done
 
-          total_high="$(jq '[.[].totalHigh] | add // 0' audit-reports/release-results.json)"
-          total_critical="$(jq '[.[].totalCritical] | add // 0' audit-reports/release-results.json)"
-          newly_detected="$(jq '[.[].newlyDetected] | add // 0' audit-reports/release-results.json)"
-          fixed_now="$(jq '[.[].fixedNow] | add // 0' audit-reports/release-results.json)"
-          release_count="$(jq 'length' audit-reports/release-results.json)"
-          scan_errors="$(jq '[.[].imageStats[]? | select(.grype_exit != 0 and .grype_exit != 2)] | length' audit-reports/release-results.json)"
-
-          {
-            echo "## Released CVE Audit"
-            echo
-            echo "- Channel: \`${CHANNEL}\`"
-            echo "- Releases scanned: ${release_count}"
-            echo "- Scan started at: \`${scan_started_at}\`"
-            echo "- Artifact: \`${artifact_name}\`"
-            echo
-            echo "Download full reports:"
-            echo
-            echo "\`\`\`bash"
-            echo "${artifact_download_command}"
-            echo "\`\`\`"
-            echo
-            echo "### Totals"
-            echo
-            echo "- HIGH: ${total_high}"
-            echo "- CRITICAL: ${total_critical}"
-            echo "- New since release scan: ${newly_detected}"
-            echo "- Fix available now: ${fixed_now}"
-            echo "- Grype scan errors: ${scan_errors}"
-            echo
-            echo "### Releases"
-            echo
-            echo "| Sequence | Chart | Image tag | Baseline | HIGH | CRITICAL | New | Fix now | Result |"
-            echo "| ---: | --- | --- | --- | ---: | ---: | ---: | ---: | --- |"
-            jq -r '.[] |
-              "| \(.release_sequence) | \(.release_chart_version // "unknown") | `\(.detected_release_tag // "unknown")` | \(.baseline_source // "missing") | \(.totalHigh) | \(.totalCritical) | \(.newlyDetected) | \(.fixedNow) | \(.scanResult) |"' \
-              audit-reports/release-results.json
-          } > audit-reports/summary.md
+          node .github/scripts/cve/build-released-cve-audit.mjs \
+            --release-results audit-reports/release-results.json \
+            --output-dir audit-reports \
+            --channel "${CHANNEL}" \
+            --scan-started-at "${scan_started_at}" \
+            --artifact-name "${artifact_name}" \
+            --artifact-download-command "${artifact_download_command}" \
+            --slack-usergroup-id "${SLACK_IMPLEMENTATIONS_USERGROUP_ID}"
 
           cat audit-reports/summary.md >> "${GITHUB_STEP_SUMMARY}"
 
-          if (( total_high > 0 || total_critical > 0 || scan_errors > 0 )); then
-            status="FAILURE"
-            title=":rotating_light: Released CVE audit: ATTENTION NEEDED"
-            blocker="Released images contain ${total_high} HIGH and ${total_critical} CRITICAL findings"
-          else
-            status="SUCCESS"
-            title=":white_check_mark: Released CVE audit: clean"
-            blocker=""
-          fi
+          status="$(jq -r '.status' audit-reports/released-cve-audit-result.json)"
+          title="$(jq -r '.slackTitle' audit-reports/released-cve-audit-result.json)"
 
           {
             echo "status=${status}"
@@ -379,27 +343,7 @@ jobs:
             echo "artifact_name=${artifact_name}"
             echo "artifact_download_command=${artifact_download_command}"
             echo "summary<<__AUDIT_SUMMARY__"
-            if [[ "${status}" != "SUCCESS" ]]; then
-              echo "<!subteam^${SLACK_IMPLEMENTATIONS_USERGROUP_ID}|@implementations>"
-              echo "*Good to go:* NO - ${blocker}"
-            else
-              echo "*Good to go:* YES"
-            fi
-            echo "*Channel:* \`${CHANNEL}\`"
-            echo "*Releases scanned:* ${release_count}"
-            echo "*Findings:* ${total_high} HIGH / ${total_critical} CRITICAL"
-            echo "*New since release scan:* ${newly_detected}"
-            echo "*Fix available now:* ${fixed_now}"
-            echo "*Grype scan errors:* ${scan_errors}"
-            echo "*Per-release summary:*"
-            jq -r '.[] |
-              "- sequence \(.release_sequence) chart `\(.release_chart_version // "unknown")` tag `\(.detected_release_tag // "unknown")`: \(.totalHigh) HIGH / \(.totalCritical) CRITICAL, new \(.newlyDetected), fix-now \(.fixedNow), baseline \(.baseline_source // "missing")"' \
-              audit-reports/release-results.json
-            echo "*Artifact:* \`${artifact_name}\`"
-            echo "*Download reports:*"
-            echo "\`\`\`"
-            echo "${artifact_download_command}"
-            echo "\`\`\`"
+            cat audit-reports/slack-summary.md
             echo "__AUDIT_SUMMARY__"
           } >> "${GITHUB_OUTPUT}"
 

--- a/composio/README.md
+++ b/composio/README.md
@@ -218,7 +218,7 @@ A Helm chart for Composio
 | otel.collector.service.type | string | `"ClusterIP"` | Service type |
 | otel.collector.serviceAccountName | string | `""` | Existing service account name (used when googleCloud.serviceAccount.create is false) |
 | otel.collector.tolerations | list | `[]` | Tolerations for collector pods |
-| otel.enabled | bool | `true` | Enable OpenTelemetry |
+| otel.enabled | bool | `false` | Enable OpenTelemetry |
 | otel.environment | string | `"development"` | Environment name for telemetry |
 | otel.exporter.otlp.endpoint | string | `"composio-otel-collector:4317"` | gRPC endpoint for OTLP (no protocol prefix needed) |
 | otel.exporter.otlp.headers | string | `""` | Optional headers for authentication |

--- a/composio/templates/apollo/apollo.yaml
+++ b/composio/templates/apollo/apollo.yaml
@@ -110,6 +110,8 @@ spec:
             {{- $coreSecret := include "composio.coreSecretName" . }}
             - name: APOLLO_SECRET_DIR
               value: {{ .Values.apollo.secretsDir | quote }}
+            - name: EXPOSE_ADVANCED_AUTH_PARAMS_BETA
+              value: "true"
             {{- if eq .Values.apollo.objectStorage.backend "s3"}}
             - name: S3_ACCESS_KEY_ID
               valueFrom:

--- a/composio/tests/apollo_test.yaml
+++ b/composio/tests/apollo_test.yaml
@@ -178,6 +178,17 @@ tests:
             name: apollo-secrets
             emptyDir: {}
 
+  - it: should expose advanced auth params beta
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXPOSE_ADVANCED_AUTH_PARAMS_BETA
+            value: "true"
+
   - it: should keep OPENAI_API_KEY optional even when openai integration is disabled
     documentSelector:
       path: kind

--- a/docs/post-installation/index.md
+++ b/docs/post-installation/index.md
@@ -6,7 +6,7 @@ The chart includes built-in OpenTelemetry support for collecting metrics and tra
 
 ```yaml
 otel:
-  enabled: true  # Set to false to disable OTEL completely
+  enabled: false  # Set to true to enable OTEL completely
   
   traces:
     enabled: true  # Enable trace collection
@@ -17,6 +17,10 @@ otel:
     enabled: true  # Enable metrics collection
     exportInterval: 60000  # Export interval in milliseconds
 ```
+
+By default, OTEL is disabled and services do not emit telemetry. This lets the
+chart run without a collector. Enable OTEL only when the collector endpoint is
+available, or leave `otel.enabled: false` to drop service telemetry at startup.
 
 #### OTEL Collector Configuration
 
@@ -58,6 +62,49 @@ otel:
             receivers: [otlp]
             processors: [memory_limiter, batch]
             exporters: [debug, prometheus, googlecloud]
+```
+
+The chart default collector metrics pipeline uses `exporters: [debug, prometheus]`.
+Add `googlecloud` to the metrics and traces exporters only after Google Cloud
+authentication is configured.
+
+#### Mercury Metrics
+
+When `otel.enabled=true`, Mercury initializes OpenTelemetry during self-hosted
+startup and exports metrics through OTLP. With the default collector prefix,
+Google Cloud Monitoring receives them under `custom.googleapis.com/composio/`.
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `mercury.tool_call` | Counter | Number of tool/action executions. |
+| `mercury.tool_call.execution_time` | Histogram | Tool execution duration in milliseconds. |
+| `mercury.tool_call.status_code` | Histogram | HTTP status code distribution for tool executions. |
+| `mercury.key_normalization.count` | Counter | Number of request key alias normalizations. |
+
+Common Mercury metric attributes include `toolkit_name`, `tool_name`,
+`toolkit_version`, `status_code`, `error`, `env`, and
+`module_loading_mechanism`. Latest-version requests can also include
+`response_validation_status`.
+
+In the collector Prometheus exporter, metric names are normalized for
+Prometheus conventions. For example:
+
+```text
+mercury_tool_call_total
+mercury_tool_call_execution_time_bucket
+mercury_tool_call_execution_time_sum
+mercury_tool_call_execution_time_count
+mercury_tool_call_status_code_bucket
+mercury_key_normalization_count_total
+```
+
+In Google Cloud Monitoring, with the default prefix, look for:
+
+```text
+custom.googleapis.com/composio/mercury.tool_call
+custom.googleapis.com/composio/mercury.tool_call.execution_time
+custom.googleapis.com/composio/mercury.tool_call.status_code
+custom.googleapis.com/composio/mercury.key_normalization.count
 ```
 
 #### Service Endpoint Configuration


### PR DESCRIPTION
## Summary

This stacks on top of #316 and splits CVE coverage into two separate nightly flows that share the same Grype report plumbing.

### 1. Upcoming nightly release candidate

- Adds `.github/workflows/grype-cve-scan.yml` as a reusable workflow for release-time Grype scans.
- Updates `nighty-release.yml` so the nightly release retags candidate images, scans the rendered release image set with Grype, uploads a full report artifact, and continues release creation even when HIGH/CRITICAL findings are present.
- CVE findings are alert-only for releases: Slack marks the release as not good to go, tags `@implementations`, includes the CVE summary and artifact download command, but does not block the Replicated release, GitHub release/PR, or onprem-testbed validation.
- Persists `release-cve-baseline.json` onto the GitHub nightly release when the CVE report is available, so future audits can compare what is known now against what was known at release time.
- Distinguishes CVE scan/report infrastructure failures from actual HIGH/CRITICAL findings. If `Build Grype report` fails, Slack says the report build failed and findings are unknown, instead of claiming Grype found vulnerabilities.
- Hardens Replicated CLI install by avoiding the flaky `curl | grep -m1` pattern under `pipefail`.

### 2. Released Stable CVE audit

- Adds a separate scheduled workflow, `.github/workflows/released-cve-audit.yml`, for auditing already shipped releases.
- Defaults to the latest 3 promotions on the Stable Replicated channel.
- Resolves channel history through the Replicated API endpoint `/v3/app/{appId}/channel/{channelId}/releases`; this is required because `replicated release ls` / `activeChannels` only identifies the currently active Stable release.
- Inspects each actual Replicated release, extracts the shipped chart archive, renders the final image list, scans those images with Grype, and uploads a full report artifact.
- Adds `.github/scripts/cve/build-released-cve-audit.mjs`, with tests, to produce:
  - `released-cve-audit-result.json`
  - `finding-context.json`
  - `summary.md`
  - `slack-summary.md`
- The released audit report explains why findings are present using release context:
  - CVE published after release
  - no fix available at release scan
  - missing release baseline
  - newly detected since release scan
  - known with fix available at release scan
  - unknown release context
- The Slack summary includes per-release counts, CVE publication timing counts, reason buckets, scan-error counts, and a download command for the full report. It tags `@implementations` when attention is needed.
- Released audits are alert-only too: discovered CVEs do not fail the audit workflow just because findings exist. Operational failures can still fail the workflow, and the workflow still tries to send a Slack fallback alert.

### 3. Shared report shape

- Both the release-time and released-audit reports include per-image CVE/advisory breakdowns: unique ID count, HIGH/CRITICAL category buckets, fixable vs no-fix counts, package occurrence counts, and the earliest Grype fix-available date detected in the run.
- The release-time scan uploads `image-cve-breakdown.json` and `image-cve-breakdown.tsv` in the report artifact.
- Temporal dependency chart images are excluded from the Composio-managed CVE scan and recorded as ignored metadata.

## Notes

For shipped-chart scans, the render path uses `OVERRIDE_IMAGE_TAGS=0`, so it scans what the release actually references. Replicated proxy images are mapped back to ECR scan targets; external/subchart images are scanned as rendered.

Older releases do not yet have `release-cve-baseline.json`, so their reason bucket is expected to show `missing release baseline`. New releases created after this lands will publish that baseline when the release-time scan report is available.

## Verification

- `node --test .github/scripts/cve/*.test.mjs`
- `ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path); puts path }' .github/workflows/grype-cve-scan.yml .github/workflows/nighty-release.yml .github/workflows/released-cve-audit.yml`
- `docker run --rm -v /private/tmp/helm-charts-reusable-cve-scan:/repo -w /repo rhysd/actionlint:latest .github/workflows/grype-cve-scan.yml .github/workflows/nighty-release.yml .github/workflows/released-cve-audit.yml`
- `git diff --check`
- Previous upcoming release workflow before the alert-only change: https://github.com/ComposioHQ/helm-charts/actions/runs/28723802706
  - Proved report build, report publication, classification, artifact upload, and final Slack notification worked.
  - That run blocked release creation because the older gate behavior was still enabled; this PR now changes that behavior to alert-only.
  - Artifact `nightly-grype-cve-reports-nightly-r20260705_01-28723802706-1`: 10 images, 583 HIGH / 102 CRITICAL, 412 fixes available now, 0 Grype operational errors.
- Released Stable audit workflow before the alert-only workflow-exit change: https://github.com/ComposioHQ/helm-charts/actions/runs/28724563907
  - Proved AWS OIDC, ECR login, Doppler OIDC, Replicated release resolution, chart extraction/rendering, Grype scan, artifact upload, and Slack notification all worked.
  - Scanned Stable channel sequences 189 (`0.2.91`), 185 (`0.2.87`), and 184 (`0.2.86`).
  - Totals: 1854 HIGH / 324 CRITICAL, 1359 fixes available now, 0 Grype scan errors, 0 release inspection errors.
  - Slack summary tagged `@implementations`, marked "Good to go: NO", included per-release counts, reason buckets, CVE publication timing, and the `gh run download` command.
- Released Nightly audit after Temporal exclusion: https://github.com/ComposioHQ/helm-charts/actions/runs/30081415292
  - Proved Temporal dependency chart images are excluded and recorded in `ignored-images.txt` / `ignored-scan-targets.json`.
  - Artifact `released-grype-cve-audit-30081415292-1`: 8 scanned image targets, 1 ignored Temporal image, 130 HIGH / 28 CRITICAL, 40 fixes available now, 0 Grype scan errors, 0 release inspection errors.
