### PR TITLE
fix: expose advanced auth params beta

### DIFF
--- a/composio/templates/apollo/apollo.yaml
+++ b/composio/templates/apollo/apollo.yaml
@@ -110,6 +110,8 @@ spec:
             {{- $coreSecret := include "composio.coreSecretName" . }}
             - name: APOLLO_SECRET_DIR
               value: {{ .Values.apollo.secretsDir | quote }}
+            - name: EXPOSE_ADVANCED_AUTH_PARAMS_BETA
+              value: "true"
             {{- if eq .Values.apollo.objectStorage.backend "s3"}}
             - name: S3_ACCESS_KEY_ID
               valueFrom:

--- a/composio/tests/apollo_test.yaml
+++ b/composio/tests/apollo_test.yaml
@@ -178,6 +178,17 @@ tests:
             name: apollo-secrets
             emptyDir: {}
 
+  - it: should expose advanced auth params beta
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXPOSE_ADVANCED_AUTH_PARAMS_BETA
+            value: "true"
+
   - it: should keep OPENAI_API_KEY optional even when openai integration is disabled
     documentSelector:
       path: kind


### PR DESCRIPTION
# Description

Adds `EXPOSE_ADVANCED_AUTH_PARAMS_BETA=true` to the Apollo deployment environment so the self-hosted Apollo pod exposes the advanced auth params beta behavior.

Also adds helm-unittest coverage to assert the env var is rendered in the Apollo Deployment.

# How did I test this PR

- `helm unittest . -f tests/apollo_test.yaml`
- `git diff --check`