### PR TITLE
Document Mercury OTel metrics and add pod identity

### DIFF
--- a/composio/README.md
+++ b/composio/README.md
@@ -218,6 +218,7 @@ A Helm chart for Composio
 | otel.collector.service.type | string | `"ClusterIP"` | Service type |
 | otel.collector.serviceAccountName | string | `""` | Existing service account name (used when googleCloud.serviceAccount.create is false) |
 | otel.collector.tolerations | list | `[]` | Tolerations for collector pods |
+| otel.clusterName | string | `""` | Optional Kubernetes cluster name added to OTEL resource attributes |
 | otel.enabled | bool | `false` | Enable OpenTelemetry |
 | otel.environment | string | `"development"` | Environment name for telemetry |
 | otel.exporter.otlp.endpoint | string | `"composio-otel-collector:4317"` | gRPC endpoint for OTLP (no protocol prefix needed) |

--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -91,6 +91,37 @@ false
 {{- printf "postgresql://%s@%s-toolkit-registry:%v/%s?sslmode=disable" $user .Release.Name (.Values.toolkitRegistry.service.port | int) $database -}}
 {{- end -}}
 
+{{/*
+Render OTEL_RESOURCE_ATTRIBUTES with Kubernetes pod identity.
+Expected keys:
+- root: chart root context
+- serviceName: service.name value
+- serviceVersion: service.version value
+*/}}
+{{- define "composio.otelResourceAttributes" -}}
+{{- $root := .root -}}
+{{- $clusterName := $root.Values.otel.clusterName | default "" -}}
+service.name={{ .serviceName }},service.namespace=$(POD_NAMESPACE),service.instance.id=$(POD_NAME),service.version={{ .serviceVersion }},deployment.environment={{ $root.Values.otel.environment | default $root.Values.global.environment | default "development" }},k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME),k8s.node.name=$(NODE_NAME){{- if $clusterName }},k8s.cluster.name={{ $clusterName }}{{- end -}}
+{{- end -}}
+
+{{/*
+Render Kubernetes downward API env vars used by composio.otelResourceAttributes.
+*/}}
+{{- define "composio.otelKubernetesEnv" -}}
+- name: POD_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+- name: POD_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
+- name: NODE_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
+{{- end -}}
+
 {{- define "temporal-encryption-key" -}}
 {{- $coreName := include "composio.coreSecretName" . -}}
 {{- $core := lookup "v1" "Secret" .Release.Namespace $coreName -}}

--- a/composio/templates/apollo/apollo.yaml
+++ b/composio/templates/apollo/apollo.yaml
@@ -108,6 +108,12 @@ spec:
                 name: {{ .Release.Name }}-apollo-config
           env:
             {{- $coreSecret := include "composio.coreSecretName" . }}
+            {{- if .Values.otel.enabled }}
+            # OTEL Resource attributes
+            {{- include "composio.otelKubernetesEnv" . | nindent 12 }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ include "composio.otelResourceAttributes" (dict "root" . "serviceName" (.Values.otel.apollo.serviceName | default "apollo") "serviceVersion" (.Values.otel.apollo.serviceVersion | default "1.0.0")) | quote }}
+            {{- end }}
             - name: APOLLO_SECRET_DIR
               value: {{ .Values.apollo.secretsDir | quote }}
             - name: EXPOSE_ADVANCED_AUTH_PARAMS_BETA

--- a/composio/templates/frontend/frontend.yaml
+++ b/composio/templates/frontend/frontend.yaml
@@ -87,6 +87,12 @@ spec:
             - configMapRef:
                 name: {{ .Release.Name }}-frontend-config
           env:
+            {{- if .Values.otel.enabled }}
+            # OTEL Resource attributes
+            {{- include "composio.otelKubernetesEnv" . | nindent 12 }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ include "composio.otelResourceAttributes" (dict "root" . "serviceName" (.Values.otel.frontend.serviceName | default "frontend") "serviceVersion" (.Values.otel.frontend.serviceVersion | default "1.0.0")) | quote }}
+            {{- end }}
             - name: FRONTEND_SECRETS_DIR
               value: {{ .Values.frontend.secretsDir | quote }}
             - name: OPENAI_API_KEY

--- a/composio/templates/mercury/mercury-service.yaml
+++ b/composio/templates/mercury/mercury-service.yaml
@@ -83,6 +83,12 @@ spec:
                   name: {{ $coreSecret }}
                   key: COMPOSIO_ADMIN_TOKEN
                   optional: true
+            {{- if .Values.otel.enabled }}
+            # OTEL Resource attributes
+            {{- include "composio.otelKubernetesEnv" . | nindent 12 }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ include "composio.otelResourceAttributes" (dict "root" . "serviceName" (.Values.otel.mercury.serviceName | default "mercury-openapi") "serviceVersion" (.Values.otel.mercury.serviceVersion | default "1.0.0")) | quote }}
+            {{- end }}
             {{- with .Values.mercury.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/composio/templates/mercury/mercury.yaml
+++ b/composio/templates/mercury/mercury.yaml
@@ -101,8 +101,9 @@ spec:
                   optional: true
             {{- if .Values.otel.enabled }}
             # OTEL Resource attributes
+            {{- include "composio.otelKubernetesEnv" . | nindent 12 }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.name={{ .Values.otel.mercury.serviceName | default "mercury-openapi" }},service.version={{ .Values.otel.mercury.serviceVersion | default "1.0.0" }},deployment.environment={{ .Values.otel.environment | default .Values.global.environment | default "development" }}"
+              value: {{ include "composio.otelResourceAttributes" (dict "root" . "serviceName" (.Values.otel.mercury.serviceName | default "mercury-openapi") "serviceVersion" (.Values.otel.mercury.serviceVersion | default "1.0.0")) | quote }}
             {{- end }}
           resources:
             {{- toYaml .Values.mercury.resources | nindent 12 }}

--- a/composio/templates/thermos/thermos-misc-workers.yaml
+++ b/composio/templates/thermos/thermos-misc-workers.yaml
@@ -114,6 +114,12 @@ spec:
                 name: {{ .Release.Name }}-thermos-config
           env:
             {{- $coreSecret := include "composio.coreSecretName" . }}
+            {{- if .Values.otel.enabled }}
+            # OTEL Resource attributes
+            {{- include "composio.otelKubernetesEnv" . | nindent 12 }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ include "composio.otelResourceAttributes" (dict "root" . "serviceName" (.Values.otel.thermos.serviceName | default "thermos") "serviceVersion" (.Values.otel.thermos.serviceVersion | default "1.0.0")) | quote }}
+            {{- end }}
             - name: THERMOS_MODE
               value: "miscellaneous_worker"
             - name: ENABLE_TEMPORAL_AUTO_RECOVERY

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -113,6 +113,12 @@ spec:
                 name: {{ .Release.Name }}-thermos-config
           env:
             {{- $coreSecret := include "composio.coreSecretName" . }}
+            {{- if .Values.otel.enabled }}
+            # OTEL Resource attributes
+            {{- include "composio.otelKubernetesEnv" . | nindent 12 }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ include "composio.otelResourceAttributes" (dict "root" . "serviceName" (.Values.otel.thermos.serviceName | default "thermos") "serviceVersion" (.Values.otel.thermos.serviceVersion | default "1.0.0")) | quote }}
+            {{- end }}
             - name: THERMOS_SECRET_DIR
               value: {{ .Values.thermos.secretsDir | quote }}
             - name: APOLLO_ADMIN_TOKEN

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -863,6 +863,9 @@ otel:
     enabled: false
   # -- Environment name for telemetry
   environment: "development"
+  # -- Optional Kubernetes cluster name added to OTEL resource attributes.
+  # Set this when exporting to backends such as Google Cloud Monitoring.
+  clusterName: ""
   # Service-specific OpenTelemetry configurations
   apollo:
     # -- Apollo service name

--- a/docs/post-installation/index.md
+++ b/docs/post-installation/index.md
@@ -79,12 +79,14 @@ Google Cloud Monitoring receives them under `custom.googleapis.com/composio/`.
 | `mercury.tool_call` | Counter | Number of tool/action executions. |
 | `mercury.tool_call.execution_time` | Histogram | Tool execution duration in milliseconds. |
 | `mercury.tool_call.status_code` | Histogram | HTTP status code distribution for tool executions. |
-| `mercury.key_normalization.count` | Counter | Number of request key alias normalizations. |
+| `mercury.outbound_http.request` | Counter | Number of outbound HTTP requests made by tool execution. |
+| `mercury.outbound_http.request.duration` | Histogram | Outbound HTTP request duration in milliseconds. |
+| `mercury.outbound_http.response.status_code` | Histogram | Outbound HTTP response status code distribution. |
 
 Common Mercury metric attributes include `toolkit_name`, `tool_name`,
-`toolkit_version`, `status_code`, `error`, `env`, and
-`module_loading_mechanism`. Latest-version requests can also include
-`response_validation_status`.
+`toolkit_version`, `status_code`, `status_class`, `method`, `attempt`,
+`error`, `env`, and `module_loading_mechanism`. Latest-version requests can
+also include `response_validation_status`.
 
 In the collector Prometheus exporter, metric names are normalized for
 Prometheus conventions. For example:
@@ -95,7 +97,9 @@ mercury_tool_call_execution_time_bucket
 mercury_tool_call_execution_time_sum
 mercury_tool_call_execution_time_count
 mercury_tool_call_status_code_bucket
-mercury_key_normalization_count_total
+mercury_outbound_http_request_total
+mercury_outbound_http_request_duration_bucket
+mercury_outbound_http_response_status_code_bucket
 ```
 
 In Google Cloud Monitoring, with the default prefix, look for:
@@ -104,8 +108,26 @@ In Google Cloud Monitoring, with the default prefix, look for:
 custom.googleapis.com/composio/mercury.tool_call
 custom.googleapis.com/composio/mercury.tool_call.execution_time
 custom.googleapis.com/composio/mercury.tool_call.status_code
-custom.googleapis.com/composio/mercury.key_normalization.count
+custom.googleapis.com/composio/mercury.outbound_http.request
+custom.googleapis.com/composio/mercury.outbound_http.request.duration
+custom.googleapis.com/composio/mercury.outbound_http.response.status_code
 ```
+
+For Google Cloud Monitoring, the chart adds Kubernetes resource identity to
+`OTEL_RESOURCE_ATTRIBUTES` for each application pod:
+
+```text
+service.namespace=$(POD_NAMESPACE)
+service.instance.id=$(POD_NAME)
+k8s.namespace.name=$(POD_NAMESPACE)
+k8s.pod.name=$(POD_NAME)
+k8s.node.name=$(NODE_NAME)
+```
+
+Set `otel.clusterName` to include `k8s.cluster.name` as well. These attributes
+keep cumulative metric streams distinct per pod and prevent Google Cloud
+Monitoring from rejecting writes with `InvalidArgument: Points must be written
+in order` when multiple pods emit the same metric and labels.
 
 #### Service Endpoint Configuration
 


### PR DESCRIPTION
## Summary
- document the Mercury OTel metrics exported through the collector and Google Cloud Monitoring
- add Kubernetes pod identity to OTEL_RESOURCE_ATTRIBUTES for Apollo, Thermos, Mercury, frontend, and Thermos misc workers
- add optional otel.clusterName so Google Cloud Monitoring can distinguish cumulative streams by Kubernetes cluster/pod identity

## Why
Google Cloud Monitoring rejects cumulative metric writes when multiple pods collapse into the same generic_node time series. Adding service.namespace, service.instance.id, and k8s.* resource attributes keeps those streams distinct without application code changes.

## Validation
- helm template composio ./composio --namespace composio --set otel.enabled=true --set otel.clusterName=test-dev
- helm template composio ./composio --namespace composio --set otel.enabled=true --set otel.clusterName=test-dev --set thermosMiscWorkers.enabled=true --set frontend.enabled=true
- helm lint ./composio --set otel.enabled=true --set otel.clusterName=test-dev