### PR TITLE
Add released CVE audit workflow placeholder

### DIFF
--- a/.github/workflows/released-cve-audit.yml
+++ b/.github/workflows/released-cve-audit.yml
@@ -1,0 +1,16 @@
+name: released-cve-audit
+
+on:
+  schedule:
+    - cron: "15 19 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: echo "released-cve-audit workflow placeholder"


### PR DESCRIPTION
## Summary
- adds a no-op `released-cve-audit` workflow on the default branch so GitHub registers the workflow name
- keeps the workflow intentionally inert: read-only permissions plus a single echo step
- this unblocks dispatch testing of the full released CVE audit workflow from the stacked PR

## Verification
- `ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path); puts path }' .github/workflows/released-cve-audit.yml`
- `git diff --cached --check`