### PR TITLE
Nightly release r20260707_02

### DIFF
--- a/composio/Chart.yaml
+++ b/composio/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: composio
 description: A Helm chart for Composio
 type: application
-version: "0.2.13"
-appVersion: "0.2.13"
+version: "0.2.98"
+appVersion: "0.2.98"
 dependencies:
   - name: redis
     version: "17.11.3"

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -167,7 +167,7 @@ apollo:
     # -- Apollo image repository (used when imageName is not set)
     repository: composio-self-host/apollo
     # -- Apollo image tag
-    tag: "r20260501_01"
+    tag: "r20260707_02"
     # -- Image pull policy
     pullPolicy: Always
     imageName: ""
@@ -212,7 +212,7 @@ apollo:
       # -- Database init image repository (used when imageName is not set)
       repository: composio-self-host/apollo-db-init
       # -- Database init image tag
-      tag: "r20260501_01"
+      tag: "r20260707_02"
       # -- Image pull policy
       pullPolicy: Always
       # -- Full image name (optional, overrides repository:tag if set)
@@ -383,7 +383,7 @@ thermos:
     # -- Thermos image repository (used when imageName is not set)
     repository: composio-self-host/thermos
     # -- Thermos image tag
-    tag: "r20260501_01"
+    tag: "r20260707_02"
     # -- Image pull policy
     pullPolicy: Always
     # -- Full image name (optional, overrides repository:tag if set)
@@ -417,7 +417,7 @@ thermos:
       # -- Database init image repository (used when imageName is not set)
       repository: composio-self-host/thermos-db-init
       # -- Database init image tag
-      tag: "r20260501_01"
+      tag: "r20260707_02"
       # -- Image pull policy
       pullPolicy: Always
       # -- Full image name (optional, overrides repository:tag if set)
@@ -478,7 +478,7 @@ toolkitRegistry:
     # -- Toolkit registry image repository (used when imageName is not set)
     repository: composio-self-host/thermos-toolkit-registry
     # -- Toolkit registry image tag
-    tag: "r20260501_01"
+    tag: "r20260707_02"
     # -- Image pull policy
     pullPolicy: Always
     # -- Full image name (optional, overrides repository:tag if set)
@@ -529,7 +529,7 @@ thermosMiscWorkers:
   image:
     # Same image as Thermos; behavior is controlled by THERMOS_MODE env var.
     repository: composio-self-host/thermos
-    tag: "r20260501_01"
+    tag: "r20260707_02"
     pullPolicy: Always
     imageName: ""
   # Reuse Thermos secrets dir by default.
@@ -1098,7 +1098,7 @@ mercury:
     # -- Mercury image repository (used when imageName is not set)
     repository: composio-self-host/mercury
     # -- Mercury image tag
-    tag: "r20260501_01"
+    tag: "r20260707_02"
     # -- Image pull policy
     pullPolicy: Always
     # -- Full image name (optional, overrides repository:tag if set)
@@ -1240,7 +1240,7 @@ frontend:
     # -- Frontend image repository (used when imageName is not set)
     repository: composio-self-host/frontend
     # -- Frontend image tag
-    tag: "r20260501_01"
+    tag: "r20260707_02"
     # -- Image pull policy
     pullPolicy: Always
     # -- Full image name (optional, overrides repository:tag if set)
@@ -1323,7 +1323,7 @@ weaviate:
     # -- Weaviate image repository (used when imageName is not set)
     repository: composio-self-host/weaviate
     # -- Weaviate image tag
-    tag: "r20260501_01"
+    tag: "r20260707_02"
     # -- Image pull policy
     pullPolicy: Always
     # -- Full image name (optional, overrides repository:tag if set)

--- a/manifests/composio.yaml
+++ b/manifests/composio.yaml
@@ -8,7 +8,7 @@ spec:
     # name must match the chart name from the .tgz chart archive
     name: composio
     # chartVersion must match the chart version from the .tgz chart archive
-    chartVersion: 0.2.13
+    chartVersion: 0.2.98
   namespace: composio
   values:
     replicated:

--- a/manifests/k8s-app.yaml
+++ b/manifests/k8s-app.yaml
@@ -6,7 +6,7 @@ metadata:
     kots.io/exclude: "true"
   labels:
     app.kubernetes.io/name: "composio"
-    app.kubernetes.io/version: "0.2.13"
+    app.kubernetes.io/version: "0.2.98"
 spec:
   selector:
     matchLabels:
@@ -17,7 +17,7 @@ spec:
     - group: apps
       kind: Deployment
   descriptor:
-    version: "0.2.13"
+    version: "0.2.98"
     description: "Composio"
     icons:
       - src: "https://avatars.githubusercontent.com/u/128464815?s=48&v=4"


### PR DESCRIPTION
## Summary

- Bump Helm chart version to 0.2.98
- Update nightly image tags to r20260707_02
- Refresh replicated manifest versions