### PR TITLE
fix: derive nightly image tag from replicated release

### DIFF
--- a/.github/scripts/calculate-nightly-release-tag.sh
+++ b/.github/scripts/calculate-nightly-release-tag.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CHART_OCI_REF="${CHART_OCI_REF:-oci://registry.composio.io/composio-rodent/nightly/composio}"
+NIGHTLY_CHANNEL_NAME="${NIGHTLY_CHANNEL_NAME:-Nightly}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_env() {
+  if [[ -z "${!1:-}" ]]; then
+    echo "$1 is required." >&2
+    exit 1
+  fi
+}
+
+write_output() {
+  local key="$1"
+  local value="$2"
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "${key}=${value}" >> "${GITHUB_OUTPUT}"
+  fi
+}
+
+chart_name_from_ref() {
+  basename "${CHART_OCI_REF}"
+}
+
+resolve_replicated_app_id() {
+  local apps_json app_id
+
+  require_env REPLICATED_APP
+  require_env REPLICATED_API_TOKEN
+
+  apps_json="$(
+    curl -fsSL "https://api.replicated.com/vendor/v3/apps" \
+      --header "Accept: application/json" \
+      --header "Authorization: ${REPLICATED_API_TOKEN}"
+  )"
+
+  app_id="$(
+    echo "${apps_json}" | jq -r --arg app "${REPLICATED_APP}" '
+      .apps[]
+      | select(.id == $app or .slug == $app or .name == $app)
+      | .id
+    ' | head -n1
+  )"
+
+  if [[ -z "${app_id}" || "${app_id}" == "null" ]]; then
+    echo "Unable to resolve Replicated app ID for ${REPLICATED_APP}" >&2
+    exit 1
+  fi
+
+  printf '%s' "${app_id}"
+}
+
+resolve_nightly_channel() {
+  local app_id="$1"
+  local channels_json total_count channel_id current_version release_sequence
+
+  channels_json="$(
+    curl -fsSLG "https://api.replicated.com/vendor/v3/app/${app_id}/channels" \
+      --data-urlencode "channelName=${NIGHTLY_CHANNEL_NAME}" \
+      --header "Accept: application/json" \
+      --header "Authorization: ${REPLICATED_API_TOKEN}"
+  )"
+
+  total_count="$(echo "${channels_json}" | jq -r '.totalCount // (.channels | length)')"
+  if [[ "${total_count}" != "1" ]]; then
+    echo "${NIGHTLY_CHANNEL_NAME} channel was not found in Replicated channels API response" >&2
+    exit 1
+  fi
+
+  channel_id="$(echo "${channels_json}" | jq -r '.channels[0].id // .channels[0].channelId // empty')"
+  current_version="$(echo "${channels_json}" | jq -r '.channels[0].currentVersion // empty')"
+  release_sequence="$(echo "${channels_json}" | jq -r '.channels[0].releaseSequence // .channels[0].currentReleaseSequence // empty')"
+
+  if [[ -z "${current_version}" || "${current_version}" == "null" ]]; then
+    echo "${NIGHTLY_CHANNEL_NAME} channel response did not include currentVersion" >&2
+    exit 1
+  fi
+
+  jq -n \
+    --arg id "${channel_id}" \
+    --arg currentVersion "${current_version}" \
+    --arg releaseSequence "${release_sequence}" \
+    '{id: $id, currentVersion: $currentVersion, releaseSequence: $releaseSequence}'
+}
+
+pull_nightly_values() {
+  local chart_version="$1"
+  local chart_name pull_root chart_dir
+
+  require_cmd helm
+
+  chart_name="$(chart_name_from_ref)"
+  pull_root="$(mktemp -d)"
+
+  helm pull "${CHART_OCI_REF}" --version "${chart_version}" --untar --untardir "${pull_root}" >/dev/null
+
+  chart_dir="${pull_root}/${chart_name}"
+  if [[ ! -f "${chart_dir}/values.yaml" ]]; then
+    echo "Chart pull succeeded but expected values.yaml was missing under ${chart_dir}" >&2
+    exit 1
+  fi
+
+  printf '%s' "${chart_dir}/values.yaml"
+}
+
+extract_base_calendar_tag() {
+  local values_file="$1"
+
+  require_cmd yq
+
+  yq -r '
+    [
+      .apollo.image.tag,
+      .apollo.dbInit.image.tag,
+      .thermos.image.tag,
+      .thermos.dbInit.image.tag,
+      .thermosMiscWorkers.image.tag,
+      .mercury.image.tag,
+      .frontend.image.tag,
+      .weaviate.image.tag,
+      .toolkitRegistry.image.tag
+    ]
+    | .[]
+    | select(. != null)
+    | tostring
+    | select(test("^r[0-9]{8}_[0-9]{2}$"))
+  ' "${values_file}" | sort -u | tail -n1
+}
+
+calculate_next_calendar_tag() {
+  local base_tag="$1"
+  local date_ist="$2"
+  local next_nn current_date current_nn
+
+  if [[ "${base_tag}" =~ ^r([0-9]{8})_([0-9]{2})$ ]]; then
+    current_date="${BASH_REMATCH[1]}"
+    current_nn="${BASH_REMATCH[2]}"
+
+    if [[ "${current_date}" == "${date_ist}" ]]; then
+      next_nn="$(printf '%02d' "$((10#${current_nn} + 1))")"
+    else
+      next_nn="01"
+    fi
+  else
+    next_nn="01"
+  fi
+
+  printf 'r%s_%s' "${date_ist}" "${next_nn}"
+}
+
+main() {
+  local date_ist app_id channel_json channel_id current_version release_sequence values_file base_tag new_tag
+
+  require_cmd jq
+
+  date_ist="${RELEASE_TAG_DATE:-$(TZ=Asia/Kolkata date +%Y%m%d)}"
+  app_id=""
+  channel_id=""
+  current_version=""
+  release_sequence=""
+
+  if [[ -n "${NIGHTLY_VALUES_FILE:-}" ]]; then
+    values_file="${NIGHTLY_VALUES_FILE}"
+  else
+    require_cmd curl
+
+    app_id="$(resolve_replicated_app_id)"
+    channel_json="$(resolve_nightly_channel "${app_id}")"
+    channel_id="$(echo "${channel_json}" | jq -r '.id // empty')"
+    current_version="$(echo "${channel_json}" | jq -r '.currentVersion // empty')"
+    release_sequence="$(echo "${channel_json}" | jq -r '.releaseSequence // empty')"
+    values_file="$(pull_nightly_values "${current_version}")"
+  fi
+
+  base_tag="$(extract_base_calendar_tag "${values_file}")"
+  new_tag="$(calculate_next_calendar_tag "${base_tag}" "${date_ist}")"
+
+  echo "Replicated app id: ${app_id:-not resolved}"
+  echo "Nightly channel id: ${channel_id:-not resolved}"
+  echo "Nightly current chart version: ${current_version:-not resolved}"
+  echo "Nightly release sequence: ${release_sequence:-not resolved}"
+  echo "Base image tag used for increment: ${base_tag:-none}"
+  echo "Calculated release tag: ${new_tag}"
+
+  write_output "replicated_app_id" "${app_id}"
+  write_output "replicated_channel_id" "${channel_id}"
+  write_output "replicated_current_version" "${current_version}"
+  write_output "replicated_release_sequence" "${release_sequence}"
+  write_output "base_tag" "${base_tag}"
+  write_output "release_tag" "${new_tag}"
+}
+
+main "$@"

--- a/.github/scripts/tests/calculate-nightly-release-tag-test.sh
+++ b/.github/scripts/tests/calculate-nightly-release-tag-test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+SCRIPT="${SCRIPT_DIR}/calculate-nightly-release-tag.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_release_tag() {
+  local name="$1"
+  local date_ist="$2"
+  local expected="$3"
+  local values_yaml="$4"
+  local tmp_dir values_file output_file actual
+
+  tmp_dir="$(mktemp -d)"
+  values_file="${tmp_dir}/values.yaml"
+  output_file="${tmp_dir}/github-output"
+
+  printf '%s\n' "${values_yaml}" > "${values_file}"
+
+  if ! RELEASE_TAG_DATE="${date_ist}" \
+    NIGHTLY_VALUES_FILE="${values_file}" \
+    GITHUB_OUTPUT="${output_file}" \
+    bash "${SCRIPT}" >"${tmp_dir}/stdout" 2>"${tmp_dir}/stderr"; then
+    echo "stdout:" >&2
+    sed 's/^/  /' "${tmp_dir}/stdout" >&2
+    echo "stderr:" >&2
+    sed 's/^/  /' "${tmp_dir}/stderr" >&2
+    fail "${name}: script exited non-zero"
+  fi
+
+  actual="$(awk -F= '$1 == "release_tag" { print $2 }' "${output_file}" | tail -n1)"
+  [[ "${actual}" == "${expected}" ]] || fail "${name}: expected ${expected}, got ${actual:-<empty>}"
+
+  rm -rf "${tmp_dir}"
+}
+
+assert_release_tag "increments same-day calendar tag" "20260724" "r20260724_04" '
+apollo:
+  image:
+    tag: r20260724_03
+'
+
+assert_release_tag "resets sequence for a new calendar day" "20260724" "r20260724_01" '
+apollo:
+  image:
+    tag: r20260723_08
+'
+
+assert_release_tag "uses the highest replicated nightly image tag in values" "20260724" "r20260724_10" '
+apollo:
+  image:
+    tag: r20260724_03
+mercury:
+  image:
+    tag: r20260724_09
+frontend:
+  image:
+    tag: latest
+'
+
+assert_release_tag "starts at sequence one when no calendar image tag exists" "20260724" "r20260724_01" '
+apollo:
+  image:
+    tag: latest
+'
+
+echo "calculate-nightly-release-tag tests passed"

--- a/.github/workflows/nighty-release.yml
+++ b/.github/workflows/nighty-release.yml
@@ -70,76 +70,41 @@ jobs:
       SOURCE_TAG_WEAVIATE: ${{ github.event.inputs.weaviate_image_tag || '' }}
       SOURCE_TAG_THERMOS_TOOLKIT_REGISTRY: ${{ github.event.inputs.thermos_toolkit_registry_image_tag || '' }}
     permissions:
+      contents: read
       id-token: write
     steps:
-      - name: Calculate release tag from latest GitHub release
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
+        with:
+          version: 'latest'
+
+      - name: Install yq
+        uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d
+
+      - name: Login to chart registry
+        shell: bash
+        env:
+          CHART_OCI_REF: oci://registry.composio.io/composio-rodent/nightly/composio
+          REPLICATED_USERNAME: ${{ secrets.REPLICATED_USERNAME }}
+          REPLICATED_TOKEN: ${{ secrets.REPLICATED_TOKEN }}
+        run: |
+          set -euo pipefail
+          registry_host="${CHART_OCI_REF#oci://}"
+          registry_host="${registry_host%%/*}"
+          printf '%s' "${REPLICATED_TOKEN}" | helm registry login "${registry_host}" --username "${REPLICATED_USERNAME}" --password-stdin
+
+      - name: Calculate release tag from latest Replicated Nightly release
         id: calculate_release_tag
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          date_ist="$(TZ=Asia/Kolkata date +%Y%m%d)"
-          api_root="https://api.github.com/repos/${GITHUB_REPOSITORY}"
-
-          releases_json="$(curl -fsSL \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "${api_root}/releases?per_page=20")"
-
-          latest_release="$(echo "${releases_json}" | jq -c '[.[] | select(.draft == false)] | sort_by(.published_at // .created_at) | last // empty')"
-
-          base_tag=""
-          source_release_tag=""
-          source_release_id=""
-          source_manifest_tag=""
-
-          if [[ -n "${latest_release}" ]]; then
-            source_release_tag="$(echo "${latest_release}" | jq -r '.tag_name // empty')"
-            source_release_id="$(echo "${latest_release}" | jq -r '.id // empty')"
-
-            manifest_asset_url="$(echo "${latest_release}" | jq -r '.assets[]? | select(.name=="release-manifest.json") | .url' | head -n1)"
-            if [[ -n "${manifest_asset_url}" ]]; then
-              manifest_json="$(curl -fsSL \
-                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-                -H "Accept: application/octet-stream" \
-                "${manifest_asset_url}")"
-              source_manifest_tag="$(echo "${manifest_json}" | jq -r '.release_tag // empty')"
-            fi
-
-            if [[ "${source_manifest_tag}" =~ ^r[0-9]{8}_[0-9]{2}$ ]]; then
-              base_tag="${source_manifest_tag}"
-            elif [[ "${source_release_tag}" =~ ^r[0-9]{8}_[0-9]{2}$ ]]; then
-              base_tag="${source_release_tag}"
-            fi
-          fi
-
-          if [[ "${base_tag}" =~ ^r([0-9]{8})_([0-9]{2})$ ]]; then
-            current_date="${BASH_REMATCH[1]}"
-            current_nn="${BASH_REMATCH[2]}"
-
-            if [[ "${current_date}" == "${date_ist}" ]]; then
-              next_nn="$(printf '%02d' "$((10#${current_nn} + 1))")"
-            else
-              next_nn="01"
-            fi
-          else
-            next_nn="01"
-          fi
-
-          new_tag="r${date_ist}_${next_nn}"
-          echo "Latest release id: ${source_release_id:-none}"
-          echo "Latest release tag: ${source_release_tag:-none}"
-          echo "Source manifest tag: ${source_manifest_tag:-none}"
-          echo "Base tag used for increment: ${base_tag:-none}"
-          echo "Calculated release tag: ${new_tag}"
-
-          echo "source_release_id=${source_release_id}" >> "${GITHUB_OUTPUT}"
-          echo "source_release_tag=${source_release_tag}" >> "${GITHUB_OUTPUT}"
-          echo "source_manifest_tag=${source_manifest_tag}" >> "${GITHUB_OUTPUT}"
-          echo "base_tag=${base_tag}" >> "${GITHUB_OUTPUT}"
-          echo "release_tag=${new_tag}" >> "${GITHUB_OUTPUT}"
+          REPLICATED_APP: ${{ secrets.REPLICATED_APP }}
+          REPLICATED_API_TOKEN: ${{ secrets.REPLICATED_API_TOKEN }}
+          CHART_OCI_REF: oci://registry.composio.io/composio-rodent/nightly/composio
+          NIGHTLY_CHANNEL_NAME: Nightly
+        run: bash ./.github/scripts/calculate-nightly-release-tag.sh
 
       - name: Determine AWS Assume Role ARN
         id: env
@@ -164,7 +129,7 @@ jobs:
           fi
 
           NEW_TAG="${{ steps.calculate_release_tag.outputs.release_tag }}"
-          echo "Using release tag from latest GitHub release calculation: ${NEW_TAG}"
+          echo "Using release tag from latest Replicated Nightly calculation: ${NEW_TAG}"
           echo "release_tag=${NEW_TAG}" >> "${GITHUB_OUTPUT}"
 
           resolve_source_tag() {


### PR DESCRIPTION
## Summary

- Replace the nightly workflow's GitHub-release-based calendar tag calculation with Replicated Nightly channel lookup.
- Add a reusable `calculate-nightly-release-tag.sh` helper that resolves the current Replicated Nightly chart, pulls its values, and increments the latest `rYYYYMMDD_NN` image tag.
- Add a focused shell test for same-day increments, new-day reset behavior, highest-tag selection, and missing-tag fallback.

## Why

The nightly image retagging step should derive the next calendar release tag from the latest Replicated nightly release, since that is the release source ultimately used to publish the chart and tag latest images.

## Validation

- `bash .github/scripts/tests/calculate-nightly-release-tag-test.sh`
- `bash -n .github/scripts/calculate-nightly-release-tag.sh`
- `bash -n .github/scripts/tests/calculate-nightly-release-tag-test.sh`
- `yq eval '.' .github/workflows/nighty-release.yml >/dev/null`
- `git diff --check`

Note: the live Replicated/AWS path depends on GitHub Actions secrets and cloud credentials, so it was not executed locally.