### PR TITLE
fix(ci): use valid SemVer for Glean releases

### DIFF
--- a/.github/scripts/resolve-release-config.sh
+++ b/.github/scripts/resolve-release-config.sh
@@ -25,7 +25,7 @@ case "${release_type}" in
     seed_channel_name="Nightly"
     seed_channel_id="397k1WtPrJ1J56bhb70SfeKGcxL"
     seed_chart_oci_ref="oci://registry.composio.io/composio-rodent/nightly/composio"
-    version_prefix="0.2.87"
+    version_prefix="0.2.87-glean"
     ;;
   *)
     echo "Unsupported release type: ${release_type}" >&2

--- a/.github/scripts/tests/calculate-release-version-test.sh
+++ b/.github/scripts/tests/calculate-release-version-test.sh
@@ -80,16 +80,19 @@ assert_version_fails() {
 assert_version "increments standard version" \
   standard "0.2.140" "" "0.2.140" "0.2.141"
 assert_version "bootstraps empty Glean version" \
-  glean "" "0.2.87" "" "0.2.87.1"
+  glean "" "0.2.87-glean" "" "0.2.87-glean.1"
 assert_version "increments existing Glean version" \
-  glean "0.2.87.1" "0.2.87" "0.2.87.1" "0.2.87.2"
+  glean "0.2.87-glean.1" "0.2.87-glean" \
+  "0.2.87-glean.1" "0.2.87-glean.2"
 assert_version "increments a multi-digit Glean sequence" \
-  glean "0.2.87.19" "0.2.87" "0.2.87.19" "0.2.87.20"
+  glean "0.2.87-glean.19" "0.2.87-glean" \
+  "0.2.87-glean.19" "0.2.87-glean.20"
 
 assert_version_fails "rejects empty standard version" \
   standard "" "" "Nightly channel returned an invalid currentVersion: <empty>"
 assert_version_fails "rejects a different Glean family" \
-  glean "0.2.88.1" "0.2.87" "Glean-Stable currentVersion must match 0.2.87.x: 0.2.88.1"
+  glean "0.2.88-glean.1" "0.2.87-glean" \
+  "Glean-Stable currentVersion must match 0.2.87-glean.x: 0.2.88-glean.1"
 assert_version_fails "requires the Glean version prefix" \
   glean "" "" "VERSION_PREFIX is required."
 

--- a/.github/scripts/tests/resolve-release-config-test.sh
+++ b/.github/scripts/tests/resolve-release-config-test.sh
@@ -59,7 +59,7 @@ assert_config standard standard Nightly 397k1WtPrJ1J56bhb70SfeKGcxL \
 assert_config glean glean Glean-Stable 3GwShNBOwcf13Bs7i5pfn3N8TDh \
   oci://registry.composio.io/composio-rodent/glean-stable/composio glean glean \
   Nightly 397k1WtPrJ1J56bhb70SfeKGcxL \
-  oci://registry.composio.io/composio-rodent/nightly/composio 0.2.87
+  oci://registry.composio.io/composio-rodent/nightly/composio 0.2.87-glean
 
 if RELEASE_TYPE=unsupported bash "${SCRIPT}" >/dev/null 2>&1; then
   fail "unsupported release type should fail"


### PR DESCRIPTION
# Description

**Related Linear Ticket**

- https://linear.app/composio/issue/CUS-290/provide-a-private-beta-path-for-pending-glean-action-releases

## Summary

- Replace the invalid four-component Glean version `0.2.87.1` with the Helm-compatible prerelease version `0.2.87-glean.1`.
- Preserve the fixed `0.2.87` Glean family and increment only the final prerelease segment.
- Keep standard release behavior and Glean image-tag calculation unchanged.

Root cause: Helm chart metadata requires SemVer, and the Replicated release version must match the included chart version.

# How did I test this PR

- `bash .github/scripts/tests/resolve-release-config-test.sh` — passed
- `bash .github/scripts/tests/calculate-nightly-release-tag-test.sh` — passed
- `bash .github/scripts/tests/calculate-release-version-test.sh` — passed
- `bash .github/scripts/tests/nighty-release-workflow-test.sh` — passed
- `bash .github/scripts/tests/nightly-slack-summary-test.sh` — passed
- `bash -n .github/scripts/resolve-release-config.sh .github/scripts/calculate-release-version.sh .github/scripts/tests/resolve-release-config-test.sh .github/scripts/tests/calculate-release-version-test.sh` — passed
- `yq eval '.' .github/workflows/nighty-release.yml` — passed
- `helm lint composio` — passed
- `helm template composio composio` — passed
- `helm package composio --version 0.2.87-glean.1 --destination <temp-dir>` — passed
- Not tested by creating a live Replicated release.
