### PR TITLE
fix(ci): pass selected chart to on-prem harness

### DIFF
--- a/.github/scripts/tests/nighty-release-workflow-test.sh
+++ b/.github/scripts/tests/nighty-release-workflow-test.sh
@@ -119,6 +119,14 @@ assert_eq "replicated new version consumption" \
   "$(yq -r '.jobs.replicated-release.outputs.version' "${WORKFLOW}")" \
   '${{ needs.retag-latest-images.outputs.new_version }}'
 
+expected_harness_env_json='{"RUN_TRIGGER_TESTS":"1","RUN_POLLING_TRIGGER_TESTS":"1","RUN_WEBHOOK_TRIGGER_TESTS":"1","HELM_OCI_CHART_REF":"${{ needs.release-config.outputs.chart_oci_ref }}"}'
+assert_eq "fresh-install harness selected chart" \
+  "$(yq -r '.jobs.onprem-testbed.steps[] | select(.id == "fresh") | .env.HARNESS_ENV_JSON' "${WORKFLOW}")" \
+  "${expected_harness_env_json}"
+assert_eq "upgrade harness selected chart" \
+  "$(yq -r '.jobs.onprem-testbed.steps[] | select(.id == "upgrade") | .env.HARNESS_ENV_JSON' "${WORKFLOW}")" \
+  "${expected_harness_env_json}"
+
 assert_step_before "version validation precedes AWS credentials" \
   calculate_version "Determine AWS Assume Role ARN"
 assert_not_contains "late inline version calculation" \

--- a/.github/workflows/nighty-release.yml
+++ b/.github/workflows/nighty-release.yml
@@ -813,7 +813,7 @@ jobs:
           MIGRATION_DIRECTION: upgrade
           CLUSTER_SIZE: xlarge
           INCLUDE_OPTIONAL_SCENARIOS: "false"
-          HARNESS_ENV_JSON: '{"RUN_TRIGGER_TESTS":"1","RUN_POLLING_TRIGGER_TESTS":"1","RUN_WEBHOOK_TRIGGER_TESTS":"1"}'
+          HARNESS_ENV_JSON: '{"RUN_TRIGGER_TESTS":"1","RUN_POLLING_TRIGGER_TESTS":"1","RUN_WEBHOOK_TRIGGER_TESTS":"1","HELM_OCI_CHART_REF":"${{ needs.release-config.outputs.chart_oci_ref }}"}'
           ONPREM_REF: main
           ONPREM_DISPATCH_MODE: repository_dispatch
         run: |
@@ -832,7 +832,7 @@ jobs:
           MIGRATION_DIRECTION: upgrade
           CLUSTER_SIZE: xlarge
           INCLUDE_OPTIONAL_SCENARIOS: "false"
-          HARNESS_ENV_JSON: '{"RUN_TRIGGER_TESTS":"1","RUN_POLLING_TRIGGER_TESTS":"1","RUN_WEBHOOK_TRIGGER_TESTS":"1"}'
+          HARNESS_ENV_JSON: '{"RUN_TRIGGER_TESTS":"1","RUN_POLLING_TRIGGER_TESTS":"1","RUN_WEBHOOK_TRIGGER_TESTS":"1","HELM_OCI_CHART_REF":"${{ needs.release-config.outputs.chart_oci_ref }}"}'
           ONPREM_REF: main
           ONPREM_DISPATCH_MODE: repository_dispatch
         run: |


### PR DESCRIPTION
# Description

**Related Linear Ticket**

- https://linear.app/composio/issue/CUS-290/provide-a-private-beta-path-for-pending-glean-action-releases

## Summary

- Add the selected release configuration's `chart_oci_ref` to `HARNESS_ENV_JSON` for both fresh-install and upgrade CMX harness runs.
- Preserve the existing trigger-test flags.
- Ensure Glean builds test the `glean-stable` OCI channel while standard builds continue to test the Nightly channel.
- Add workflow contract coverage for both harness calls.

Without this wiring, the onprem-testbed resolver used its default Nightly chart reference even when the release workflow built and promoted a Glean-Stable release.

## Screenshots / Recordings

Not applicable. This changes GitHub Actions configuration and has no application UI.

# How did I test this PR

- `bash .github/scripts/tests/resolve-release-config-test.sh` — passed
- `bash .github/scripts/tests/calculate-nightly-release-tag-test.sh` — passed
- `bash .github/scripts/tests/calculate-release-version-test.sh` — passed
- `bash .github/scripts/tests/nighty-release-workflow-test.sh` — passed
- `bash .github/scripts/tests/nightly-slack-summary-test.sh` — passed
- `bash -n .github/scripts/tests/nighty-release-workflow-test.sh` — passed
- `yq eval '.' .github/workflows/nighty-release.yml >/dev/null` — passed
- `git diff --check origin/release-stable...HEAD` — passed
- Ran the onprem-testbed workflow input resolver with a `repository_dispatch` payload containing the Glean-Stable `HELM_OCI_CHART_REF`; it emitted `oci://registry.composio.io/composio-rodent/glean-stable/composio` — passed
- `actionlint` was not run because it is not installed locally.
- A live Replicated release and CMX workflow were not run because they mutate external release and cluster state.