### PR TITLE
fix(ci): hardcode Glean release base tag

### DIFF
--- a/.github/scripts/calculate-nightly-release-tag.sh
+++ b/.github/scripts/calculate-nightly-release-tag.sh
@@ -6,9 +6,7 @@ CHART_OCI_REF="${CHART_OCI_REF:-oci://registry.composio.io/composio-rodent/night
 RELEASE_CHANNEL_NAME="${RELEASE_CHANNEL_NAME:-${NIGHTLY_CHANNEL_NAME:-Nightly}}"
 RELEASE_CHANNEL_ID="${RELEASE_CHANNEL_ID:-}"
 TAG_CALCULATION_MODE="${TAG_CALCULATION_MODE:-standard}"
-SEED_CHANNEL_NAME="${SEED_CHANNEL_NAME:-}"
-SEED_CHANNEL_ID="${SEED_CHANNEL_ID:-}"
-SEED_CHART_OCI_REF="${SEED_CHART_OCI_REF:-}"
+readonly GLEAN_BASE_TAG="r20260701_02"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -154,11 +152,14 @@ extract_base_calendar_tag() {
     | tail -n1
 }
 
-extract_glean_tags() {
+extract_glean_suffixes() {
   local values_file="$1"
 
   extract_image_tags "${values_file}" \
-    | awk '/^r[0-9]{8}_[0-9]{2}(-p[0-9]{8}_[0-9]{2})?$/' \
+    | awk '/^r[0-9]{8}_[0-9]{2}-p[0-9]{8}_[0-9]{2}$/ {
+        sub(/^r[0-9]{8}_[0-9]{2}-/, "")
+        print
+      }' \
     | sort -u
 }
 
@@ -208,8 +209,8 @@ calculate_next_glean_tag() {
 
 main() {
   local date_ist app_id channel_json channel_id current_version release_sequence
-  local values_file base_tag base_tags base_count suffix_tag new_tag glean_tags
-  local seed_channel_json values_source_name values_source_version values_source_ref
+  local values_file="" base_tag suffix_tag new_tag
+  local values_source_name values_source_version values_source_ref
 
   require_cmd jq
 
@@ -247,25 +248,9 @@ main() {
         echo "${RELEASE_CHANNEL_NAME} channel response did not include currentVersion" >&2
         exit 1
       fi
-
-      require_env SEED_CHANNEL_NAME
-      require_env SEED_CHANNEL_ID
-      require_env SEED_CHART_OCI_REF
-
-      seed_channel_json="$(
-        resolve_release_channel "${app_id}" "${SEED_CHANNEL_NAME}" "${SEED_CHANNEL_ID}"
-      )"
-      values_source_version="$(echo "${seed_channel_json}" | jq -r '.currentVersion // empty')"
-      if [[ -z "${values_source_version}" || "${values_source_version}" == "null" ]]; then
-        echo "${SEED_CHANNEL_NAME} seed channel response did not include currentVersion" >&2
-        exit 1
-      fi
-
-      values_source_name="${SEED_CHANNEL_NAME}"
-      values_source_ref="${SEED_CHART_OCI_REF}"
+    else
+      values_file="$(pull_release_values "${values_source_ref}" "${values_source_version}")"
     fi
-
-    values_file="$(pull_release_values "${values_source_ref}" "${values_source_version}")"
   fi
 
   case "${TAG_CALCULATION_MODE}" in
@@ -274,32 +259,13 @@ main() {
       new_tag="$(calculate_next_calendar_tag "${base_tag}" "${date_ist}")"
       ;;
     glean)
-      glean_tags="$(extract_glean_tags "${values_file}")"
-      base_tags="$(
-        printf '%s\n' "${glean_tags}" \
-          | sed -E 's/-p[0-9]{8}_[0-9]{2}$//' \
-          | awk 'NF' \
-          | sort -u
-      )"
-      base_count="$(printf '%s\n' "${base_tags}" | awk 'NF { count++ } END { print count + 0 }')"
-      if [[ "${base_count}" == "0" ]]; then
-        echo "Glean tag calculation requires a valid fixed base tag." >&2
-        exit 1
+      base_tag="${GLEAN_BASE_TAG}"
+      if [[ -n "${values_file}" ]]; then
+        suffix_tag="$(
+          extract_glean_suffixes "${values_file}" \
+            | tail -n1
+        )"
       fi
-      if [[ "${base_count}" != "1" ]]; then
-        echo "Glean tag calculation requires exactly one fixed base tag; found ${base_count}." >&2
-        exit 1
-      fi
-      base_tag="${base_tags}"
-      suffix_tag="$(
-        printf '%s\n' "${glean_tags}" \
-          | awk -v prefix="${base_tag}-" 'index($0, prefix) == 1 {
-              sub("^" prefix, "", $0)
-              print
-            }' \
-          | sort -u \
-          | tail -n1
-      )"
       new_tag="$(calculate_next_glean_tag "${base_tag}" "${suffix_tag}" "${date_ist}")"
       ;;
     *)

--- a/.github/scripts/resolve-release-config.sh
+++ b/.github/scripts/resolve-release-config.sh
@@ -3,9 +3,6 @@
 set -euo pipefail
 
 release_type="${RELEASE_TYPE:-standard}"
-seed_channel_name=""
-seed_channel_id=""
-seed_chart_oci_ref=""
 version_prefix=""
 
 case "${release_type}" in
@@ -22,9 +19,6 @@ case "${release_type}" in
     chart_oci_ref="oci://registry.composio.io/composio-rodent/glean-stable/composio"
     tag_calculation_mode="glean"
     branch_prefix="glean"
-    seed_channel_name="Nightly"
-    seed_channel_id="397k1WtPrJ1J56bhb70SfeKGcxL"
-    seed_chart_oci_ref="oci://registry.composio.io/composio-rodent/nightly/composio"
     version_prefix="0.2.87-glean"
     ;;
   *)
@@ -49,7 +43,4 @@ write_output channel_id "${channel_id}"
 write_output chart_oci_ref "${chart_oci_ref}"
 write_output tag_calculation_mode "${tag_calculation_mode}"
 write_output branch_prefix "${branch_prefix}"
-write_output seed_channel_name "${seed_channel_name}"
-write_output seed_channel_id "${seed_channel_id}"
-write_output seed_chart_oci_ref "${seed_chart_oci_ref}"
 write_output version_prefix "${version_prefix}"

--- a/.github/scripts/tests/calculate-nightly-release-tag-test.sh
+++ b/.github/scripts/tests/calculate-nightly-release-tag-test.sh
@@ -37,10 +37,11 @@ case "$*" in
     printf '%s' '{"totalCount":1,"channels":[{"id":"3GwShNBOwcf13Bs7i5pfn3N8TDh","releaseSequence":0}]}'
     ;;
   *"channelName=Nightly"*)
-    if [[ "${FAKE_API_SCENARIO:-bootstrap}" == "bootstrap" ]]; then
-      printf '%s' '{"totalCount":1,"channels":[{"id":"397k1WtPrJ1J56bhb70SfeKGcxL","currentVersion":"0.2.140","releaseSequence":238}]}'
-    else
+    if [[ "${FAKE_API_SCENARIO:-}" == "empty-standard" ]]; then
       printf '%s' '{"totalCount":1,"channels":[{"id":"397k1WtPrJ1J56bhb70SfeKGcxL","releaseSequence":0}]}'
+    else
+      echo "unexpected Nightly channel lookup" >&2
+      exit 1
     fi
     ;;
   *)
@@ -80,7 +81,7 @@ EOF
   chmod +x "${bin_dir}/curl" "${bin_dir}/helm"
 }
 
-assert_empty_glean_uses_nightly_seed() {
+assert_empty_glean_uses_fixed_base_without_chart_pull() {
   local tmp_dir output_file helm_log
 
   tmp_dir="$(mktemp -d)"
@@ -89,7 +90,7 @@ assert_empty_glean_uses_nightly_seed() {
   write_fake_api_tools "${tmp_dir}/bin"
 
   if ! PATH="${tmp_dir}/bin:${PATH}" \
-    FAKE_API_SCENARIO=bootstrap \
+    FAKE_API_SCENARIO=empty-glean \
     FAKE_HELM_LOG="${helm_log}" \
     RELEASE_TAG_DATE=20260730 \
     REPLICATED_APP=composio-rodent \
@@ -98,62 +99,44 @@ assert_empty_glean_uses_nightly_seed() {
     RELEASE_CHANNEL_ID=3GwShNBOwcf13Bs7i5pfn3N8TDh \
     CHART_OCI_REF=oci://registry.composio.io/composio-rodent/glean-stable/composio \
     TAG_CALCULATION_MODE=glean \
-    SEED_CHANNEL_NAME=Nightly \
-    SEED_CHANNEL_ID=397k1WtPrJ1J56bhb70SfeKGcxL \
-    SEED_CHART_OCI_REF=oci://registry.composio.io/composio-rodent/nightly/composio \
     GITHUB_OUTPUT="${output_file}" \
     bash "${SCRIPT}" >"${tmp_dir}/stdout" 2>"${tmp_dir}/stderr"; then
     sed 's/^/  /' "${tmp_dir}/stderr" >&2
-    fail "empty Glean channel did not bootstrap"
+    fail "empty Glean channel did not use the fixed base"
   fi
 
   assert_output "${output_file}" replicated_current_version ""
-  assert_output "${output_file}" release_tag "r20260729_04-p20260730_01"
-  grep -Fq \
-    'pull oci://registry.composio.io/composio-rodent/nightly/composio --version 0.2.140' \
-    "${helm_log}" || fail "empty Glean channel did not pull the Nightly seed chart"
+  assert_output "${output_file}" release_tag "r20260701_02-p20260730_01"
+  [[ ! -s "${helm_log}" ]] || fail "empty Glean channel unexpectedly pulled a chart"
 
   rm -rf "${tmp_dir}"
 }
 
-assert_api_release_tag_fails() {
-  local name="$1"
-  local mode="$2"
-  local channel_name="$3"
-  local channel_id="$4"
-  local seed_name="$5"
-  local seed_id="$6"
-  local seed_ref="$7"
-  local scenario="$8"
-  local expected_error="$9"
-  local tmp_dir chart_ref
+assert_empty_standard_channel_fails() {
+  local tmp_dir
 
   tmp_dir="$(mktemp -d)"
   write_fake_api_tools "${tmp_dir}/bin"
-  chart_ref="oci://registry.composio.io/composio-rodent/nightly/composio"
-  if [[ "${mode}" == "glean" ]]; then
-    chart_ref="oci://registry.composio.io/composio-rodent/glean-stable/composio"
-  fi
 
   if PATH="${tmp_dir}/bin:${PATH}" \
-    FAKE_API_SCENARIO="${scenario}" \
+    FAKE_API_SCENARIO=empty-standard \
     FAKE_HELM_LOG="${tmp_dir}/helm-log" \
     RELEASE_TAG_DATE=20260730 \
     REPLICATED_APP=composio-rodent \
     REPLICATED_API_TOKEN=test-token \
-    RELEASE_CHANNEL_NAME="${channel_name}" \
-    RELEASE_CHANNEL_ID="${channel_id}" \
-    CHART_OCI_REF="${chart_ref}" \
-    TAG_CALCULATION_MODE="${mode}" \
-    SEED_CHANNEL_NAME="${seed_name}" \
-    SEED_CHANNEL_ID="${seed_id}" \
-    SEED_CHART_OCI_REF="${seed_ref}" \
+    RELEASE_CHANNEL_NAME=Nightly \
+    RELEASE_CHANNEL_ID=397k1WtPrJ1J56bhb70SfeKGcxL \
+    CHART_OCI_REF=oci://registry.composio.io/composio-rodent/nightly/composio \
+    TAG_CALCULATION_MODE=standard \
     bash "${SCRIPT}" >"${tmp_dir}/stdout" 2>"${tmp_dir}/stderr"; then
-    fail "${name}: script unexpectedly succeeded"
+    fail "empty standard channel unexpectedly succeeded"
   fi
 
-  grep -Fq "${expected_error}" "${tmp_dir}/stderr" \
-    || fail "${name}: expected error was not emitted"
+  grep -Fq \
+    "Nightly channel response did not include currentVersion" \
+    "${tmp_dir}/stderr" \
+    || fail "empty standard channel error was not emitted"
+
   rm -rf "${tmp_dir}"
 }
 
@@ -190,31 +173,6 @@ assert_release_tag() {
   rm -rf "${tmp_dir}"
 }
 
-assert_release_tag_fails() {
-  local name="$1"
-  local mode="$2"
-  local date_ist="$3"
-  local expected_error="$4"
-  local values_yaml="$5"
-  local tmp_dir values_file
-
-  tmp_dir="$(mktemp -d)"
-  values_file="${tmp_dir}/values.yaml"
-  printf '%s\n' "${values_yaml}" > "${values_file}"
-
-  if RELEASE_TAG_DATE="${date_ist}" \
-    TAG_CALCULATION_MODE="${mode}" \
-    RELEASE_VALUES_FILE="${values_file}" \
-    NIGHTLY_VALUES_FILE="${values_file}" \
-    bash "${SCRIPT}" >"${tmp_dir}/stdout" 2>"${tmp_dir}/stderr"; then
-    fail "${name}: script unexpectedly succeeded"
-  fi
-
-  grep -Fq "${expected_error}" "${tmp_dir}/stderr" \
-    || fail "${name}: expected error was not emitted"
-  rm -rf "${tmp_dir}"
-}
-
 assert_release_tag "increments same-day calendar tag" standard "20260724" "r20260724_04" '
 apollo:
   image:
@@ -245,76 +203,51 @@ apollo:
     tag: latest
 '
 
-assert_release_tag "creates first glean suffix from fixed base" glean "20260801" \
-  "r20260729_01-p20260801_01" '
+assert_release_tag "creates first glean suffix with hardcoded base" glean "20260801" \
+  "r20260701_02-p20260801_01" '
 apollo:
   image:
     tag: r20260729_01
 '
 
-assert_release_tag "increments glean suffix on the same day" glean "20260801" \
-  "r20260729_01-p20260801_02" '
+assert_release_tag "increments glean suffix independently of historical base" glean "20260801" \
+  "r20260701_02-p20260801_02" '
 apollo:
   image:
     tag: r20260729_01-p20260801_01
 '
 
 assert_release_tag "resets glean suffix on a new day" glean "20260801" \
-  "r20260729_01-p20260801_01" '
+  "r20260701_02-p20260801_01" '
 apollo:
   image:
     tag: r20260729_01-p20260731_08
 '
 
-assert_release_tag "keeps glean base fixed while suffix advances" glean "20260802" \
-  "r20260729_01-p20260802_01" '
+assert_release_tag "uses highest glean suffix across image tags" glean "20260801" \
+  "r20260701_02-p20260801_10" '
 apollo:
   image:
-    tag: r20260729_01-p20260801_09
+    tag: r20260729_01-p20260801_03
 mercury:
   image:
-    tag: r20260729_01-p20260801_09
+    tag: r20260730_01-p20260801_09
 '
 
-assert_release_tag_fails "rejects glean values without a fixed base" glean \
-  "20260801" "Glean tag calculation requires a valid fixed base tag." '
+assert_release_tag "ignores image tags without a glean suffix" glean "20260801" \
+  "r20260701_02-p20260801_01" '
 apollo:
   image:
     tag: latest
-'
-
-assert_release_tag_fails "rejects mixed glean fixed bases" glean \
-  "20260801" "Glean tag calculation requires exactly one fixed base tag; found 2." '
-apollo:
-  image:
-    tag: r20260729_01-p20260731_08
 mercury:
   image:
     tag: r20260730_01
+frontend:
+  image:
+    tag: latest-p20260801_99
 '
 
-assert_empty_glean_uses_nightly_seed
-
-assert_api_release_tag_fails \
-  "empty standard channel remains invalid" \
-  standard Nightly 397k1WtPrJ1J56bhb70SfeKGcxL \
-  "" "" "" empty-standard \
-  "Nightly channel response did not include currentVersion"
-
-assert_api_release_tag_fails \
-  "empty Glean seed remains invalid" \
-  glean Glean-Stable 3GwShNBOwcf13Bs7i5pfn3N8TDh \
-  Nightly 397k1WtPrJ1J56bhb70SfeKGcxL \
-  oci://registry.composio.io/composio-rodent/nightly/composio \
-  empty-seed \
-  "Nightly seed channel response did not include currentVersion"
-
-assert_api_release_tag_fails \
-  "mismatched Glean seed channel id is rejected" \
-  glean Glean-Stable 3GwShNBOwcf13Bs7i5pfn3N8TDh \
-  Nightly wrong-seed-id \
-  oci://registry.composio.io/composio-rodent/nightly/composio \
-  bootstrap \
-  "Nightly channel ID mismatch"
+assert_empty_glean_uses_fixed_base_without_chart_pull
+assert_empty_standard_channel_fails
 
 echo "calculate-nightly-release-tag tests passed"

--- a/.github/scripts/tests/nighty-release-workflow-test.sh
+++ b/.github/scripts/tests/nighty-release-workflow-test.sh
@@ -80,28 +80,28 @@ assert_contains "selected tag mode" \
 assert_contains "selected promotion" \
   '--promote "${{ needs.release-config.outputs.channel_name }}"'
 
-assert_eq "seed channel name output" \
-  "$(yq -r '.jobs.release-config.outputs.seed_channel_name' "${WORKFLOW}")" \
-  '${{ steps.config.outputs.seed_channel_name }}'
-assert_eq "seed channel id output" \
-  "$(yq -r '.jobs.release-config.outputs.seed_channel_id' "${WORKFLOW}")" \
-  '${{ steps.config.outputs.seed_channel_id }}'
-assert_eq "seed chart output" \
-  "$(yq -r '.jobs.release-config.outputs.seed_chart_oci_ref' "${WORKFLOW}")" \
-  '${{ steps.config.outputs.seed_chart_oci_ref }}'
+assert_eq "seed channel name output removed" \
+  "$(yq -r '.jobs.release-config.outputs.seed_channel_name // "absent"' "${WORKFLOW}")" \
+  absent
+assert_eq "seed channel id output removed" \
+  "$(yq -r '.jobs.release-config.outputs.seed_channel_id // "absent"' "${WORKFLOW}")" \
+  absent
+assert_eq "seed chart output removed" \
+  "$(yq -r '.jobs.release-config.outputs.seed_chart_oci_ref // "absent"' "${WORKFLOW}")" \
+  absent
 assert_eq "version prefix output" \
   "$(yq -r '.jobs.release-config.outputs.version_prefix' "${WORKFLOW}")" \
   '${{ steps.config.outputs.version_prefix }}'
 
-assert_eq "selected seed channel name" \
-  "$(yq -r '.jobs.retag-latest-images.steps[] | select(.id == "calculate_release_tag") | .env.SEED_CHANNEL_NAME' "${WORKFLOW}")" \
-  '${{ needs.release-config.outputs.seed_channel_name }}'
-assert_eq "selected seed channel id" \
-  "$(yq -r '.jobs.retag-latest-images.steps[] | select(.id == "calculate_release_tag") | .env.SEED_CHANNEL_ID' "${WORKFLOW}")" \
-  '${{ needs.release-config.outputs.seed_channel_id }}'
-assert_eq "selected seed chart" \
-  "$(yq -r '.jobs.retag-latest-images.steps[] | select(.id == "calculate_release_tag") | .env.SEED_CHART_OCI_REF' "${WORKFLOW}")" \
-  '${{ needs.release-config.outputs.seed_chart_oci_ref }}'
+assert_eq "seed channel name env removed" \
+  "$(yq -r '.jobs.retag-latest-images.steps[] | select(.id == "calculate_release_tag") | .env.SEED_CHANNEL_NAME // "absent"' "${WORKFLOW}")" \
+  absent
+assert_eq "seed channel id env removed" \
+  "$(yq -r '.jobs.retag-latest-images.steps[] | select(.id == "calculate_release_tag") | .env.SEED_CHANNEL_ID // "absent"' "${WORKFLOW}")" \
+  absent
+assert_eq "seed chart env removed" \
+  "$(yq -r '.jobs.retag-latest-images.steps[] | select(.id == "calculate_release_tag") | .env.SEED_CHART_OCI_REF // "absent"' "${WORKFLOW}")" \
+  absent
 
 assert_eq "release version helper" \
   "$(yq -r '.jobs.retag-latest-images.steps[] | select(.id == "calculate_version") | .run' "${WORKFLOW}")" \

--- a/.github/scripts/tests/resolve-release-config-test.sh
+++ b/.github/scripts/tests/resolve-release-config-test.sh
@@ -27,10 +27,7 @@ assert_config() {
   local expected_ref="$5"
   local expected_mode="$6"
   local expected_prefix="$7"
-  local expected_seed_name="$8"
-  local expected_seed_id="$9"
-  local expected_seed_ref="${10}"
-  local expected_version_prefix="${11}"
+  local expected_version_prefix="$8"
   local tmp_dir output_file
 
   tmp_dir="$(mktemp -d)"
@@ -43,23 +40,20 @@ assert_config() {
   assert_output "${output_file}" chart_oci_ref "${expected_ref}"
   assert_output "${output_file}" tag_calculation_mode "${expected_mode}"
   assert_output "${output_file}" branch_prefix "${expected_prefix}"
-  assert_output "${output_file}" seed_channel_name "${expected_seed_name}"
-  assert_output "${output_file}" seed_channel_id "${expected_seed_id}"
-  assert_output "${output_file}" seed_chart_oci_ref "${expected_seed_ref}"
   assert_output "${output_file}" version_prefix "${expected_version_prefix}"
+  if grep -Eq '^seed_(channel_name|channel_id|chart_oci_ref)=' "${output_file}"; then
+    fail "resolver unexpectedly emitted seed-channel configuration"
+  fi
   rm -rf "${tmp_dir}"
 }
 
 assert_config "" standard Nightly 397k1WtPrJ1J56bhb70SfeKGcxL \
-  oci://registry.composio.io/composio-rodent/nightly/composio standard nightly \
-  "" "" "" ""
+  oci://registry.composio.io/composio-rodent/nightly/composio standard nightly ""
 assert_config standard standard Nightly 397k1WtPrJ1J56bhb70SfeKGcxL \
-  oci://registry.composio.io/composio-rodent/nightly/composio standard nightly \
-  "" "" "" ""
+  oci://registry.composio.io/composio-rodent/nightly/composio standard nightly ""
 assert_config glean glean Glean-Stable 3GwShNBOwcf13Bs7i5pfn3N8TDh \
   oci://registry.composio.io/composio-rodent/glean-stable/composio glean glean \
-  Nightly 397k1WtPrJ1J56bhb70SfeKGcxL \
-  oci://registry.composio.io/composio-rodent/nightly/composio 0.2.87-glean
+  0.2.87-glean
 
 if RELEASE_TYPE=unsupported bash "${SCRIPT}" >/dev/null 2>&1; then
   fail "unsupported release type should fail"

--- a/.github/workflows/nighty-release.yml
+++ b/.github/workflows/nighty-release.yml
@@ -80,9 +80,6 @@ jobs:
       chart_oci_ref: ${{ steps.config.outputs.chart_oci_ref }}
       tag_calculation_mode: ${{ steps.config.outputs.tag_calculation_mode }}
       branch_prefix: ${{ steps.config.outputs.branch_prefix }}
-      seed_channel_name: ${{ steps.config.outputs.seed_channel_name }}
-      seed_channel_id: ${{ steps.config.outputs.seed_channel_id }}
-      seed_chart_oci_ref: ${{ steps.config.outputs.seed_chart_oci_ref }}
       version_prefix: ${{ steps.config.outputs.version_prefix }}
     steps:
       - name: Checkout code
@@ -198,9 +195,6 @@ jobs:
           RELEASE_CHANNEL_NAME: ${{ needs.release-config.outputs.channel_name }}
           RELEASE_CHANNEL_ID: ${{ needs.release-config.outputs.channel_id }}
           TAG_CALCULATION_MODE: ${{ needs.release-config.outputs.tag_calculation_mode }}
-          SEED_CHANNEL_NAME: ${{ needs.release-config.outputs.seed_channel_name }}
-          SEED_CHANNEL_ID: ${{ needs.release-config.outputs.seed_channel_id }}
-          SEED_CHART_OCI_REF: ${{ needs.release-config.outputs.seed_chart_oci_ref }}
         run: bash ./.github/scripts/calculate-nightly-release-tag.sh
 
       - name: Calculate and validate release version


### PR DESCRIPTION
# Description

**Related Linear Ticket**

* https://linear.app/composio/issue/IMIN-467/29nd-july-release

## Summary

- Hardcode `r20260701_02` as the base for Glean image release tags.
- Continue incrementing only the latest valid `pYYYYMMDD_NN` suffix from Glean-Stable chart values.
- Start empty Glean-Stable channels directly from the fixed base without pulling Nightly as a seed.
- Remove the obsolete seed-channel resolver outputs and workflow wiring.
- Keep standard Nightly tag calculation unchanged.

# How did I test this PR

- `bash .github/scripts/tests/calculate-nightly-release-tag-test.sh` — passed
- `bash .github/scripts/tests/resolve-release-config-test.sh` — passed
- `bash .github/scripts/tests/calculate-release-version-test.sh` — passed
- `bash .github/scripts/tests/nighty-release-workflow-test.sh` — passed
- `bash .github/scripts/tests/nightly-slack-summary-test.sh` — passed
- `bash -n .github/scripts/calculate-nightly-release-tag.sh .github/scripts/resolve-release-config.sh .github/scripts/tests/calculate-nightly-release-tag-test.sh .github/scripts/tests/resolve-release-config-test.sh .github/scripts/tests/nighty-release-workflow-test.sh` — passed
- `yq -e '.' .github/workflows/nighty-release.yml` — passed
- `git diff --check` — passed
- `actionlint` was not run because it is not installed locally.
- Not tested with a live Replicated release, ECR retag, GitHub Actions run, or CMX harness execution.
