### PR TITLE
feat(ci): separate nightly release validation alerts

### DIFF
--- a/.github/scripts/nightly-slack-summary.sh
+++ b/.github/scripts/nightly-slack-summary.sh
@@ -95,6 +95,15 @@ esac
   fi
   echo "${verdict_line}"
   echo "${release_blocking_line}"
+  if [[ -n "${ONPREM_FRESH_URL:-}" || -n "${ONPREM_UPGRADE_URL:-}" ]]; then
+    echo "*On-prem validation:*"
+    if [[ -n "${ONPREM_FRESH_URL:-}" ]]; then
+      echo "- Fresh install: \`${ONPREM_FRESH_CONCLUSION:-unknown}\` — <${ONPREM_FRESH_URL}|open test run>"
+    fi
+    if [[ -n "${ONPREM_UPGRADE_URL:-}" ]]; then
+      echo "- Upgrade: \`${ONPREM_UPGRADE_CONCLUSION:-unknown}\` — <${ONPREM_UPGRADE_URL}|open test run>"
+    fi
+  fi
   if [[ "${REPLICATED_RESULT:-unknown}" == "success" ]]; then
     echo "*Release created:* YES"
     echo "- Image release tag: \`${RELEASE_TAG:-unknown}\`"

--- a/.github/scripts/run-onprem-test-harness.sh
+++ b/.github/scripts/run-onprem-test-harness.sh
@@ -9,6 +9,7 @@ ONPREM_WORKFLOW_FILE="${ONPREM_WORKFLOW_FILE:-replicated-cmx-harness.yml}"
 ONPREM_REF="${ONPREM_REF:-main}"
 ONPREM_DISPATCH_MODE="${ONPREM_DISPATCH_MODE:-workflow_dispatch}"
 HARNESS_NAME="${HARNESS_NAME:-onprem-testbed}"
+DISPATCH_ID="${DISPATCH_ID:-${GITHUB_REPOSITORY:-local}:${GITHUB_RUN_ID:-manual}:${GITHUB_RUN_ATTEMPT:-1}:${HARNESS_NAME}}"
 HARNESS_ENV_JSON="${HARNESS_ENV_JSON:-}"
 if [[ -z "${HARNESS_ENV_JSON}" ]]; then
   HARNESS_ENV_JSON="{}"
@@ -93,10 +94,12 @@ append_field "migration_direction" "${MIGRATION_DIRECTION}"
 append_field "cluster_size" "${CLUSTER_SIZE}"
 append_field "cluster_ttl" "${CLUSTER_TTL}"
 append_field "harness_env_json" "${HARNESS_ENV_JSON}"
+append_field "dispatch_id" "${DISPATCH_ID}"
 
 echo "Dispatching ${HARNESS_NAME} to ${ONPREM_REPO}/${ONPREM_WORKFLOW_FILE} on ${ONPREM_REF}"
 echo "Dispatch mode: ${ONPREM_DISPATCH_MODE}"
 echo "Helm chart version: ${HELM_CHART_VERSION}"
+echo "Dispatch ID: ${DISPATCH_ID}"
 echo "Scenarios: ${SCENARIOS:-<default>}"
 echo "Upgrade from versions: ${UPGRADE_FROM_VERSIONS:-<none>}"
 echo "Cluster size: ${CLUSTER_SIZE:-<workflow default>}"
@@ -135,11 +138,14 @@ if [[ -z "${run_id}" ]]; then
         --workflow "${ONPREM_WORKFLOW_FILE}" \
         --event "${run_event}" \
         --limit 20 \
-        --json databaseId,createdAt,url
+        --json databaseId,createdAt,displayTitle,url
     )"
     run_id="$(
-      jq -r --argjson started "${dispatch_started}" '
-        [.[] | select((.createdAt | fromdateiso8601) >= $started)]
+      jq -r --argjson started "${dispatch_started}" --arg dispatch_id "${DISPATCH_ID}" '
+        [.[] | select(
+          (.createdAt | fromdateiso8601) >= $started
+          and (.displayTitle | contains($dispatch_id))
+        )]
         | sort_by(.createdAt)
         | reverse
         | .[0].databaseId // empty

--- a/.github/scripts/tests/nightly-slack-summary-test.sh
+++ b/.github/scripts/tests/nightly-slack-summary-test.sh
@@ -81,5 +81,18 @@ assert_contains "${glean_dir}/github-output" \
 assert_contains "${glean_dir}/slack-summary.txt" \
   "- Replicated Glean-Stable version: \`0.2.134\` -> \`0.2.135\`"
 
-rm -rf "${cve_dir}" "${build_dir}" "${report_dir}" "${glean_dir}"
+onprem_dir="$(run_summary onprem \
+  ONPREM_RESULT=failure \
+  ONPREM_FRESH_CONCLUSION=failure \
+  ONPREM_FRESH_URL=https://github.com/ComposioHQ/onprem-testbed/actions/runs/101 \
+  ONPREM_UPGRADE_CONCLUSION=success \
+  ONPREM_UPGRADE_URL=https://github.com/ComposioHQ/onprem-testbed/actions/runs/102)"
+assert_contains "${onprem_dir}/slack-summary.txt" \
+  "*Good to go:* NA - onprem-testbed validation result was failure"
+assert_contains "${onprem_dir}/slack-summary.txt" \
+  "- Fresh install: \`failure\` — <https://github.com/ComposioHQ/onprem-testbed/actions/runs/101|open test run>"
+assert_contains "${onprem_dir}/slack-summary.txt" \
+  "- Upgrade: \`success\` — <https://github.com/ComposioHQ/onprem-testbed/actions/runs/102|open test run>"
+
+rm -rf "${cve_dir}" "${build_dir}" "${report_dir}" "${glean_dir}" "${onprem_dir}"
 echo "nightly-slack-summary tests passed"

--- a/.github/workflows/nighty-release.yml
+++ b/.github/workflows/nighty-release.yml
@@ -72,6 +72,7 @@ env:
 
 jobs:
   release-config:
+    name: Prepare release configuration
     runs-on: ubuntu-latest
     outputs:
       release_type: ${{ steps.config.outputs.release_type }}
@@ -93,6 +94,7 @@ jobs:
         run: bash ./.github/scripts/resolve-release-config.sh
 
   nightly-secrets:
+    name: Validate nightly secrets
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -125,6 +127,7 @@ jobs:
           fi
 
   retag-latest-images:
+    name: Build nightly image release
     runs-on: ubuntu-latest
     needs:
       - release-config
@@ -351,6 +354,7 @@ jobs:
           echo "retagged_images: ${{ steps.retag.outputs.retagged_images }}"
 
   cve-scan:
+    name: CVE scan
     needs:
       - release-config
       - retag-latest-images
@@ -366,13 +370,51 @@ jobs:
       fail_on_high_critical: false
       render_temporal: true
 
+  cve-validation-verdict:
+    name: CVE release validation
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - cve-scan
+    steps:
+      - name: Publish CVE validation verdict
+        shell: bash
+        env:
+          CVE_JOB_RESULT: ${{ needs.cve-scan.result }}
+          CVE_SCAN_RESULT: ${{ needs.cve-scan.outputs.scan_result }}
+          CVE_FAILURE_SUMMARY: ${{ needs.cve-scan.outputs.failure_summary }}
+          CVE_ARTIFACT_NAME: ${{ needs.cve-scan.outputs.artifact_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [[ "${CVE_JOB_RESULT}" == "success" && "${CVE_SCAN_RESULT}" == "success" ]]; then
+            echo "### ✅ CVE validation passed" >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          message="${CVE_FAILURE_SUMMARY:-CVE validation did not complete successfully}"
+          echo "::error title=Nightly CVE validation failed::${message}. Release publication was not blocked."
+          {
+            echo "### 🚨 Nightly release published with CVE validation failure"
+            echo
+            echo "${message}"
+            echo
+            echo "- CVE workflow result: \`${CVE_JOB_RESULT}\`"
+            echo "- CVE scan result: \`${CVE_SCAN_RESULT:-unknown}\`"
+            if [[ -n "${CVE_ARTIFACT_NAME}" ]]; then
+              echo "- Report artifact: \`${CVE_ARTIFACT_NAME}\`"
+            fi
+            echo "- [Open nightly workflow](${RUN_URL})"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          exit 1
+
   replicated-release:
+    name: Create Replicated nightly release
     runs-on: ubuntu-latest
     if: ${{ always() && needs.retag-latest-images.result == 'success' }}
     needs:
       - release-config
       - retag-latest-images
-      - cve-scan
     permissions:
       contents: write
       id-token: write
@@ -499,6 +541,7 @@ jobs:
           git push --force-with-lease origin "${{ steps.branch.outputs.branch_name }}"
 
   create-nightly-release-pr:
+    name: Publish release PR and GitHub release
     if: ${{ always() && needs.replicated-release.result == 'success' }}
     runs-on: ubuntu-latest
     needs:
@@ -768,6 +811,7 @@ jobs:
             core.info("Published GitHub release.");
 
   onprem-testbed:
+    name: On-prem release validation
     if: ${{ needs.replicated-release.result == 'success' }}
     runs-on: ubuntu-latest
     needs:
@@ -777,6 +821,11 @@ jobs:
       id-token: write
       contents: read
     timeout-minutes: 720
+    outputs:
+      fresh_conclusion: ${{ steps.fresh.outputs.conclusion }}
+      fresh_url: ${{ steps.fresh.outputs.run_url }}
+      upgrade_conclusion: ${{ steps.upgrade.outputs.conclusion }}
+      upgrade_url: ${{ steps.upgrade.outputs.run_url }}
     steps:
       - name: Checkout harness dispatch scripts
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -838,11 +887,19 @@ jobs:
         if: ${{ steps.fresh.outcome != 'success' || steps.upgrade.outcome != 'success' }}
         shell: bash
         run: |
-          echo "Fresh-install harness outcome: ${{ steps.fresh.outcome }}" >&2
-          echo "Upgrade harness outcome: ${{ steps.upgrade.outcome }}" >&2
+          fresh_url="${{ steps.fresh.outputs.run_url }}"
+          upgrade_url="${{ steps.upgrade.outputs.run_url }}"
+          echo "::error title=Nightly on-prem validation failed::Fresh install: ${{ steps.fresh.outcome }}; upgrade: ${{ steps.upgrade.outcome }}. Release publication was not blocked."
+          {
+            echo "### 🚨 Nightly release published with on-prem validation failure"
+            echo
+            echo "- Fresh install: **${{ steps.fresh.outcome }}** — [open test run](${fresh_url})"
+            echo "- Upgrade: **${{ steps.upgrade.outcome }}** — [open test run](${upgrade_url})"
+          } >> "${GITHUB_STEP_SUMMARY}"
           exit 1
 
   notify-nightly-report:
+    name: Publish final release report
     if: always()
     runs-on: ubuntu-latest
     needs:
@@ -850,6 +907,7 @@ jobs:
       - nightly-secrets
       - retag-latest-images
       - cve-scan
+      - cve-validation-verdict
       - replicated-release
       - create-nightly-release-pr
       - onprem-testbed
@@ -900,6 +958,10 @@ jobs:
           REPLICATED_RESULT: ${{ needs.replicated-release.result }}
           PR_RESULT: ${{ needs.create-nightly-release-pr.result }}
           ONPREM_RESULT: ${{ needs.onprem-testbed.result }}
+          ONPREM_FRESH_CONCLUSION: ${{ needs.onprem-testbed.outputs.fresh_conclusion }}
+          ONPREM_FRESH_URL: ${{ needs.onprem-testbed.outputs.fresh_url }}
+          ONPREM_UPGRADE_CONCLUSION: ${{ needs.onprem-testbed.outputs.upgrade_conclusion }}
+          ONPREM_UPGRADE_URL: ${{ needs.onprem-testbed.outputs.upgrade_url }}
           RELEASE_CHANNEL_NAME: ${{ needs.release-config.outputs.channel_name }}
           RELEASE_TAG: ${{ needs.retag-latest-images.outputs.release_tag }}
           RELEASE_BRANCH: ${{ needs.replicated-release.outputs.branch_name }}


### PR DESCRIPTION
## Summary

- decouple Replicated nightly release creation from CVE validation
- split CVE and on-prem checks into explicit validation jobs with visible GitHub error annotations
- wait for the exact correlated onprem-testbed fresh-install and upgrade runs
- surface both validation conclusions and direct run links in the final Slack report
- preserve release publication when validation fails while leaving the workflow visibly red

## Dependency

- Requires ComposioHQ/onprem-testbed#41 to merge first so dispatched runs expose the correlation ID in their run names.

## Validation

- `bash .github/scripts/tests/nightly-slack-summary-test.sh`
- shell syntax checks
- workflow YAML parsing
- `git diff --check`