### PR TITLE
Make encryption keys independently rotatable

### DIFF
--- a/composio/templates/_helpers.tpl
+++ b/composio/templates/_helpers.tpl
@@ -18,6 +18,36 @@ Expand the name of the chart.
 {{- printf "%s" .Values.secret.name -}}
 {{- end -}}
 
+{{/*
+Render one encryption-key env var sourced from the core secret.
+
+Usage:
+  {{- include "composio.encryptionKeyEnv" (dict
+        "envVar" "ORG_API_KEY_ENCRYPTION_KEY"
+        "setting" "orgApiKeyEncryptionKey"
+        "default" "ENCRYPTION_KEY"
+        "context" .) | nindent 12 }}
+
+Resolves .Values.encryptionKeys.<setting>.secretKey and falls back to the
+supplied default, so existing releases render exactly as they did before this
+helper was introduced. An empty resolved value renders nothing, which is how
+the cloud-only outer-layer keys stay absent on self-hosted installs.
+*/}}
+{{- define "composio.encryptionKeyEnv" -}}
+{{- $ctx := .context -}}
+{{- $keys := default (dict) $ctx.Values.encryptionKeys -}}
+{{- $cfg := default (dict) (get $keys .setting) -}}
+{{- $secretKey := default .default $cfg.secretKey -}}
+{{- if $secretKey -}}
+- name: {{ .envVar }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "composio.coreSecretName" $ctx }}
+      key: {{ $secretKey }}
+      optional: true
+{{- end -}}
+{{- end -}}
+
 
 {{- define "composio-admin-token" -}}
 {{- $coreName := include "composio.coreSecretName" . -}}

--- a/composio/templates/apollo/apollo-db-init.job.yaml
+++ b/composio/templates/apollo/apollo-db-init.job.yaml
@@ -71,18 +71,8 @@ spec:
                   name: {{ $coreSecret }}
                   key: POSTGRES_URL
                   optional: true
-            - name: ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: ENCRYPTION_KEY
-                  optional: true
-            - name: ORG_API_KEY_ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: ENCRYPTION_KEY
-                  optional: true
+            {{- with include "composio.encryptionKeyEnv" (dict "envVar" "ENCRYPTION_KEY" "setting" "encryptionKey" "default" "ENCRYPTION_KEY" "context" .) }}{{- . | nindent 12 }}{{- end }}
+            {{- with include "composio.encryptionKeyEnv" (dict "envVar" "ORG_API_KEY_ENCRYPTION_KEY" "setting" "orgApiKeyEncryptionKey" "default" "ENCRYPTION_KEY" "context" .) }}{{- . | nindent 12 }}{{- end }}
             - name: SHOULD_REWRITE_COMPOSIO_SERVICE_KEY_NAME
               value: "true"
             - name: SELF_HOSTED

--- a/composio/templates/apollo/apollo.yaml
+++ b/composio/templates/apollo/apollo.yaml
@@ -161,12 +161,9 @@ spec:
                   key: {{ $externalRedis.key }}
                   optional: true
             {{- end }}
-            - name: ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: ENCRYPTION_KEY
-                  optional: true
+            {{- with include "composio.encryptionKeyEnv" (dict "envVar" "ENCRYPTION_KEY" "setting" "encryptionKey" "default" "ENCRYPTION_KEY" "context" .) }}{{- . | nindent 12 }}{{- end }}
+            {{- with include "composio.encryptionKeyEnv" (dict "envVar" "CONNECTED_ACCOUNT_ENCRYPTION_KEY" "setting" "connectedAccountEncryptionKey" "default" "" "context" .) }}{{- . | nindent 12 }}{{- end }}
+            {{- with include "composio.encryptionKeyEnv" (dict "envVar" "AUTH_CONFIG_ENCRYPTION_KEY" "setting" "authConfigEncryptionKey" "default" "" "context" .) }}{{- . | nindent 12 }}{{- end }}
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -199,12 +196,7 @@ spec:
                   name: {{ $coreSecret }}
                   key: POSTGRES_URL
                   optional: true
-            - name: ORG_API_KEY_ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: ENCRYPTION_KEY
-                  optional: true
+            {{- with include "composio.encryptionKeyEnv" (dict "envVar" "ORG_API_KEY_ENCRYPTION_KEY" "setting" "orgApiKeyEncryptionKey" "default" "ENCRYPTION_KEY" "context" .) }}{{- . | nindent 12 }}{{- end }}
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/composio/templates/thermos/thermos-misc-workers.yaml
+++ b/composio/templates/thermos/thermos-misc-workers.yaml
@@ -140,18 +140,8 @@ spec:
                   name: {{ $coreSecret }}
                   key: THERMOS_DATABASE_URL
                   optional: true
-            - name: POLLING_TRIGGER_ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
-                  optional: true
-            - name: WEBHOOK_PAYLOAD_ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
-                  optional: true
+            {{- with include "composio.encryptionKeyEnv" (dict "envVar" "POLLING_TRIGGER_ENCRYPTION_KEY" "setting" "pollingTriggerEncryptionKey" "default" "TEMPORAL_TRIGGER_ENCRYPTION_KEY" "context" .) }}{{- . | nindent 12 }}{{- end }}
+            {{- with include "composio.encryptionKeyEnv" (dict "envVar" "WEBHOOK_PAYLOAD_ENCRYPTION_KEY" "setting" "webhookPayloadEncryptionKey" "default" "TEMPORAL_TRIGGER_ENCRYPTION_KEY" "context" .) }}{{- . | nindent 12 }}{{- end }}
             - name: TOOLKIT_REGISTRY_DB_URL
               value: {{ include "composio.toolkitRegistryDbUrl" . | quote }}
             {{- if .Values.thermosMiscWorkers.env }}

--- a/composio/templates/thermos/thermos.yaml
+++ b/composio/templates/thermos/thermos.yaml
@@ -135,18 +135,8 @@ spec:
                   name: {{ $coreSecret }}
                   key: THERMOS_DATABASE_URL
                   optional: true
-            - name: POLLING_TRIGGER_ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
-                  optional: true
-            - name: WEBHOOK_PAYLOAD_ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $coreSecret }}
-                  key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
-                  optional: true
+            {{- with include "composio.encryptionKeyEnv" (dict "envVar" "POLLING_TRIGGER_ENCRYPTION_KEY" "setting" "pollingTriggerEncryptionKey" "default" "TEMPORAL_TRIGGER_ENCRYPTION_KEY" "context" .) }}{{- . | nindent 12 }}{{- end }}
+            {{- with include "composio.encryptionKeyEnv" (dict "envVar" "WEBHOOK_PAYLOAD_ENCRYPTION_KEY" "setting" "webhookPayloadEncryptionKey" "default" "TEMPORAL_TRIGGER_ENCRYPTION_KEY" "context" .) }}{{- . | nindent 12 }}{{- end }}
             - name: TOOLKIT_REGISTRY_DB_URL
               value: {{ include "composio.toolkitRegistryDbUrl" . | quote }}
             {{- if .Values.thermos.env }}

--- a/composio/tests/encryption_keys_test.yaml
+++ b/composio/tests/encryption_keys_test.yaml
@@ -1,0 +1,171 @@
+suite: encryption key wiring
+templates:
+  - apollo/apollo.yaml
+  - thermos/thermos.yaml
+tests:
+  # The defaults must reproduce the historical aliasing exactly. If these
+  # break, existing installs lose access to their API keys on upgrade.
+  - it: defaults alias ORG_API_KEY_ENCRYPTION_KEY onto the ENCRYPTION_KEY secret entry
+    template: apollo/apollo.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      apollo.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ORG_API_KEY_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: composio-composio-secrets
+                key: ENCRYPTION_KEY
+                optional: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: composio-composio-secrets
+                key: ENCRYPTION_KEY
+                optional: true
+
+  - it: defaults alias both Thermos trigger keys onto TEMPORAL_TRIGGER_ENCRYPTION_KEY
+    template: thermos/thermos.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WEBHOOK_PAYLOAD_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: composio-composio-secrets
+                key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
+                optional: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POLLING_TRIGGER_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: composio-composio-secrets
+                key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
+                optional: true
+
+  # Self-hosted single-encrypts. The outer-layer keys must stay absent unless
+  # explicitly configured, or Apollo starts double-encrypting new rows and the
+  # existing single-encrypted rows become unreadable.
+  - it: omits the outer-layer keys by default
+    template: apollo/apollo.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: CONNECTED_ACCOUNT_ENCRYPTION_KEY
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: AUTH_CONFIG_ENCRYPTION_KEY
+
+  - it: allows ORG_API_KEY_ENCRYPTION_KEY to be split onto its own secret entry
+    template: apollo/apollo.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      encryptionKeys.orgApiKeyEncryptionKey.secretKey: ORG_API_KEY_ENCRYPTION_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ORG_API_KEY_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: composio-composio-secrets
+                key: ORG_API_KEY_ENCRYPTION_KEY
+                optional: true
+
+  - it: allows the polling trigger key to be split from the webhook key
+    template: thermos/thermos.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      encryptionKeys.pollingTriggerEncryptionKey.secretKey: POLLING_TRIGGER_ENCRYPTION_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POLLING_TRIGGER_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: composio-composio-secrets
+                key: POLLING_TRIGGER_ENCRYPTION_KEY
+                optional: true
+      # The webhook key must be unaffected by splitting the polling key.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WEBHOOK_PAYLOAD_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: composio-composio-secrets
+                key: TEMPORAL_TRIGGER_ENCRYPTION_KEY
+                optional: true
+
+  - it: wires the outer-layer keys when explicitly configured
+    template: apollo/apollo.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      encryptionKeys.connectedAccountEncryptionKey.secretKey: CONNECTED_ACCOUNT_ENCRYPTION_KEY
+      encryptionKeys.authConfigEncryptionKey.secretKey: AUTH_CONFIG_ENCRYPTION_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CONNECTED_ACCOUNT_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: composio-composio-secrets
+                key: CONNECTED_ACCOUNT_ENCRYPTION_KEY
+                optional: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_CONFIG_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: composio-composio-secrets
+                key: AUTH_CONFIG_ENCRYPTION_KEY
+                optional: true
+
+  - it: honours a custom core secret name
+    template: apollo/apollo.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      secret.name: my-custom-secret
+      encryptionKeys.orgApiKeyEncryptionKey.secretKey: ORG_API_KEY_ENCRYPTION_KEY
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ORG_API_KEY_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-custom-secret
+                key: ORG_API_KEY_ENCRYPTION_KEY
+                optional: true

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -10,6 +10,42 @@ features:
 # Composio Application Secrets
 secret:
   name: "composio-composio-secrets"
+# Encryption key wiring.
+#
+# Historically several distinct application env vars were served from the same
+# two entries in the core secret. The defaults below preserve that exactly, so
+# upgrading an existing release changes nothing. Override a `secretKey` only
+# when you have added that entry to the core secret and intend to rotate it
+# independently — see docs/encryption-key-rotation-runbook.md in the platform
+# repo.
+#
+# WARNING: pointing one of these at a secret entry that does not exist will NOT
+# fail the deploy. Every reference is `optional: true`, so the env var is simply
+# unset and the application falls back to an internal default, which silently
+# invalidates existing API keys. Add the entry to the secret first.
+encryptionKeys:
+  # -- Core data-at-rest key backing credential payloads and log columns.
+  encryptionKey:
+    secretKey: "ENCRYPTION_KEY"
+  # -- Signs and encrypts ak_/oak_/uak_/ck_ API keys. Defaults to the same
+  # secret entry as encryptionKey, so rotating one rotates both.
+  orgApiKeyEncryptionKey:
+    secretKey: "ENCRYPTION_KEY"
+  # -- Thermos webhook payload key. Must be exactly 32 bytes.
+  webhookPayloadEncryptionKey:
+    secretKey: "TEMPORAL_TRIGGER_ENCRYPTION_KEY"
+  # -- Thermos polling trigger key. Must be exactly 32 bytes. Defaults to the
+  # same secret entry as webhookPayloadEncryptionKey.
+  pollingTriggerEncryptionKey:
+    secretKey: "TEMPORAL_TRIGGER_ENCRYPTION_KEY"
+  # -- Outer credential encryption layer, Composio cloud only. Self-hosted
+  # installs single-encrypt; leave empty. Setting these changes how new rows
+  # are written and makes existing single-encrypted rows unreadable.
+  connectedAccountEncryptionKey:
+    secretKey: ""
+  # -- Outer auth-config encryption layer, Composio cloud only. Leave empty.
+  authConfigEncryptionKey:
+    secretKey: ""
 # Namespace configuration for Composio services
 namespace:
   # -- Whether to create namespaces automatically


### PR DESCRIPTION
Lets each encryption key be backed by its own secret entry, so they can be rotated independently. Required for the break-glass rotation procedure in ComposioHQ/platform#11765.

## The bug

The chart's six encryption keys were really **two secret values**:

- `ORG_API_KEY_ENCRYPTION_KEY` read secret key `ENCRYPTION_KEY`
- both trigger keys read `TEMPORAL_TRIGGER_ENCRYPTION_KEY`
- the two outer keys had **no chart plumbing at all**

So independent rotation was not expressible. Worse, attempting it **silently corrupts data**: the rotation script re-encrypts `self_hosted.recoverable_project_api_keys` under the new org key, while Apollo — reading `ENCRYPTION_KEY` for its org provider — keeps writing new rows under the old one. The table ends up split across two keys and neither can read all of it.

This was reproduced live, then fixed and re-verified (see below).

## The change

Adds an `encryptionKeys.<name>.secretKey` block and a `composio.encryptionKeyEnv` helper. Each key resolves to its configured secret entry, **falling back to today's value**, so existing releases are unaffected.

```yaml
encryptionKeys:
  orgApiKeyEncryptionKey:
    secretKey: "ORG_API_KEY_ENCRYPTION_KEY"   # was: ENCRYPTION_KEY
```

## Safety

- **`helm template` output is byte-identical to the pre-change chart at defaults** (diff-verified) — zero upgrade risk
- `helm lint`, pod-scheduling lint, and **347 chart tests** pass
- New `tests/encryption_keys_test.yaml` covers the split and default paths

## Validation

On minikube against the real Replicated install path, chart 0.2.149:

**Before (defaults):** rotate the org key → `recoverable_project_api_keys` splits; strict decrypt fails on one row whichever key you supply.

**After (`orgApiKeyEncryptionKey.secretKey` set):**
- Apollo resolves the two keys independently (verified in-pod)
- rotated both keys to distinct values, restarted, minted a new `ak_` through the API
- **all 7 rows — 6 rotated by the script plus 1 written by Apollo afterwards — strict-decrypt cleanly under the new org key.** No split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)