### PR TITLE
test: cover Thermos worker database wiring

### DIFF
--- a/composio/tests/db_init_test.yaml
+++ b/composio/tests/db_init_test.yaml
@@ -316,6 +316,23 @@ tests:
                 key: THERMOS_DATABASE_URL
                 optional: true
 
+  - it: should wire the worker database into thermos db init
+    set:
+      thermos.dbInit.enabled: true
+      thermos.workerDb.enabled: true
+      thermos.workerDb.secretName: thermos-worker-secret
+      thermos.workerDb.secretKey: WORKER_DATABASE_URL
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: THERMOS_WORKER_DB
+            valueFrom:
+              secretKeyRef:
+                name: thermos-worker-secret
+                key: WORKER_DATABASE_URL
+                optional: true
+
   - it: should mount thermos db init secrets under /etc/secrets/thermos
     set:
       thermos.dbInit.enabled: true
@@ -539,6 +556,34 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[2]
           pattern: 'CREATE DATABASE composiodb;'
+
+  - it: should create and grant the configured worker database
+    set:
+      databaseMigration.enabled: true
+      thermos.workerDb.enabled: true
+      thermos.workerDb.databaseName: thermos-worker-db
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'CREATE DATABASE "thermos-worker-db";'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'ALTER DATABASE "thermos-worker-db" OWNER TO "postgres";'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: '\\c "thermos-worker-db"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'GRANT ALL PRIVILEGES ON SCHEMA public TO "postgres";'
+
+  - it: should omit worker database SQL when worker DB is disabled
+    set:
+      databaseMigration.enabled: true
+      thermos.workerDb.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'thermos_workerdb'
 
   - it: should quote database migration user as a SQL identifier
     set:

--- a/composio/tests/thermos_test.yaml
+++ b/composio/tests/thermos_test.yaml
@@ -133,6 +133,37 @@ tests:
             name: thermos-secrets
             emptyDir: {}
 
+  - it: should wire the worker database from the configured secret
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      thermos.workerDb.enabled: true
+      thermos.workerDb.secretName: thermos-worker-secret
+      thermos.workerDb.secretKey: WORKER_DATABASE_URL
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: THERMOS_WORKER_DB
+            valueFrom:
+              secretKeyRef:
+                name: thermos-worker-secret
+                key: WORKER_DATABASE_URL
+                optional: true
+
+  - it: should omit the worker database env when disabled
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      thermos.workerDb.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: THERMOS_WORKER_DB
+
   - it: should render additional thermos init containers
     documentSelector:
       path: kind
@@ -450,6 +481,23 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-toolkit-registry
+
+  - it: should wire the worker database into misc workers
+    set:
+      thermosMiscWorkers.enabled: true
+      thermos.workerDb.enabled: true
+      thermos.workerDb.secretName: thermos-worker-secret
+      thermos.workerDb.secretKey: WORKER_DATABASE_URL
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: THERMOS_WORKER_DB
+            valueFrom:
+              secretKeyRef:
+                name: thermos-worker-secret
+                key: WORKER_DATABASE_URL
+                optional: true
 
   - it: should percent-encode misc worker toolkit registry db url and shell-quote wait configuration
     set:


### PR DESCRIPTION
## Summary

Add regression coverage for the native Thermos worker-database behavior introduced by #314:

- worker DB creation and public-schema grants in postgres init
- main Thermos `THERMOS_WORKER_DB` secret/key wiring
- Thermos db-init worker DB wiring
- misc-worker worker DB wiring
- custom secret, key, and database names
- disabled behavior omits the environment variable and SQL

## Validation

- `helm unittest . -f tests/thermos_test.yaml -f tests/db_init_test.yaml` — 75 passed
- `helm lint composio --set replicated.enabled=false --set global.imagePullSecrets={}`
- full `helm template` render with database migration and misc workers enabled