### PR TITLE
fix: disable Thermos worker DB by default

### DIFF
--- a/composio/tests/db_init_test.yaml
+++ b/composio/tests/db_init_test.yaml
@@ -419,6 +419,23 @@ tests:
       - isKind:
           of: Job
 
+  - it: should not create the Thermos worker DB by default
+    set:
+      databaseMigration.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'CREATE DATABASE "thermos_workerdb";'
+
+  - it: should create the Thermos worker DB when explicitly enabled
+    set:
+      databaseMigration.enabled: true
+      thermos.workerDb.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[2]
+          pattern: 'CREATE DATABASE "thermos_workerdb";'
+
   - it: should not create postgres init job when disabled
     set:
       databaseMigration.enabled: false

--- a/composio/tests/thermos_test.yaml
+++ b/composio/tests/thermos_test.yaml
@@ -19,6 +19,35 @@ tests:
           path: metadata.labels.release
           value: RELEASE-NAME
 
+  - it: should not wire the worker DB by default
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: THERMOS_WORKER_DB
+
+  - it: should wire the worker DB when explicitly enabled
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      thermos.workerDb.enabled: true
+      thermos.workerDb.secretName: worker-db-secret
+      thermos.workerDb.secretKey: WORKER_DATABASE_URL
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: THERMOS_WORKER_DB
+            valueFrom:
+              secretKeyRef:
+                name: worker-db-secret
+                key: WORKER_DATABASE_URL
+                optional: true
+
   - it: should not set serviceAccountName when SA is disabled
     documentSelector:
       path: kind

--- a/composio/values.yaml
+++ b/composio/values.yaml
@@ -349,7 +349,7 @@ thermos:
   # worker database's public schema.
   workerDb:
     # -- Enable Thermos worker DB runtime wiring, worker DB creation, and worker DB migrations.
-    enabled: true
+    enabled: false
     # -- Secret containing the worker DB connection URL. Empty uses `secret.name`.
     secretName: ""
     # -- Secret key containing the worker DB connection URL.


### PR DESCRIPTION
## Summary

- default `thermos.workerDb.enabled` to `false`
- preserve explicit opt-in worker DB wiring and database creation
- add regression coverage for both default-disabled and explicit-enabled behavior

## Testing

- `helm unittest . -f tests/thermos_test.yaml`
- `helm unittest . -f tests/db_init_test.yaml`
- `helm unittest . -f "tests/*_test.yaml"` (344 tests)
- `helm lint . --set replicated.enabled=false --set global.imagePullSecrets={}`