### PR TITLE
Revamp released CVE audit Slack report to Block Kit layout

### DIFF
--- a/.github/scripts/cve/build-released-cve-audit-alert.mjs
+++ b/.github/scripts/cve/build-released-cve-audit-alert.mjs
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { contextBlock, dividerBlock, headerBlock, sectionBlock } from "./slack-blocks.mjs";
 
 async function readTextIfPresent(file) {
   if (!file) return "";
@@ -33,6 +34,7 @@ export function buildReleasedCveAuditAlert({
   auditStatus = "",
   auditTitle = "",
   auditSummary = "",
+  auditBlocks = [],
   slackUsergroupId = "",
   channel = "Stable",
   releaseCount = "3",
@@ -59,6 +61,7 @@ export function buildReleasedCveAuditAlert({
         resolvedStatus === "SUCCESS"
           ? `${summary}\n`
           : withFailureMention(summary, trim(slackUsergroupId)),
+      blocks: Array.isArray(auditBlocks) ? auditBlocks : [],
     };
   }
 
@@ -90,10 +93,52 @@ export function buildReleasedCveAuditAlert({
     lines.push(`*Workflow:* <${runUrl}|released CVE audit run>`);
   }
 
+  const title = ":rotating_light: Released CVE audit: WORKFLOW FAILED";
+
+  const verdictLines = [];
+  if (slackUsergroupId) {
+    verdictLines.push(`<!subteam^${slackUsergroupId}|@implementations>`, "");
+  }
+  verdictLines.push(
+    "*Good to go:* NO - released CVE audit did not complete",
+    "",
+    "*Scope:* Already released channel versions only; independent of the nightly release workflow.",
+    "",
+    "*Release blocking:* NO - this audit is alert-only.",
+  );
+
+  const blocks = [
+    headerBlock(title),
+    sectionBlock(verdictLines.join("\n")),
+    dividerBlock(),
+    sectionBlock(
+      [
+        `*Requested audit:* ${scope}`,
+        "*Findings:* UNKNOWN - the audit failed before producing the CVE summary.",
+        "",
+        "*Stages*",
+        `${releasesOutcome === "success" ? ":white_check_mark:" : ":x:"} Release resolution — \`${releasesOutcome || "unknown"}\``,
+        `${auditOutcome === "success" ? ":white_check_mark:" : ":x:"} Audit scan/report — \`${auditOutcome || "unknown"}\``,
+      ].join("\n"),
+    ),
+  ];
+  if (artifactName) {
+    blocks.push(contextBlock(`Audit artifact: \`${artifactName}\``));
+  }
+  if (artifactDownloadCommand) {
+    blocks.push(
+      sectionBlock(`*Download partial reports, if any were uploaded:*\n\`\`\`\n${artifactDownloadCommand}\n\`\`\``),
+    );
+  }
+  if (runUrl) {
+    blocks.push(contextBlock(`<${runUrl}|Workflow>`));
+  }
+
   return {
     status: "FAILURE",
-    title: ":rotating_light: Released CVE audit: WORKFLOW FAILED",
+    title,
     summary: `${lines.join("\n")}\n`,
+    blocks,
   };
 }
 
@@ -119,12 +164,15 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   const outputDir = args.output_dir || "audit-reports";
   const resultFile = args.result_file || path.join(outputDir, "released-cve-audit-result.json");
   const summaryFile = args.summary_file || path.join(outputDir, "slack-summary.md");
+  const blocksFile = args.blocks_file || path.join(outputDir, "slack-blocks.json");
   const result = await readJsonIfPresent(resultFile);
   const summary = await readTextIfPresent(summaryFile);
+  const blocks = await readJsonIfPresent(blocksFile);
   const alert = buildReleasedCveAuditAlert({
     auditStatus: result.status,
     auditTitle: result.slackTitle,
     auditSummary: summary,
+    auditBlocks: Array.isArray(blocks) ? blocks : [],
     slackUsergroupId: args.slack_usergroup_id || "",
     channel: args.channel || "Stable",
     releaseCount: args.release_count || "3",

--- a/.github/scripts/cve/build-released-cve-audit-alert.test.mjs
+++ b/.github/scripts/cve/build-released-cve-audit-alert.test.mjs
@@ -27,6 +27,22 @@ test("uses the completed released audit summary when one exists", () => {
   assert.doesNotMatch(alert.summary, /Nightly release gate/);
 });
 
+test("passes the audit Block Kit layout through when one exists", () => {
+  const auditBlocks = [
+    { type: "header", text: { type: "plain_text", text: ":rotating_light: Released CVE audit: ATTENTION NEEDED", emoji: true } },
+    { type: "section", text: { type: "mrkdwn", text: "*Good to go:* NO" } },
+  ];
+  const alert = buildReleasedCveAuditAlert({
+    auditStatus: "FAILURE",
+    auditTitle: ":rotating_light: Released CVE audit: ATTENTION NEEDED",
+    auditSummary: "*Good to go:* NO - Released images contain 2 HIGH and 1 CRITICAL findings\n",
+    auditBlocks,
+    slackUsergroupId: "S123",
+  });
+
+  assert.deepEqual(alert.blocks, auditBlocks);
+});
+
 test("builds a tagged fallback alert when the released audit fails before summary generation", () => {
   const alert = buildReleasedCveAuditAlert({
     auditStatus: "",
@@ -55,4 +71,13 @@ test("builds a tagged fallback alert when the released audit fails before summar
   assert.match(alert.summary, /Audit scan\/report: `failure`/);
   assert.match(alert.summary, /released-grype-cve-audit-2-1/);
   assert.match(alert.summary, /https:\/\/github\.com\/ComposioHQ\/helm-charts\/actions\/runs\/2/);
+
+  assert.equal(alert.blocks[0].type, "header");
+  assert.equal(alert.blocks[0].text.text, ":rotating_light: Released CVE audit: WORKFLOW FAILED");
+  assert.match(alert.blocks[1].text.text, /^<!subteam\^S123\|@implementations>/);
+  const blocksText = JSON.stringify(alert.blocks);
+  assert.match(blocksText, /:white_check_mark: Release resolution/);
+  assert.match(blocksText, /:x: Audit scan\/report/);
+  assert.match(blocksText, /released-grype-cve-audit-2-1/);
+  assert.match(blocksText, /actions\/runs\/2\|Workflow>/);
 });

--- a/.github/scripts/cve/build-released-cve-audit.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.mjs
@@ -1,6 +1,14 @@
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { displayImageName } from "./image-display.mjs";
+import {
+  contextBlock,
+  dividerBlock,
+  fieldsBlock,
+  headerBlock,
+  monoTable,
+  sectionBlock,
+} from "./slack-blocks.mjs";
 
 const REASON_LABELS = {
   "published-after-release": "published after release",
@@ -365,8 +373,8 @@ function buildSlackSummary(report) {
   return `${lines.join("\n")}\n`;
 }
 
-function topImageBreakdownLines(imageCveBreakdown) {
-  const top = [...imageCveBreakdown]
+function topImageRows(imageCveBreakdown) {
+  return [...imageCveBreakdown]
     .filter((item) => item.cve_count > 0)
     .sort((left, right) =>
       right.cve_count - left.cve_count ||
@@ -374,6 +382,10 @@ function topImageBreakdownLines(imageCveBreakdown) {
       String(left.image).localeCompare(String(right.image)),
     )
     .slice(0, 5);
+}
+
+function topImageBreakdownLines(imageCveBreakdown) {
+  const top = topImageRows(imageCveBreakdown);
 
   if (top.length === 0) {
     return ["- No image-level HIGH/CRITICAL CVE rows."];
@@ -389,6 +401,96 @@ function topImageBreakdownLines(imageCveBreakdown) {
   );
 }
 
+export function buildSlackBlocks(report) {
+  const verdictLines = [];
+  if (report.status !== "SUCCESS" && report.slackUsergroupId) {
+    verdictLines.push(`<!subteam^${report.slackUsergroupId}|@implementations>`, "");
+  }
+  verdictLines.push(
+    report.status === "SUCCESS"
+      ? "*Good to go:* YES"
+      : `*Good to go:* NO - Released images contain ${report.totalHigh} HIGH and ${report.totalCritical} CRITICAL findings`,
+    "",
+    "*Scope:* Already released channel versions only; independent of the nightly release workflow.",
+    "",
+    "*Release blocking:* NO - this audit is alert-only.",
+  );
+
+  const blocks = [
+    headerBlock(report.slackTitle),
+    sectionBlock(verdictLines.join("\n")),
+    dividerBlock(),
+    fieldsBlock([
+      `*Channel:*\n\`${report.channel}\``,
+      `*Releases scanned:*\n${report.releaseCount}`,
+      `*Findings:*\n${report.totalHigh} HIGH / ${report.totalCritical} CRITICAL`,
+      `*Fix available now:*\n${report.fixedNow}`,
+      `*New since release scan:*\n${report.newlyDetected}`,
+      `*Earliest fix date detected:*\n${report.earliestFixAvailableAt || "none"}`,
+      `*Ignored images:*\n${report.ignoredImages}`,
+      `*Scan errors:*\nGrype ${report.scanErrors} · release inspection ${report.releaseErrors}`,
+    ]),
+    sectionBlock(
+      [
+        "*CVE publication timing*",
+        `after release ${report.publishTiming.publishedAfterRelease} · ` +
+          `before/on release ${report.publishTiming.publishedOnOrBeforeRelease} · ` +
+          `unknown ${report.publishTiming.unknownPublishDate}`,
+        "",
+        "*Why findings are present*",
+        ...reasonLines(report.reasonCounts),
+      ].join("\n"),
+    ),
+    dividerBlock(),
+  ];
+
+  const top = topImageRows(report.imageCveBreakdown);
+  if (top.length === 0) {
+    blocks.push(sectionBlock("*Top image CVE breakdown*\n\nNo image-level HIGH/CRITICAL CVE rows."));
+  } else {
+    const imageTable = monoTable(
+      ["REL", "IMAGE", "CVES", "FIX", "NO-FIX", "CRIT", "HIGH", "EARLIEST FIX"],
+      top.map((item) => [
+        item.release_sequence,
+        displayImageName(item.image),
+        item.cve_count,
+        item.fix_available_cves,
+        item.no_fix_available_cves,
+        item.severity.Critical.cves,
+        item.severity.High.cves,
+        item.earliest_fix_available_at || "-",
+      ]),
+      ["r", "l", "r", "r", "r", "r", "r", "l"],
+    );
+    blocks.push(sectionBlock(`*Top image CVE breakdown*\n\`\`\`\n${imageTable}\n\`\`\``));
+  }
+
+  const releaseTable = monoTable(
+    ["SEQ", "CHART", "TAG", "HIGH", "CRIT", "IGNORED", "AFTER-REL", "NO-FIX@REL", "BASELINE"],
+    report.releases.map((release) => [
+      release.sequence,
+      release.chart_version || "unknown",
+      release.detected_release_tag || "unknown",
+      release.totalHigh,
+      release.totalCritical,
+      release.ignoredImages,
+      release.publishTiming.publishedAfterRelease,
+      release.reasonCounts["no-fix-at-release-scan"] || 0,
+      release.baseline_source || "missing",
+    ]),
+    ["r", "l", "l", "r", "r", "r", "r", "r", "l"],
+  );
+  blocks.push(sectionBlock(`*Per-release summary*\n\`\`\`\n${releaseTable}\n\`\`\``));
+
+  blocks.push(contextBlock(`Audit artifact: \`${report.artifactName}\``));
+  blocks.push(sectionBlock(`*Download reports:*\n\`\`\`\n${report.artifactDownloadCommand}\n\`\`\``));
+  if (report.runUrl) {
+    blocks.push(contextBlock(`<${report.runUrl}|Workflow>`));
+  }
+
+  return blocks;
+}
+
 export async function buildReleasedCveAudit({
   releaseResultsFile,
   outputDir,
@@ -397,6 +499,7 @@ export async function buildReleasedCveAudit({
   artifactName,
   artifactDownloadCommand,
   slackUsergroupId = "",
+  runUrl = "",
 }) {
   const releaseResults = await readJson(releaseResultsFile, []);
   const findingContext = buildFindingContext(releaseResults);
@@ -462,12 +565,16 @@ export async function buildReleasedCveAudit({
     imageCveBreakdown,
     findingContext,
     slackUsergroupId,
+    runUrl,
   };
+
+  const slackBlocks = buildSlackBlocks(report);
 
   await writeFile(path.join(outputDir, "finding-context.json"), `${JSON.stringify(findingContext, null, 2)}\n`);
   await writeFile(path.join(outputDir, "released-cve-audit-result.json"), `${JSON.stringify(report, null, 2)}\n`);
   await writeFile(path.join(outputDir, "summary.md"), buildMarkdownSummary(report));
   await writeFile(path.join(outputDir, "slack-summary.md"), buildSlackSummary(report));
+  await writeFile(path.join(outputDir, "slack-blocks.json"), `${JSON.stringify(slackBlocks)}\n`);
 
   return report;
 }
@@ -499,5 +606,6 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     artifactName: args.artifact_name,
     artifactDownloadCommand: args.artifact_download_command,
     slackUsergroupId: args.slack_usergroup_id || "",
+    runUrl: args.run_url || "",
   });
 }

--- a/.github/scripts/cve/build-released-cve-audit.test.mjs
+++ b/.github/scripts/cve/build-released-cve-audit.test.mjs
@@ -145,6 +145,7 @@ test("buildReleasedCveAudit explains why findings are present in released versio
       artifactDownloadCommand:
         "gh run download 1 --repo ComposioHQ/helm-charts --name released-grype-cve-audit-1-1 --dir ./released-cve-audit",
       slackUsergroupId: "S123",
+      runUrl: "https://github.com/ComposioHQ/helm-charts/actions/runs/1",
     });
 
     assert.equal(result.status, "FAILURE");
@@ -197,6 +198,26 @@ test("buildReleasedCveAudit explains why findings are present in released versio
     assert.match(slack, /unknown 1/);
     assert.match(slack, /published after release: 1/);
     assert.match(slack, /no fix at release scan: 1/);
+
+    const blocks = JSON.parse(await readFile(path.join(dir, "slack-blocks.json"), "utf8"));
+    assert.ok(Array.isArray(blocks));
+    assert.equal(blocks[0].type, "header");
+    assert.equal(blocks[0].text.text, ":rotating_light: Released CVE audit: ATTENTION NEEDED");
+    assert.equal(blocks[1].type, "section");
+    assert.match(blocks[1].text.text, /^<!subteam\^S123\|@implementations>/);
+    assert.match(blocks[1].text.text, /\*Good to go:\* NO - Released images contain 2 HIGH and 1 CRITICAL findings/);
+    assert.match(blocks[1].text.text, /\*Release blocking:\* NO - this audit is alert-only\./);
+    const fieldsBlock = blocks.find((block) => Array.isArray(block.fields));
+    assert.ok(fieldsBlock, "expected a field-grid section");
+    assert.ok(fieldsBlock.fields.some((field) => field.text === "*Findings:*\n2 HIGH / 1 CRITICAL"));
+    assert.ok(fieldsBlock.fields.some((field) => field.text === "*Channel:*\n`Stable`"));
+    const blocksText = JSON.stringify(blocks);
+    assert.match(blocksText, /Top image CVE breakdown/);
+    assert.match(blocksText, /Per-release summary/);
+    assert.match(blocksText, /apollo:r20260701_01/);
+    assert.doesNotMatch(blocksText, /artifacts\.composio\.io\/proxy\/composio-rodent/);
+    assert.equal(blocks.at(-1).type, "context");
+    assert.match(blocks.at(-1).elements[0].text, /actions\/runs\/1\|Workflow>/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/.github/scripts/cve/slack-blocks.mjs
+++ b/.github/scripts/cve/slack-blocks.mjs
@@ -1,0 +1,56 @@
+// Shared Slack Block Kit helpers for the CVE audit reports, mirroring the
+// layout conventions of the nightly release report (nightly-slack-summary.sh):
+// header, mrkdwn sections, field grids, dividers, and context rows.
+
+const SECTION_TEXT_LIMIT = 2900;
+
+// Slack caps section text at 3000 chars; truncate defensively and keep any
+// code fence balanced so a huge table cannot invalidate the payload.
+function truncateSectionText(text) {
+  if (text.length <= SECTION_TEXT_LIMIT) return text;
+  let cut = text.slice(0, SECTION_TEXT_LIMIT);
+  const lastNewline = cut.lastIndexOf("\n");
+  if (lastNewline > 0) cut = cut.slice(0, lastNewline);
+  const fenceCount = (cut.match(/^```/gm) || []).length;
+  if (fenceCount % 2 === 1) cut += "\n```";
+  return `${cut}\n_…truncated; full details in the audit artifact._`;
+}
+
+export function headerBlock(text) {
+  return { type: "header", text: { type: "plain_text", text, emoji: true } };
+}
+
+export function sectionBlock(text) {
+  return { type: "section", text: { type: "mrkdwn", text: truncateSectionText(text) } };
+}
+
+export function fieldsBlock(fields) {
+  return { type: "section", fields: fields.map((text) => ({ type: "mrkdwn", text })) };
+}
+
+export function contextBlock(text) {
+  return { type: "context", elements: [{ type: "mrkdwn", text }] };
+}
+
+export function dividerBlock() {
+  return { type: "divider" };
+}
+
+// Render a fixed-width table for use inside a Slack code fence. `aligns` takes
+// one "l"/"r" per column; numeric columns read best right-aligned.
+export function monoTable(headers, rows, aligns = []) {
+  const table = [headers, ...rows].map((row) => row.map((cell) => String(cell ?? "")));
+  const widths = headers.map((_, column) =>
+    Math.max(...table.map((row) => row[column].length)),
+  );
+  return table
+    .map((row) =>
+      row
+        .map((cell, column) =>
+          (aligns[column] === "r" ? cell.padStart(widths[column]) : cell.padEnd(widths[column])),
+        )
+        .join("  ")
+        .trimEnd(),
+    )
+    .join("\n");
+}

--- a/.github/workflows/released-cve-audit.yml
+++ b/.github/workflows/released-cve-audit.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           sparse-checkout: |
             .github/scripts/cve
+            .github/actions/slack-notify
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -228,6 +229,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           CHANNEL: ${{ inputs.channel || 'Stable' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           scan_started_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
@@ -370,7 +372,8 @@ jobs:
             --scan-started-at "${scan_started_at}" \
             --artifact-name "${artifact_name}" \
             --artifact-download-command "${artifact_download_command}" \
-            --slack-usergroup-id "${SLACK_IMPLEMENTATIONS_USERGROUP_ID}"
+            --slack-usergroup-id "${SLACK_IMPLEMENTATIONS_USERGROUP_ID}" \
+            --run-url "${RUN_URL}"
 
           cat audit-reports/summary.md >> "${GITHUB_STEP_SUMMARY}"
 
@@ -455,6 +458,10 @@ jobs:
 
           status="$(jq -r '.status' audit-reports/released-cve-audit-alert.json)"
           title="$(jq -r '.title' audit-reports/released-cve-audit-alert.json)"
+          blocks="$(jq -c '.blocks // []' audit-reports/released-cve-audit-alert.json)"
+          if [[ "${blocks}" == "[]" ]]; then
+            blocks=""
+          fi
 
           {
             echo "status=${status}"
@@ -464,6 +471,9 @@ jobs:
             echo "summary<<__AUDIT_ALERT_SUMMARY__"
             jq -r '.summary' audit-reports/released-cve-audit-alert.json
             echo "__AUDIT_ALERT_SUMMARY__"
+            echo "blocks<<__AUDIT_ALERT_BLOCKS__"
+            echo "${blocks}"
+            echo "__AUDIT_ALERT_BLOCKS__"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Upload released CVE audit reports
@@ -476,57 +486,10 @@ jobs:
 
       - name: Announce released CVE audit in Slack
         if: ${{ always() && (github.event_name != 'workflow_dispatch' || inputs.notify_slack) && steps.alert.outputs.summary != '' && steps.doppler.outputs.NIGHTLY_SLACK_WEBHOOK_URL != '' }}
-        shell: bash
-        env:
-          INPUT_STATUS: ${{ steps.alert.outputs.status }}
-          INPUT_TITLE: ${{ steps.alert.outputs.title }}
-          INPUT_SUMMARY: ${{ steps.alert.outputs.summary }}
-          SLACK_WEBHOOK_URL: ${{ steps.doppler.outputs.NIGHTLY_SLACK_WEBHOOK_URL }}
-        run: |
-          set -euo pipefail
-
-          case "${INPUT_STATUS}" in
-            SUCCESS) color="#28a745" ;;
-            FAILURE) color="#cb2431" ;;
-            *)       color="#808080" ;;
-          esac
-
-          payload="$(
-            jq -n \
-              --arg color "${color}" \
-              --arg title "${INPUT_TITLE}" \
-              --arg summary "${INPUT_SUMMARY}" \
-              '
-              def chunks($text; $size):
-                [range(0; ($text | length); $size) as $start | $text[$start:($start + $size)]]
-                | map(select(length > 0));
-
-              {
-                text: ($title + "\n" + $summary[0:3000]),
-                attachments: [{
-                  color: $color,
-                  blocks: ([
-                    {
-                      type: "section",
-                      text: { type: "mrkdwn", text: ("*" + $title + "*") }
-                    }
-                  ] + (chunks($summary; 2900) | .[:49] | map({
-                    type: "section",
-                    text: { type: "mrkdwn", text: . }
-                  })))
-                }],
-                unfurl_links: false,
-                unfurl_media: false
-              }'
-          )"
-
-          response="$(
-            curl -fsS -X POST "${SLACK_WEBHOOK_URL}" \
-              -H "Content-Type: application/json" \
-              -d "${payload}"
-          )"
-
-          if [[ "${response}" != "ok" ]]; then
-            echo "::error::Slack webhook returned unexpected response: ${response}" >&2
-            exit 1
-          fi
+        uses: ./.github/actions/slack-notify
+        with:
+          status: ${{ steps.alert.outputs.status }}
+          slack_webhook_url: ${{ steps.doppler.outputs.NIGHTLY_SLACK_WEBHOOK_URL }}
+          title: ${{ steps.alert.outputs.title }}
+          summary: ${{ steps.alert.outputs.summary }}
+          blocks: ${{ steps.alert.outputs.blocks }}

--- a/.gitignore
+++ b/.gitignore
@@ -116,4 +116,7 @@ temp/
 # Build artifacts
 dist/
 build/
-out/ 
+out/
+
+# Local clone of the separate ComposioHQ/onprem-testbed repo
+/onprem-testbed/


### PR DESCRIPTION
## Why

The nightly release Slack report was revamped to a readable Block Kit layout in #369, but the released CVE audit workflow was untouched and still posts one giant wall-of-text attachment ([example](https://composioworkspace.slack.com/archives/C0BF54WQE6L/p1786304016697979) vs the [nightly report](https://composioworkspace.slack.com/archives/C0BF54WQE6L/p1786303133136329)). This brings the audit report up to the same layout.

## What

- **`.github/scripts/cve/slack-blocks.mjs`** (new): shared Block Kit helpers — header/section/field-grid/context/divider builders, fixed-width table rendering for code fences, and the same fence-safe 3000-char section truncation the nightly report uses.
- **`build-released-cve-audit.mjs`**: renders `slack-blocks.json` next to the existing `slack-summary.md` (which is kept as the notification fallback text). Layout: header → verdict/mention/scope section → field grid (channel, releases scanned, findings, fixes, scan errors) → publication-timing/why-present section → monospace tables for top-image and per-release breakdowns → artifact + download + workflow-link rows. Also accepts `--run-url` so the report ends with a Workflow link like the nightly one.
- **`build-released-cve-audit-alert.mjs`**: passes the audit blocks through when the audit completed, and renders a matching Block Kit fallback for the workflow-failed alert.
- **`released-cve-audit.yml`**: posts through the shared `.github/actions/slack-notify` action (which already supports `blocks`) instead of the inline webhook attachment payload; sparse checkout extended to include the action. If blocks are ever missing, the action falls back to the old attachment rendering, so the report degrades gracefully.
- **`.gitignore`**: ignore a local `onprem-testbed/` clone (it is the separate `ComposioHQ/onprem-testbed` repo, never committed here).

## Testing

- `node --test .github/scripts/cve/*.test.mjs` — 9/9 pass, including new assertions for the blocks file, the alert blocks passthrough, and the workflow-failed fallback blocks.
- Smoke-ran both CLIs end to end on sample release results and verified the emitted payload (11 blocks, valid types, tables render, proxy-prefixed image names shortened).
- `yq` validates the workflow YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)