### PR TITLE
feat(ci): tag onprem-testbed release snapshots

### DIFF
--- a/.github/scripts/create-onprem-release-tag.cjs
+++ b/.github/scripts/create-onprem-release-tag.cjs
@@ -1,0 +1,95 @@
+function errorStatus(error) {
+  return error.status ?? error.response?.status;
+}
+
+async function getOptionalRef({ github, owner, repo, ref }) {
+  try {
+    const response = await github.rest.git.getRef({ owner, repo, ref });
+    return response.data;
+  } catch (error) {
+    if (errorStatus(error) === 404) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function verifyImmutableTag({ existingRef, repo, tag, targetSha }) {
+  if (existingRef.object.sha !== targetSha) {
+    throw new Error(
+      `Refusing to move existing ${repo} tag ${tag} from ${existingRef.object.sha} to ${targetSha}`,
+    );
+  }
+}
+
+async function createImmutableReleaseTag({ github, core, owner, repo, tag }) {
+  if (!tag) {
+    throw new Error("Release tag is required");
+  }
+
+  const { data: targetRepository } = await github.rest.repos.get({
+    owner,
+    repo,
+  });
+  const defaultBranch = targetRepository.default_branch;
+  if (!defaultBranch) {
+    throw new Error(`${owner}/${repo} does not have a default branch`);
+  }
+
+  const { data: branchRef } = await github.rest.git.getRef({
+    owner,
+    repo,
+    ref: `heads/${defaultBranch}`,
+  });
+  const targetSha = branchRef.object.sha;
+  const tagRef = `tags/${tag}`;
+  const existingRef = await getOptionalRef({
+    github,
+    owner,
+    repo,
+    ref: tagRef,
+  });
+
+  if (existingRef) {
+    verifyImmutableTag({ existingRef, repo, tag, targetSha });
+    core.info(`${repo} tag ${tag} already points to ${targetSha}.`);
+    return { branch: defaultBranch, created: false, sha: targetSha, tag };
+  }
+
+  try {
+    await github.rest.git.createRef({
+      owner,
+      repo,
+      ref: `refs/${tagRef}`,
+      sha: targetSha,
+    });
+  } catch (error) {
+    if (![409, 422].includes(errorStatus(error))) {
+      throw error;
+    }
+
+    const concurrentRef = await getOptionalRef({
+      github,
+      owner,
+      repo,
+      ref: tagRef,
+    });
+    if (!concurrentRef) {
+      throw error;
+    }
+
+    verifyImmutableTag({
+      existingRef: concurrentRef,
+      repo,
+      tag,
+      targetSha,
+    });
+    core.info(`${repo} tag ${tag} was concurrently created at ${targetSha}.`);
+    return { branch: defaultBranch, created: false, sha: targetSha, tag };
+  }
+
+  core.info(`Created ${repo} tag ${tag} at ${targetSha} from ${defaultBranch}.`);
+  return { branch: defaultBranch, created: true, sha: targetSha, tag };
+}
+
+module.exports = { createImmutableReleaseTag };

--- a/.github/scripts/create-onprem-release-tag.test.cjs
+++ b/.github/scripts/create-onprem-release-tag.test.cjs
@@ -1,0 +1,169 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const owner = "ComposioHQ";
+const repo = "onprem-testbed";
+const tag = "0.2.114";
+const targetSha = "1111111111111111111111111111111111111111";
+
+function loadSubject() {
+  try {
+    return require("./create-onprem-release-tag.cjs");
+  } catch (error) {
+    assert.fail(`Unable to load create-onprem-release-tag.cjs: ${error.message}`);
+  }
+}
+
+function githubFixture({
+  existingTagSha,
+  concurrentTagSha,
+  concurrentStatus = 422,
+} = {}) {
+  const refs = new Map([
+    ["heads/main", { object: { sha: targetSha } }],
+  ]);
+  if (existingTagSha) {
+    refs.set(`tags/${tag}`, { object: { sha: existingTagSha } });
+  }
+
+  let pendingConcurrentTagSha = concurrentTagSha;
+
+  const github = {
+    rest: {
+      repos: {
+        async get(request) {
+          assert.deepEqual(request, { owner, repo });
+          return { data: { default_branch: "main" } };
+        },
+      },
+      git: {
+        async getRef(request) {
+          assert.equal(request.owner, owner);
+          assert.equal(request.repo, repo);
+          const ref = refs.get(request.ref);
+          if (!ref) {
+            const error = new Error(`Reference ${request.ref} not found`);
+            error.status = 404;
+            throw error;
+          }
+          return { data: ref };
+        },
+        async createRef(request) {
+          assert.equal(request.owner, owner);
+          assert.equal(request.repo, repo);
+          assert.equal(request.ref, `refs/tags/${tag}`);
+          assert.equal(request.sha, targetSha);
+
+          if (pendingConcurrentTagSha) {
+            refs.set(`tags/${tag}`, {
+              object: { sha: pendingConcurrentTagSha },
+            });
+            pendingConcurrentTagSha = undefined;
+            const error = new Error("Reference already exists");
+            error.status = concurrentStatus;
+            throw error;
+          }
+
+          refs.set(`tags/${tag}`, { object: { sha: request.sha } });
+          return { data: refs.get(`tags/${tag}`) };
+        },
+      },
+    },
+  };
+
+  return { github, refs };
+}
+
+const core = { info() {} };
+
+test("creates the chart-version tag at the default-branch HEAD", async () => {
+  const { createImmutableReleaseTag } = loadSubject();
+  const { github, refs } = githubFixture();
+
+  const result = await createImmutableReleaseTag({
+    github,
+    core,
+    owner,
+    repo,
+    tag,
+  });
+
+  assert.deepEqual(result, {
+    branch: "main",
+    created: true,
+    sha: targetSha,
+    tag,
+  });
+  assert.equal(refs.get(`tags/${tag}`).object.sha, targetSha);
+});
+
+test("accepts an existing tag when it already points to the release SHA", async () => {
+  const { createImmutableReleaseTag } = loadSubject();
+  const { github, refs } = githubFixture({ existingTagSha: targetSha });
+
+  const result = await createImmutableReleaseTag({
+    github,
+    core,
+    owner,
+    repo,
+    tag,
+  });
+
+  assert.deepEqual(result, {
+    branch: "main",
+    created: false,
+    sha: targetSha,
+    tag,
+  });
+  assert.equal(refs.get(`tags/${tag}`).object.sha, targetSha);
+});
+
+test("refuses to move an existing tag that points to another SHA", async () => {
+  const { createImmutableReleaseTag } = loadSubject();
+  const conflictingSha = "2222222222222222222222222222222222222222";
+  const { github, refs } = githubFixture({ existingTagSha: conflictingSha });
+
+  await assert.rejects(
+    createImmutableReleaseTag({ github, core, owner, repo, tag }),
+    /Refusing to move existing onprem-testbed tag 0\.2\.114/,
+  );
+  assert.equal(refs.get(`tags/${tag}`).object.sha, conflictingSha);
+});
+
+for (const concurrentStatus of [409, 422]) {
+  test(`accepts a concurrently created tag after HTTP ${concurrentStatus}`, async () => {
+    const { createImmutableReleaseTag } = loadSubject();
+    const { github, refs } = githubFixture({
+      concurrentStatus,
+      concurrentTagSha: targetSha,
+    });
+
+    const result = await createImmutableReleaseTag({
+      github,
+      core,
+      owner,
+      repo,
+      tag,
+    });
+
+    assert.deepEqual(result, {
+      branch: "main",
+      created: false,
+      sha: targetSha,
+      tag,
+    });
+    assert.equal(refs.get(`tags/${tag}`).object.sha, targetSha);
+  });
+}
+
+test("rejects a concurrently created tag when it points to another SHA", async () => {
+  const { createImmutableReleaseTag } = loadSubject();
+  const conflictingSha = "3333333333333333333333333333333333333333";
+  const { github, refs } = githubFixture({ concurrentTagSha: conflictingSha });
+
+  await assert.rejects(
+    createImmutableReleaseTag({ github, core, owner, repo, tag }),
+    /Refusing to move existing onprem-testbed tag 0\.2\.114/,
+  );
+  assert.equal(refs.get(`tags/${tag}`).object.sha, conflictingSha);
+});

--- a/.github/scripts/tests/nighty-release-workflow-test.sh
+++ b/.github/scripts/tests/nighty-release-workflow-test.sh
@@ -55,6 +55,30 @@ assert_step_before() {
   fi
 }
 
+assert_job_step_before() {
+  local name="$1"
+  local job="$2"
+  local first_id="$3"
+  local second_id="$4"
+  local first_index second_index
+
+  first_index="$(
+    yq -r \
+      ".jobs.${job}.steps | to_entries | map(select(.value.id == \"${first_id}\")) | .[0].key" \
+      "${WORKFLOW}"
+  )"
+  second_index="$(
+    yq -r \
+      ".jobs.${job}.steps | to_entries | map(select(.value.id == \"${second_id}\")) | .[0].key" \
+      "${WORKFLOW}"
+  )"
+
+  if [[ "${first_index}" == "null" || "${second_index}" == "null" || "${first_index}" -ge "${second_index}" ]]; then
+    echo "FAIL: ${name}: expected ${first_id} before ${second_id}" >&2
+    exit 1
+  fi
+}
+
 assert_eq "release input type" \
   "$(yq -r '.on.workflow_dispatch.inputs.release_type.type' "${WORKFLOW}")" choice
 assert_eq "release input default" \
@@ -126,6 +150,27 @@ assert_eq "fresh-install harness selected chart" \
 assert_eq "upgrade harness selected chart" \
   "$(yq -r '.jobs.onprem-testbed.steps[] | select(.id == "upgrade") | .env.HARNESS_ENV_JSON' "${WORKFLOW}")" \
   "${expected_harness_env_json}"
+
+assert_eq "onprem tag token repository scope" \
+  "$(yq -r '.jobs.onprem-testbed.steps[] | select(.id == "onprem_app_token") | .env.GITHUB_APP_REPOSITORIES' "${WORKFLOW}")" \
+  onprem-testbed
+assert_eq "onprem tag token permission scope" \
+  "$(yq -r '.jobs.onprem-testbed.steps[] | select(.id == "onprem_app_token") | .env.GITHUB_APP_PERMISSIONS_JSON' "${WORKFLOW}")" \
+  '{"contents":"write"}'
+assert_eq "onprem tag uses app token" \
+  "$(yq -r '.jobs.onprem-testbed.steps[] | select(.id == "tag_onprem_release") | .with."github-token"' "${WORKFLOW}")" \
+  '${{ steps.onprem_app_token.outputs.token }}'
+assert_eq "onprem tag uses chart version" \
+  "$(yq -r '.jobs.onprem-testbed.steps[] | select(.id == "tag_onprem_release") | .env.ONPREM_RELEASE_VERSION' "${WORKFLOW}")" \
+  '${{ needs.replicated-release.outputs.version }}'
+assert_contains "onprem tag helper checked out" \
+  '.github/scripts/create-onprem-release-tag.cjs'
+assert_contains "onprem tag uses immutable helper" \
+  'createImmutableReleaseTag'
+assert_job_step_before "onprem release tag precedes fresh harness" \
+  onprem-testbed tag_onprem_release fresh
+assert_job_step_before "onprem release tag precedes upgrade harness" \
+  onprem-testbed tag_onprem_release upgrade
 
 assert_eq "onprem fresh outcome exposed" \
   "$(yq -r '.jobs.onprem-testbed.outputs.fresh_result' "${WORKFLOW}")" \

--- a/.github/workflows/nighty-release.yml
+++ b/.github/workflows/nighty-release.yml
@@ -787,6 +787,7 @@ jobs:
           sparse-checkout: |
             .github/scripts/run-onprem-test-harness.sh
             .github/scripts/github-app-token.mjs
+            .github/scripts/create-onprem-release-tag.cjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -799,6 +800,47 @@ jobs:
           doppler-project: opra-ci
           doppler-config: prd
           inject-env-vars: true
+
+      - name: Mint onprem-testbed tag token
+        id: onprem_app_token
+        shell: bash
+        env:
+          GITHUB_APP_OWNER: ${{ github.repository_owner }}
+          GITHUB_APP_REPOSITORIES: onprem-testbed
+          GITHUB_APP_PERMISSIONS_JSON: '{"contents":"write"}'
+        run: |
+          set -euo pipefail
+          export GITHUB_APP_CLIENT_ID="${NIGHTLY_GITHUB_APP_CLIENT_ID}"
+          export GITHUB_APP_PRIVATE_KEY="${NIGHTLY_GITHUB_APP_PRIVATE_KEY}"
+          token_json="$(node .github/scripts/github-app-token.mjs)"
+          token="$(jq -r '.token' <<<"${token_json}")"
+          expires_at="$(jq -r '.expires_at' <<<"${token_json}")"
+          if [[ -z "${token}" || "${token}" == "null" ]]; then
+            echo "Unable to mint GitHub App token" >&2
+            exit 1
+          fi
+          echo "::add-mask::${token}"
+          echo "token=${token}" >> "${GITHUB_OUTPUT}"
+          echo "expires_at=${expires_at}" >> "${GITHUB_OUTPUT}"
+
+      - name: Tag onprem-testbed release snapshot
+        id: tag_onprem_release
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          ONPREM_RELEASE_VERSION: ${{ needs.replicated-release.outputs.version }}
+        with:
+          github-token: ${{ steps.onprem_app_token.outputs.token }}
+          script: |
+            const { createImmutableReleaseTag } = require(
+              "./.github/scripts/create-onprem-release-tag.cjs",
+            );
+            await createImmutableReleaseTag({
+              github,
+              core,
+              owner: context.repo.owner,
+              repo: "onprem-testbed",
+              tag: process.env.ONPREM_RELEASE_VERSION,
+            });
 
       - name: Run onprem-testbed fresh-install harness
         id: fresh


### PR DESCRIPTION
# Description

## Summary

- Create a lightweight tag in `ComposioHQ/onprem-testbed` for every successful nightly Replicated release, named exactly after the new Helm chart version.
- Resolve the `onprem-testbed` default-branch HEAD and create the tag before fresh-install and upgrade harness dispatches.
- Mint a GitHub App token scoped only to `onprem-testbed` with `contents: write`.
- Keep release snapshots immutable: accept a same-SHA tag on reruns, reject an existing tag at another SHA, and safely handle concurrent `409`/`422` ref creation races.
- Add workflow contract coverage and behavioral tests for tag creation and idempotency.

# How did I test this PR

- `node --test .github/scripts/create-onprem-release-tag.test.cjs` — 6/6 passed
- `bash .github/scripts/tests/calculate-nightly-release-tag-test.sh` — passed
- `bash .github/scripts/tests/resolve-release-config-test.sh` — passed
- `bash .github/scripts/tests/calculate-release-version-test.sh` — passed
- `bash .github/scripts/tests/nighty-release-workflow-test.sh` — passed
- `bash .github/scripts/tests/nightly-slack-summary-test.sh` — passed
- Node and Bash syntax checks — passed
- `yq -e '.' .github/workflows/nighty-release.yml` — passed
- `git diff --check release-stable...HEAD` — passed

`actionlint` is not installed locally. No live nightly GitHub Actions, Replicated, or CMX run was performed.